### PR TITLE
Allow read-only arrays to be passed as a value to Select component

### DIFF
--- a/semcore/select/src/index.d.ts
+++ b/semcore/select/src/index.d.ts
@@ -13,7 +13,7 @@ import { IInputValueProps } from '@semcore/input';
 export interface ISelectInputSearch extends IInputValueProps {}
 
 export type OptionValue = string | number;
-export type SelectValue = string | number | Array<string | number> | null;
+export type SelectValue = string | number | ReadonlyArray<string | number> | null;
 
 export type SelectOption = {
   value: OptionValue;


### PR DESCRIPTION
```
const values: ReadonlyArray<number> = [1,2,3];

// ...
<Select
  multiselect
  value={values} // This generates TS error "...cannot be assigned to the mutable type '(string | number)[]'."
  // ...
/>
```