### PR TITLE
BaseTrigger fix shadow styles for invalid state

### DIFF
--- a/semcore/base-trigger/src/style/base-trigger.shadow.css
+++ b/semcore/base-trigger/src/style/base-trigger.shadow.css
@@ -39,6 +39,10 @@ SBaseTrigger {
     text-decoration: none;
   }
 
+  &:focus {
+    box-shadow: var(--keyborad-focus);
+  }
+
   &:active,
   &:hover,
   &[active] {
@@ -227,7 +231,8 @@ SBaseTrigger[state='valid'] {
 SBaseTrigger[state='invalid'] {
   border-color: var(--orange);
 
-  &[keyboardFocused] {
+  &[keyboardFocused],
+  &:focus {
     box-shadow: 0 0 0 3px color-mod(var(--orange) a(30%));
   }
 }

--- a/semcore/base-trigger/src/style/base-trigger.shadow.css
+++ b/semcore/base-trigger/src/style/base-trigger.shadow.css
@@ -39,6 +39,7 @@ SBaseTrigger {
     text-decoration: none;
   }
 
+  &[keyboardFocused],
   &:focus {
     border: 1px solid var(--light-blue);
     box-shadow: var(--keyborad-focus);
@@ -55,11 +56,6 @@ SBaseTrigger[disabled] {
   opacity: var(--disabled-opacity);
   cursor: default;
   pointer-events: none; /* Disable link interactions */
-}
-
-SBaseTrigger[keyboardFocused] {
-  box-shadow: var(--keyborad-focus);
-  z-index: 1;
 }
 
 SInner {

--- a/semcore/base-trigger/src/style/base-trigger.shadow.css
+++ b/semcore/base-trigger/src/style/base-trigger.shadow.css
@@ -40,6 +40,7 @@ SBaseTrigger {
   }
 
   &:focus {
+    border: 1px solid var(--light-blue);
     box-shadow: var(--keyborad-focus);
   }
 

--- a/semcore/base-trigger/src/style/base-trigger.shadow.css
+++ b/semcore/base-trigger/src/style/base-trigger.shadow.css
@@ -226,4 +226,8 @@ SBaseTrigger[state='valid'] {
 
 SBaseTrigger[state='invalid'] {
   border-color: var(--orange);
+
+  &[keyboardFocused] {
+    box-shadow: 0 0 0 3px color-mod(var(--orange) a(30%));
+  }
 }

--- a/semcore/base-trigger/src/style/base-trigger.shadow.css
+++ b/semcore/base-trigger/src/style/base-trigger.shadow.css
@@ -234,6 +234,7 @@ SBaseTrigger[state='invalid'] {
 
   &[keyboardFocused],
   &:focus {
+    border-color: var(--orange);
     box-shadow: 0 0 0 3px color-mod(var(--orange) a(30%));
   }
 }

--- a/semcore/base-trigger/src/style/base-trigger.shadow.css
+++ b/semcore/base-trigger/src/style/base-trigger.shadow.css
@@ -58,6 +58,10 @@ SBaseTrigger[disabled] {
   pointer-events: none; /* Disable link interactions */
 }
 
+SBaseTrigger[keyboardFocused] {
+  z-index: 1;
+}
+
 SInner {
   display: inline-flex;
   align-items: center;

--- a/semcore/base-trigger/src/style/base-trigger.shadow.css
+++ b/semcore/base-trigger/src/style/base-trigger.shadow.css
@@ -39,8 +39,7 @@ SBaseTrigger {
     text-decoration: none;
   }
 
-  &[keyboardFocused],
-  &:focus {
+  &[keyboardFocused] {
     border: 1px solid var(--light-blue);
     box-shadow: var(--keyborad-focus);
   }
@@ -232,8 +231,7 @@ SBaseTrigger[state='valid'] {
 SBaseTrigger[state='invalid'] {
   border-color: var(--orange);
 
-  &[keyboardFocused],
-  &:focus {
+  &[keyboardFocused] {
     border-color: var(--orange);
     box-shadow: 0 0 0 3px color-mod(var(--orange) a(30%));
   }

--- a/semcore/base-trigger/src/style/filter-trigger.shadow.css
+++ b/semcore/base-trigger/src/style/filter-trigger.shadow.css
@@ -17,11 +17,6 @@ SButtonTrigger {
     text-decoration: none;
   }
 
-  &[keyboardFocused] {
-    border: 1px solid var(--light-blue);
-    box-shadow: var(--keyborad-focus);
-  }
-
   &:active,
   &:hover,
   &[active] {
@@ -71,11 +66,6 @@ SButtonTrigger[state='valid'] {
 
 SButtonTrigger[state='invalid'] {
   border-color: var(--orange);
-
-  &[keyboardFocused] {
-    border-color: var(--orange);
-    box-shadow: 0 0 0 3px color-mod(var(--orange) a(30%));
-  }
 }
 
 SFilterTrigger[selected] {

--- a/semcore/base-trigger/src/style/filter-trigger.shadow.css
+++ b/semcore/base-trigger/src/style/filter-trigger.shadow.css
@@ -17,6 +17,10 @@ SButtonTrigger {
     text-decoration: none;
   }
 
+  &:focus {
+    box-shadow: var(--keyborad-focus);
+  }
+
   &:active,
   &:hover,
   &[active] {
@@ -67,6 +71,7 @@ SButtonTrigger[state='valid'] {
 SButtonTrigger[state='invalid'] {
   border-color: var(--orange);
 
+  &:focus,
   &[keyboardFocused] {
     box-shadow: 0 0 0 3px color-mod(var(--orange) a(30%));
   }

--- a/semcore/base-trigger/src/style/filter-trigger.shadow.css
+++ b/semcore/base-trigger/src/style/filter-trigger.shadow.css
@@ -74,6 +74,7 @@ SButtonTrigger[state='invalid'] {
 
   &:focus,
   &[keyboardFocused] {
+    border-color: var(--orange);
     box-shadow: 0 0 0 3px color-mod(var(--orange) a(30%));
   }
 }

--- a/semcore/base-trigger/src/style/filter-trigger.shadow.css
+++ b/semcore/base-trigger/src/style/filter-trigger.shadow.css
@@ -66,6 +66,10 @@ SButtonTrigger[state='valid'] {
 
 SButtonTrigger[state='invalid'] {
   border-color: var(--orange);
+
+  &[keyboardFocused] {
+    box-shadow: 0 0 0 3px color-mod(var(--orange) a(30%));
+  }
 }
 
 SFilterTrigger[selected] {

--- a/semcore/base-trigger/src/style/filter-trigger.shadow.css
+++ b/semcore/base-trigger/src/style/filter-trigger.shadow.css
@@ -17,8 +17,7 @@ SButtonTrigger {
     text-decoration: none;
   }
 
-  &[keyboardFocused],
-  &:focus {
+  &[keyboardFocused] {
     border: 1px solid var(--light-blue);
     box-shadow: var(--keyborad-focus);
   }
@@ -73,7 +72,6 @@ SButtonTrigger[state='valid'] {
 SButtonTrigger[state='invalid'] {
   border-color: var(--orange);
 
-  &:focus,
   &[keyboardFocused] {
     border-color: var(--orange);
     box-shadow: 0 0 0 3px color-mod(var(--orange) a(30%));

--- a/semcore/base-trigger/src/style/filter-trigger.shadow.css
+++ b/semcore/base-trigger/src/style/filter-trigger.shadow.css
@@ -17,6 +17,7 @@ SButtonTrigger {
     text-decoration: none;
   }
 
+  &[keyboardFocused],
   &:focus {
     border: 1px solid var(--light-blue);
     box-shadow: var(--keyborad-focus);

--- a/semcore/base-trigger/src/style/filter-trigger.shadow.css
+++ b/semcore/base-trigger/src/style/filter-trigger.shadow.css
@@ -18,6 +18,7 @@ SButtonTrigger {
   }
 
   &:focus {
+    border: 1px solid var(--light-blue);
     box-shadow: var(--keyborad-focus);
   }
 


### PR DESCRIPTION
Now if you try to navigate from the keyboard to a form with validation errors in your custom Select, you will see that BaseTrigger has wrong box-shadow (blue instead of orange).
(for example: [codesanbox](https://codesandbox.io/s/elastic-fog-lludt))
So, developers have to use a .shadow.css shadow file with a single line for this case (but i think they probably forget and don't test this behavior).
This PR should solve this problem.