### PR TITLE
[textarea] resize fix

### DIFF
--- a/semcore/textarea/CHANGELOG.md
+++ b/semcore/textarea/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.2.7] - 2022-03-25
+
+### Fix
+
+- Fixed wrong resize of controlled textarea when value is significantly changes in parent controller.
+
 ## [3.2.6] - 2022-03-14
 
 ### Changed

--- a/semcore/textarea/CHANGELOG.md
+++ b/semcore/textarea/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
-## [3.2.7] - 2022-03-25
+## [3.2.7] - 2022-03-30
 
 ### Fix
 

--- a/semcore/textarea/src/Textarea.jsx
+++ b/semcore/textarea/src/Textarea.jsx
@@ -99,9 +99,7 @@ class Textarea extends Component {
     const STextarea = Root;
     const { styles } = this.asProps;
 
-    return sstyled(styles)(
-      <STextarea render={Box} tag="textarea" ref={this.setRef} onChange={this.calculateRows} />,
-    );
+    return sstyled(styles)(<STextarea render={Box} tag="textarea" ref={this.setRef} />);
   }
 }
 

--- a/semcore/textarea/src/Textarea.jsx
+++ b/semcore/textarea/src/Textarea.jsx
@@ -3,6 +3,7 @@ import { Box } from '@semcore/flex-box';
 import autoFocusEnhance from '@semcore/utils/lib/enhances/autoFocusEnhance';
 import canUseDOM from '@semcore/utils/lib/canUseDOM';
 import cssToIntDefault from '@semcore/utils/lib/cssToIntDefault';
+import rafTrottle from '@semcore/utils/lib/rafTrottle';
 import createComponent, { Component, sstyled, Root } from '@semcore/core';
 
 import style from './style/textarea.shadow.css';
@@ -23,7 +24,12 @@ class Textarea extends Component {
 
   uncontrolledProps() {
     return {
-      value: (e) => e.target.value,
+      value: [
+        (e) => e.target.value,
+        () => {
+          this.calculateRows();
+        },
+      ],
     };
   }
 
@@ -44,7 +50,7 @@ class Textarea extends Component {
     window.removeEventListener('resize', this.calculateRows);
   };
 
-  calculateRows = (disabledScrolling = false) => {
+  calculateRows = rafTrottle((disabledScrolling = false) => {
     const { node } = this;
     const { rows, minRows, maxRows } = this.asProps;
     if (!node || !canUseDOM() || rows || !maxRows) return;
@@ -73,7 +79,7 @@ class Textarea extends Component {
     if (!disabledScrolling) {
       node.scrollTop = node.scrollHeight;
     }
-  };
+  });
 
   componentDidMount() {
     this.calculateRows(true);


### PR DESCRIPTION
Disabled rows recalculation on change event cause it may override rows recalculation on value prop change

@lsroman, is fix safe or it breaks some secret behaviour?

Source issue text:

> Если выставить min/max rows, чтобы автоматически считалась высота, то если у нас есть ограничение длинны инпута и при этом мы делаем copy/paste, то во время вставки высота textarea растянется по длинне вставляемой строки, но при этом вставки всего текста разумеется не будет.
> Это нужно как-то разрулить во время использования, или это что-то типо багули?
> Пример: https://codesandbox.io/s/lucid-leaf-pg8ply?file=/src/App.js
> Чтобы понять о чем речь, нужно вставить в инпут строчку 100+ символов
> Я догадываюсь что рассчет идет именно на ограничение MaxRows, но что делать когда нужно чтобы Textarea растянулся ровно на столько, сколько есть текста? У меня сейчас как раз такой кейс по дизайну

Codesandbox example tip: hit ctrl+v multiple times