### PR TITLE
Fix focusing when no input rendered

### DIFF
--- a/semcore/input-tags/src/InputTags.tsx
+++ b/semcore/input-tags/src/InputTags.tsx
@@ -56,8 +56,8 @@ class InputTags extends Component<IInputTagsProps> {
 
   setFocusInput = (e) => {
     const inputRef = this._input.current;
-    const caretPosition = inputRef.value.length;
     if (inputRef && e.target !== inputRef) {
+      const caretPosition = inputRef.value.length;
       e.preventDefault();
       inputRef.focus();
       inputRef.setSelectionRange(caretPosition, caretPosition);


### PR DESCRIPTION
<InputTags.Value> can be omitted in some cases, for example when <InputTag> has maximum allowed number of tags.
This fixes an error occurring on focusing: TypeError: Cannot read properties of null (reading 'value')

## What changed?

reading from the ref moved into if statement

### Definition of Done

- [ ] Dependencies checked (if applicable)
- [ ] TS types updated (if applicable)
- [ ] CHANGELOG.md updated (if applicable)
- [ ] Complete unit testing (if applicable)
- [ ] Complete screenshot testing (if applicable)
- [ ] Complete UX review (if applicable)
- [ ] Documentation design guide updated (if any)
- [ ] Documentation examples updated (if any)
- [ ] Documentation API updated (if any)
- [ ] Add link to design (if any)
- [ ] No major bugs pending
- [ ] Complete self code review

### Reviewer checklist

- [ ] Does the code work? Does it perform its intended function and the logic is correct?
- [ ] Is the code easily understandable?
- [ ] Verify the design is implemented as per the design requirements
- [ ] Verify the names used in the programs/methods/functions convey the intent and all functions commented
- [ ] Verify the unit tests are testing the code to perform the intended functionality
- [ ] Verify the unit tests cover the positive and negative scenarios
- [ ] Verify the screenshot tests are added and are they comprehensive
- [ ] Verify documentation (design/api/example) has been added/updated
