### PR TITLE
[babel-plugin-root] fixed syntax sugar of props passing

### DIFF
--- a/tools/babel-plugin-root/CHANGELOG.md
+++ b/tools/babel-plugin-root/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [1.1.0] - 2022-04-01
+
+### Fixed
+
+- Fixed root props passing in function components
+
 ## [1.0.1] - 2021-04-30
 
 ### Fixed

--- a/tools/babel-plugin-root/babel-plugin-root.js
+++ b/tools/babel-plugin-root/babel-plugin-root.js
@@ -34,11 +34,10 @@ function RootPlugin({ types: t }, opts) {
             const propsIdent = refP.scope.generateUidIdentifierBasedOnNode('props');
             refP.scope.push({
               id: propsIdent,
-              init: t.ConditionalExpression(
-                t.ThisExpression(),
-                t.MemberExpression(t.ThisExpression(), t.Identifier(options.fieldAssign)),
-                t.Identifier('arguments[0]'),
-              ),
+              init:
+                refP.scope.block.type === 'ClassMethod'
+                  ? t.MemberExpression(t.ThisExpression(), t.Identifier(options.fieldAssign))
+                  : t.Identifier('arguments[0]'),
             });
 
             refP.scope.path.traverse({


### PR DESCRIPTION
## What changed?

 fixed syntax sugar of props passing. The sugar is about following transformation:
```diff
- const x = props;
+ const x = this ? this.asProps : arguments[0]
```
Transformation in root plugin passes props to `Root` node of component. 
What makes things worser, that transformation is wrong and currently works only because of components code second babel transformation, which has a undocumented behaviour, that sometimes [mess things up and confuses developers](https://stackoverflow.com/questions/34973442/how-to-stop-babel-from-transpiling-this-to-undefined-and-inserting-use-str).

That incorrect behaviour was detected during using esbuild to build components. We still can transform components thrice (build time in components repo, build with babel in host repo, build of the final bundle with esbuild), but it is really bad way to solve issues and, surely, makes build time slower.

Transformation may still be wrong in some rare cases but I hope that syntax sugar will be removed before rare cases ocasion.

### Definition of Done

- [x] All repo tests passed successfully, even screenshots
- [x] Now props passed without second babel transformation (e.g. with esbuild)

### Reviewer checklist

- [ ] Does the code work? Does it perform its intended function and the logic is correct?
- [x] Is the code easily understandable?
- [ ] Verify the unit tests are testing the code to perform the intended functionality
- [ ] Verify the unit tests cover the positive and negative scenarios
- [ ] Verify the screenshot tests are added and are they comprehensive
