### PR TITLE
[scroll-area] make onScroll prop optional

### DIFF
--- a/semcore/scroll-area/CHANGELOG.md
+++ b/semcore/scroll-area/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.7.1] - 2022-04-25
+
+### Fixed
+
+- Made `onScroll` property optional.
+
 ## [3.7.0] - 2022-04-21
 
 ### Added

--- a/semcore/scroll-area/src/index.d.ts
+++ b/semcore/scroll-area/src/index.d.ts
@@ -15,7 +15,7 @@ export interface IScrollAreaProps extends IBoxProps {
   /** Callback executed when container change size  */
   onResize?: ResizeObserverCallback;
   /** Called every time user scrolls area  */
-  onScroll: (event: React.SyntheticEvent<HTMLElement>) => void;
+  onScroll?: (event: React.SyntheticEvent<HTMLElement>) => void;
 }
 
 export interface IScrollAreaContext extends IScrollAreaProps {


### PR DESCRIPTION
## What changed?

Made onScroll prop optional

### Definition of Done

- [x] Dependencies checked (if applicable)
- [x] TS types updated (if applicable)
- [ ] CHANGELOG.md updated (if applicable)
- [ ] Complete unit testing (if applicable)
- [ ] Complete screenshot testing (if applicable)
- [ ] Complete UX review (if applicable)
- [ ] Documentation design guide updated (if any)
- [ ] Documentation examples updated (if any)
- [ ] Documentation API updated (if any)
- [ ] Add link to design (if any)
- [ ] No major bugs pending
- [ ] Complete self code review

### Reviewer checklist

- [ ] Does the code work? Does it perform its intended function and the logic is correct?
- [ ] Is the code easily understandable?
- [ ] Verify the design is implemented as per the design requirements
- [ ] Verify the names used in the programs/methods/functions convey the intent and all functions commented
- [ ] Verify the unit tests are testing the code to perform the intended functionality
- [ ] Verify the unit tests cover the positive and negative scenarios
- [ ] Verify the screenshot tests are added and are they comprehensive
- [ ] Verify documentation (design/api/example) has been added/updated
