### PR TITLE
[utils] Fixed repeated call of the same handler in assign props function

### DIFF
--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.35.1] - 2022-07-27
+
+### Fixed
+
+- Fixed repeated call of the same handler in assign props function.
+
 ## [3.35.0] - 2022-07-19
 
 ### Fixed
 
-- Fixed pcakage compatibility with ES modules.
+- Fixed package compatibility with ES modules.
 
 ## [3.34.0] - 2022-06-16
 

--- a/semcore/utils/__tests__/index.test.tsx
+++ b/semcore/utils/__tests__/index.test.tsx
@@ -209,15 +209,35 @@ describe('Utils CSS in JS', () => {
       },
     );
 
+    const spy4 = jest.fn();
+    const spy5 = jest.fn();
+    const result4 = assignProps(
+      {
+        onClick: spy4,
+      },
+      {
+        onClick: spy5,
+      },
+    );
+
     result1.onClick();
     result2.onClick();
     result3.onClick();
-    expect(result1.onClick).not.toEqual(spy1);
-    expect(spy1).toBeCalledTimes(2);
+    result4.onClick();
+
+    expect(spy1).toBeCalledTimes(1);
+    expect(result1.onClick).toEqual(spy1);
+
     expect(spy2).toBeCalledTimes(1);
     expect(result2.onClick).toEqual(spy2);
+
     expect(spy3).toBeCalledTimes(1);
     expect(result3.onClick).toEqual(spy3);
+
+    expect(spy4).toBeCalledTimes(1);
+    expect(spy5).toBeCalledTimes(1);
+    expect(result1.onClick).not.toEqual(spy4);
+    expect(result1.onClick).not.toEqual(spy5);
   });
 
   test('Utils assignHandlers', () => {

--- a/semcore/utils/src/assignProps.ts
+++ b/semcore/utils/src/assignProps.ts
@@ -2,6 +2,8 @@ import { CSSProperties, Ref } from 'react';
 import cn from 'classnames';
 import { forkRef } from './ref';
 
+const handlerRex = new RegExp(/^on[A-Z]+/);
+
 export function callAllEventHandlers(...fns) {
   return (...args) =>
     !fns.some((fn) => {
@@ -15,7 +17,7 @@ export function callAllEventHandlers(...fns) {
 
 export function assignHandlers(props, source) {
   return Object.keys(source).reduce((proxySource, propName) => {
-    if (typeof source[propName] === 'function' && propName.startsWith('on')) {
+    if (typeof source[propName] === 'function' && handlerRex.test(propName)) {
       proxySource[propName] = callAllEventHandlers(props[propName], source[propName]);
     }
     return proxySource;
@@ -28,7 +30,8 @@ function assignHandlersInner(props, source) {
       propName !== 'ref' &&
       typeof source[propName] === 'function' &&
       typeof props[propName] === 'function' &&
-      propName.startsWith('on')
+      handlerRex.test(propName) &&
+      props[propName] !== source[propName]
     ) {
       proxySource[propName] = callAllEventHandlers(props[propName], source[propName]);
     }


### PR DESCRIPTION
Signed-off-by: r.lysov <r.lysov@semrush.com>

## What changed?

For example code:

```
const fn = () => console.log('test');
const props = assigneProps({
 onClick: fn
}, {
  onClick: fn
})
props.onClick()
```
"test" should be written in console once

### Definition of Done

- [ ] Dependencies checked (if applicable)
- [ ] TS types updated (if applicable)
- [x] CHANGELOG.md updated (if applicable)
- [x] Complete unit testing (if applicable)
- [ ] Complete screenshot testing (if applicable)
- [ ] Complete UX review (if applicable)
- [ ] Documentation design guide updated (if any)
- [ ] Documentation examples updated (if any)
- [ ] Documentation API updated (if any)
- [ ] Add link to design (if any)
- [ ] No major bugs pending
- [x] Complete self code review

### Reviewer checklist

- [ ] Does the code work? Does it perform its intended function and the logic is correct?
- [ ] Is the code easily understandable?
- [ ] Verify the design is implemented as per the design requirements
- [ ] Verify the names used in the programs/methods/functions convey the intent and all functions commented
- [ ] Verify the unit tests are testing the code to perform the intended functionality
- [ ] Verify the unit tests cover the positive and negative scenarios
- [ ] Verify the screenshot tests are added and are they comprehensive
- [ ] Verify documentation (design/api/example) has been added/updated
