### PR TITLE
[badge,utils] Add support a11y

### DIFF
--- a/semcore/badge/CHANGELOG.md
+++ b/semcore/badge/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Added
 
-- Added support a11y.
+- Added aria-hidden because component "badge" is not the main functionality and will only confuse the blind user.
 
 ## [3.0.6] - 2022-08-11
 

--- a/semcore/badge/CHANGELOG.md
+++ b/semcore/badge/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.1.0] - 2022-08-12
+
+### Added
+
+- Added support a11y.
+
 ## [3.0.6] - 2022-08-11
 
 ### Changed

--- a/semcore/badge/__tests__/index.test.tsx
+++ b/semcore/badge/__tests__/index.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { testing, snapshot } from '@semcore/jest-preset-ui';
 import Badge from '../src';
 
-const { cleanup } = testing;
+const { cleanup, axe, render } = testing;
 
 describe('Badge', () => {
   afterEach(cleanup);
@@ -33,5 +33,13 @@ describe('Badge', () => {
       </>
     );
     expect(await snapshot(component)).toMatchImageSnapshot();
+  });
+
+  test('a11y', async () => {
+    const { container } = render(<Badge bg="green">new</Badge>);
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
   });
 });

--- a/semcore/badge/package.json
+++ b/semcore/badge/package.json
@@ -13,7 +13,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@semcore/utils": "^3.37",
+    "@semcore/utils": "^3.15",
     "@semcore/flex-box": "^4"
   },
   "peerDependencies": {

--- a/semcore/badge/package.json
+++ b/semcore/badge/package.json
@@ -13,7 +13,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@semcore/utils": "^3.15",
+    "@semcore/utils": "^3.37",
     "@semcore/flex-box": "^4"
   },
   "peerDependencies": {

--- a/semcore/badge/src/Badge.jsx
+++ b/semcore/badge/src/Badge.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import createComponent, { Component, Root, sstyled } from '@semcore/core';
 import { Box } from '@semcore/flex-box';
 import resolveColor from '@semcore/utils/lib/color';
+import reactToText from '@semcore/utils/lib/reactToText';
 
 import style from './style/badge.shadow.css';
 
@@ -15,10 +16,16 @@ class RootBadge extends Component {
 
   render() {
     const SBadge = Root;
-    const { styles, color, bg } = this.asProps;
+    const { styles, color, bg, children } = this.asProps;
 
     return sstyled(styles)(
-      <SBadge render={Box} tag="span" use:color={resolveColor(color)} use:bg={resolveColor(bg)} />,
+      <SBadge
+        render={Box}
+        tag="span"
+        aria-label={`badge: ${reactToText(children)}`}
+        use:color={resolveColor(color)}
+        use:bg={resolveColor(bg)}
+      />,
     );
   }
 }

--- a/semcore/badge/src/Badge.jsx
+++ b/semcore/badge/src/Badge.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import createComponent, { Component, Root, sstyled } from '@semcore/core';
 import { Box } from '@semcore/flex-box';
 import resolveColor from '@semcore/utils/lib/color';
-import reactToText from '@semcore/utils/lib/reactToText';
 
 import style from './style/badge.shadow.css';
 
@@ -16,13 +15,13 @@ class RootBadge extends Component {
 
   render() {
     const SBadge = Root;
-    const { styles, color, bg, children } = this.asProps;
+    const { styles, color, bg } = this.asProps;
 
     return sstyled(styles)(
       <SBadge
         render={Box}
         tag="span"
-        aria-label={`badge: ${reactToText(children)}`}
+        aria-hidden={true}
         use:color={resolveColor(color)}
         use:bg={resolveColor(bg)}
       />,

--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.37.0] - 2022-08-12
+
+### Added
+
+- Added util function `reactToText` to convert react component to text.
+
 ## [3.36.0] - 2022-08-11
 
 ### Added

--- a/semcore/utils/__tests__/index.test.tsx
+++ b/semcore/utils/__tests__/index.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { testing, snapshot } from '@semcore/jest-preset-ui';
+
 const { cleanup } = testing;
 
 import isNode from '../src/isNode';
@@ -9,6 +10,7 @@ import useCss from '../src/use/useCss';
 import resolveColor, { shade, opacity } from '../src/color';
 import { interpolate } from '../src/enhances/i18nEnhance';
 import assignProps, { assignHandlers } from '../src/assignProps';
+import reactToText from '../src/reactToText';
 
 describe('Utils CSS in JS', () => {
   afterEach(cleanup);
@@ -377,5 +379,45 @@ describe('Utils interpolate', () => {
     expect(interpolate(Template, { name: `<script>console.log('oh my!')</script>` })).toBe(
       `&lt;script&gt;console.log('oh my!')&lt;/script&gt;`,
     );
+  });
+});
+
+describe('Utils reactToText', () => {
+  afterEach(cleanup);
+
+  test('support string', () => {
+    expect(reactToText('string')).toBe('string');
+  });
+
+  test('support number', () => {
+    expect(reactToText(0)).toBe('0');
+    expect(reactToText(1)).toBe('1');
+  });
+
+  test('support boolean', () => {
+    expect(reactToText(false)).toBe('false');
+    expect(reactToText(true)).toBe('true');
+  });
+
+  test('support undefined types', () => {
+    expect(reactToText(undefined)).toBe('');
+    expect(reactToText(null)).toBe('');
+    expect(reactToText(NaN)).toBe('');
+  });
+
+  test('support array and obj', () => {
+    expect(reactToText(['arr', '-', 'arr'])).toBe('arr-arr');
+    expect(reactToText({})).toBe('');
+  });
+
+  test('support react component', () => {
+    expect(reactToText(<div>component</div>)).toBe('component');
+    expect(
+      reactToText(
+        <>
+          <span>multi</span> <span>component</span>
+        </>,
+      ),
+    ).toBe('multi component');
   });
 });

--- a/semcore/utils/src/reactToText.ts
+++ b/semcore/utils/src/reactToText.ts
@@ -1,0 +1,23 @@
+import React from 'react';
+
+function reactToText(node: React.ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number' || typeof node === 'boolean') {
+    return node.toString();
+  }
+  if (!node) {
+    return '';
+  }
+  if (Array.isArray(node)) {
+    return node.map((entry) => reactToText(entry)).join('');
+  }
+
+  const props: { children?: React.ReactNode } = (node as any).props ? (node as any).props : {};
+
+  if (!props || !props.children) {
+    return '';
+  }
+
+  return reactToText(props.children);
+}
+
+export default reactToText;

--- a/semcore/utils/src/reactToText.ts
+++ b/semcore/utils/src/reactToText.ts
@@ -2,6 +2,7 @@ import React from 'react';
 
 function reactToText(node: React.ReactNode): string {
   if (typeof node === 'string' || typeof node === 'number' || typeof node === 'boolean') {
+    if (Number.isNaN(node)) return '';
     return node.toString();
   }
   if (!node) {

--- a/website/docs/components/badge/badge-a11y.md
+++ b/website/docs/components/badge/badge-a11y.md
@@ -1,0 +1,19 @@
+---
+title: A11y
+---
+
+@## Roles & attributes
+
+The list below will help you to keep in mind the necessary roles and attributes to make our components fully accessible in your interfaces.
+
+| Role | Attribute                  | Element | Usage                                                                         |
+| ---- | -------------------------- | ------- | ----------------------------------------------------------------------------- |
+|      | `aria-label="Badge: text"` | `span`  | Provides a label describing the badge type represented in the `span` element. |
+
+@## Resources
+
+- [W3 label example](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) has detailed information about the label accessible behavior.
+
+@## Other recommendations
+
+See more accessibility recommendations in the common [Accessibility guide](/core-principles/a11y/).

--- a/website/docs/components/badge/badge-a11y.md
+++ b/website/docs/components/badge/badge-a11y.md
@@ -6,13 +6,13 @@ title: A11y
 
 The list below will help you to keep in mind the necessary roles and attributes to make our components fully accessible in your interfaces.
 
-| Role | Attribute                  | Element | Usage                                                                         |
-| ---- | -------------------------- | ------- | ----------------------------------------------------------------------------- |
-|      | `aria-label="Badge: text"` | `span`  | Provides a label describing the badge type represented in the `span` element. |
+| Role | Attribute            | Element | Usage                                                                                          |
+| ---- | -------------------- | ------- | ---------------------------------------------------------------------------------------------- |
+|      | `aria-hidden="true"` | `span`  | This element is auxiliary and should not be played by a screen reader so as not to interfere.. |
 
 @## Resources
 
-- [W3 label example](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) has detailed information about the label accessible behavior.
+- [W3 area-hidden example](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) has detailed information about which elements to hide.
 
 @## Other recommendations
 

--- a/website/docs/components/badge/badge.md
+++ b/website/docs/components/badge/badge.md
@@ -78,6 +78,7 @@ The feature status can be shown inside most of our controls. Please note the rel
 
 The `Badge` is usually located to the right outside of the element and to the right inside the element. As an exception, in the [Notice](/components/notice/) component, it is positioned to the left relative to the text. `Margins` to budge are always multiples of 4.
 
+@page badge-a11y
 @page badge-api
 @page badge-code
 @page badge-changelog

--- a/website/docs/components/badge/components/playground.jsx
+++ b/website/docs/components/badge/components/playground.jsx
@@ -1,20 +1,9 @@
 import React from 'react';
-
 import PlaygroundGeneration from '@components/PlaygroundGeneration';
-
 import Badge from '@semcore/badge';
 
-const BG = {
-  mist: 'gray-300',
-  cyan: 'blue-300',
-  red: 'red-300',
-  orange: 'orange-300',
-  green: 'green-300',
-  white: 'white',
-};
-
 const Preview = (preview) => {
-  const { select, radio, text } = preview('Button');
+  const { select, radio, text } = preview('Badge');
 
   const color = radio({
     key: 'color',
@@ -25,12 +14,9 @@ const Preview = (preview) => {
 
   const bg = select({
     key: 'bg',
-    defaultValue: 'mist',
+    defaultValue: 'gray-300',
     label: 'Background',
-    options: Object.keys(BG).map((value) => ({
-      name: value,
-      value: BG[value],
-    })),
+    options: ['gray-300', 'blue-300', 'red-300', 'orange-300', 'green-300', 'white'],
   });
 
   const child = text({

--- a/website/docs/components/badge/examples/base.jsx
+++ b/website/docs/components/badge/examples/base.jsx
@@ -1,23 +1,15 @@
 import React from 'react';
 import Badge from '@semcore/badge';
-import { Box } from '@semcore/flex-box';
-
-const BageList = [
-  <Badge bg="blue-300">admin</Badge>,
-  <Badge bg="red-300">alpha</Badge>,
-  <Badge bg="orange-300">beta</Badge>,
-  <Badge bg="green-300">new</Badge>,
-  <Badge>soon</Badge>,
-];
+import { Flex } from '@semcore/flex-box';
 
 export default () => {
   return (
-    <>
-      {BageList.map((Item) => (
-        <Box m={2} inline>
-          {Item}
-        </Box>
-      ))}
-    </>
+    <Flex gap={2}>
+      <Badge bg="blue-300">admin</Badge>
+      <Badge bg="red-300">alpha</Badge>
+      <Badge bg="orange-300">beta</Badge>
+      <Badge bg="green-300">new</Badge>
+      <Badge>soon</Badge>
+    </Flex>
   );
 };

--- a/website/src/docs-components/PlaygroundGeneration.jsx
+++ b/website/src/docs-components/PlaygroundGeneration.jsx
@@ -74,11 +74,14 @@ Playground.createWidget(
           <Select value={value} onChange={(value) => onChange(value)} {...others}>
             <Select.Trigger />
             <Select.Menu>
-              {options.map((o, i) => (
-                <Select.Option key={i} value={o.value}>
-                  {o.name}
-                </Select.Option>
-              ))}
+              {options.map((o, i) => {
+                const option = typeof o === 'string' ? { value: o, name: o } : o;
+                return (
+                  <Select.Option key={i} value={option.value}>
+                    {option.name}
+                  </Select.Option>
+                );
+              })}
             </Select.Menu>
           </Select>
         </div>
@@ -100,11 +103,14 @@ Playground.createWidget(
             onChange={(value) => onChange(value)}
             {...others}
           >
-            {options.map((o) => (
-              <Pills.Item key={o} value={o}>
-                {o}
-              </Pills.Item>
-            ))}
+            {options.map((o, i) => {
+              const option = typeof o === 'string' ? { value: o, name: o } : o;
+              return (
+                <Pills.Item key={i} value={option.value}>
+                  {option.name}
+                </Pills.Item>
+              );
+            })}
           </Pills>
         </div>
       </label>


### PR DESCRIPTION
…onvert react component to text.

Signed-off-by: r.lysov <r.lysov@semrush.com>

Added support a11y for Badge component

## Description

- Add aria-hidden for component
- Added util function `reactToText` to convert react component to text
- Update documentation

## Motivation and Context

The component becomes accessible 💪

## How has this been tested?

Turn on the screen reader and listen to how it reads label text.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
