### PR TITLE
Fix cropped text in TabLine

### DIFF
--- a/semcore/tab-line/src/style/tab-line.shadow.css
+++ b/semcore/tab-line/src/style/tab-line.shadow.css
@@ -115,12 +115,14 @@ STabLineItem[size='m'] {
   height: 28px;
   min-width: 18px;
   font-size: var(--fs-200);
+  lihe-height: var(--lh-200);
 }
 
 STabLineItem[size='l'] {
   height: 40px;
   min-width: 26px;
   font-size: var(--fs-300);
+  lihe-height: var(--lh-300);
 }
 
 STabLineItem[neighborLocation='left'] {


### PR DESCRIPTION
Signed-off-by: dpodolkhov <92044833+dpodolkhov@users.noreply.github.com>

Fix cropping text is tabs. 

## Description

As `line-height` property is not specified, the value 1 is applied. But some letters in Italian, Vietnamese has ascenders do not fit to this height.

## Motivation and Context

![image](https://user-images.githubusercontent.com/92044833/186910797-4f07df4e-3e05-4300-b311-13c0c95a6e74.png)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
