### PR TITLE
[button,link] Fixed aria warning detection.

### DIFF
--- a/semcore/button/CHANGELOG.md
+++ b/semcore/button/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.0.15] - 2022-08-29
+
+### Fixed
+
+- Fixed aria warning detection.
+
 ## [4.0.14] - 2022-08-24
 
 ### Fixed
@@ -78,7 +84,8 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.32.0 ~> 3.32.1], `@semcore/flex-box` [4.5.1 ~> 4.5.3]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.32.0 ~> 3.32.1]
+  , `@semcore/flex-box` [4.5.1 ~> 4.5.3]).
 
 ## [4.0.1] - 2022-05-19
 

--- a/semcore/button/src/Button.jsx
+++ b/semcore/button/src/Button.jsx
@@ -6,6 +6,7 @@ import keyboardFocusEnhance from '@semcore/utils/lib/enhances/keyboardFocusEnhan
 import addonTextChildren from '@semcore/utils/lib/addonTextChildren';
 import logger from '@semcore/utils/lib/logger';
 import reactToText from '@semcore/utils/lib/reactToText';
+import getOriginChildren from '@semcore/utils/lib/getOriginChildren';
 import SpinButton from './SpinButton';
 
 import style from './style/button.shadow.css';
@@ -55,10 +56,8 @@ class RootButton extends Component {
       addonRight,
       'aria-label': ariaLabel,
     } = this.asProps;
-
     const useTheme = use && theme ? `${use}-${theme}` : false;
-
-    const isTextInside = reactToText(Children);
+    const isTextInside = reactToText(getOriginChildren(Children));
 
     logger.warn(
       !isTextInside && !ariaLabel,

--- a/semcore/link/CHANGELOG.md
+++ b/semcore/link/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.1.3] - 2022-08-29
+
+### Fixed
+
+- Fixed aria warning detection.
+
 ## [4.1.2] - 2022-08-26
 
 ### Fixed

--- a/semcore/link/src/Link.jsx
+++ b/semcore/link/src/Link.jsx
@@ -6,6 +6,7 @@ import keyboardFocusEnhance from '@semcore/utils/lib/enhances/keyboardFocusEnhan
 import addonTextChildren from '@semcore/utils/lib/addonTextChildren';
 import resolveColor, { shade } from '@semcore/utils/lib/color';
 import reactToText from '@semcore/utils/lib/reactToText';
+import getOriginChildren from '@semcore/utils/lib/getOriginChildren';
 import logger from '@semcore/utils/lib/logger';
 
 import style from './style/link.shadow.css';
@@ -31,7 +32,7 @@ class RootLink extends Component {
       'aria-label': ariaLabel,
     } = this.asProps;
     const colorHoverText = shade(resolveColor(color), -0.12);
-    const linkText = reactToText(Children);
+    const linkText = reactToText(getOriginChildren(Children));
 
     logger.warn(
       linkText === '' && ariaLabel === undefined,


### PR DESCRIPTION
When passing a function or using components as a tag of other components, children are not detected correctly.

## Description

An example of incorrect work:
```
<FilterTrigger tag={Button}/ >
```
because in Button:
```
 (Button)Children.origin === Children(FilterTrigger)
```
## Motivation and Context

Right job 😇

## How has this been tested?

Open example

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
