### PR TITLE
[icon] a11y

### DIFF
--- a/semcore/card/__tests__/index.test.tsx
+++ b/semcore/card/__tests__/index.test.tsx
@@ -80,7 +80,12 @@ describe('Card', () => {
       <Card>
         <Card.Header>
           <Card.Title hint={tooltipContent}>Card heading</Card.Title>
-          <SettingsM style={{ float: 'right' }} color="stone" interactive />
+          <SettingsM
+            style={{ float: 'right' }}
+            color="stone"
+            interactive
+            aria-label="Open setting"
+          />
           <Card.Description>This is card additional information or insights.</Card.Description>
         </Card.Header>
         <Card.Body>

--- a/semcore/card/__tests__/index.test.tsx
+++ b/semcore/card/__tests__/index.test.tsx
@@ -84,7 +84,7 @@ describe('Card', () => {
             style={{ float: 'right' }}
             color="stone"
             interactive
-            aria-label="Open setting"
+            aria-label="Open settings"
           />
           <Card.Description>This is card additional information or insights.</Card.Description>
         </Card.Header>

--- a/semcore/carousel/src/Carousel.jsx
+++ b/semcore/carousel/src/Carousel.jsx
@@ -384,7 +384,14 @@ const Prev = (props) => {
 };
 
 Prev.defaultProps = () => ({
-  children: <ChevronLeft interactive color="gray-300" aria-hidden={true} role="button" />,
+  children: (
+    <ChevronLeft
+      interactive
+      color="gray-300"
+      aria-hidden={true}
+      aria-label="Go to the previous item"
+    />
+  ),
   top: 0,
 });
 
@@ -395,7 +402,14 @@ const Next = (props) => {
 };
 
 Next.defaultProps = () => ({
-  children: <ChevronRight interactive color="gray-300" aria-hidden={true} role="button" />,
+  children: (
+    <ChevronRight
+      interactive
+      color="gray-300"
+      aria-hidden={true}
+      aria-label="Go to the next item"
+    />
+  ),
   top: 0,
 });
 

--- a/semcore/icon/CHANGELOG.md
+++ b/semcore/icon/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.31.0] - 2022-09-30
+
+### Changed
+
+- When `interactive` prop is provided, `aria-label` or `aria-labelledby` props from now are required. If required props are not provided a warning is logged to developer console.
+
 ## [2.30.4] - 2022-09-15
 
 ### Fixed

--- a/semcore/icon/__tests__/index.test.jsx
+++ b/semcore/icon/__tests__/index.test.jsx
@@ -76,7 +76,7 @@ describe('Icon', () => {
 
   test('should support call onClick', async () => {
     const onClick = jest.fn();
-    const { getByTestId } = render(<Icon data-testid="icon" interactive />);
+    const { getByTestId } = render(<Icon data-testid="icon" interactive aria-label="Test icon" />);
 
     fireEvent.keyDown(getByTestId('icon'), { code: 'Enter' });
     expect(onClick).toHaveBeenCalledTimes(0);
@@ -86,7 +86,13 @@ describe('Icon', () => {
     const onKeyDown = jest.fn();
     const onClick = jest.fn();
     const { getByTestId } = render(
-      <Icon data-testid="icon" onClick={onClick} onKeyDown={onKeyDown} interactive />,
+      <Icon
+        data-testid="icon"
+        onClick={onClick}
+        onKeyDown={onKeyDown}
+        interactive
+        aria-label="test icon"
+      />,
     );
 
     fireEvent.keyDown(getByTestId('icon'), { code: 'Enter' });

--- a/semcore/icon/src/Icon.jsx
+++ b/semcore/icon/src/Icon.jsx
@@ -5,6 +5,7 @@ import { useBox } from '@semcore/flex-box';
 import resolveColor, { shade } from '@semcore/utils/lib/color';
 import keyboardFocusEnhance from '@semcore/utils/lib/enhances/keyboardFocusEnhance';
 import propsForElement from '@semcore/utils/lib/propsForElement';
+import logger from '@semcore/utils/lib/logger';
 
 import styles from './style/icon.shadow.css';
 
@@ -23,7 +24,12 @@ function Icon(props, ref) {
     ref,
   );
 
-  const { interactive, color: colorProps } = props;
+  const {
+    interactive,
+    color: colorProps,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledby,
+  } = props;
   const color = resolveColor(colorProps);
   const { keyboardFocused, ...propsWithKeyboardEnhance } = keyboardFocusEnhance()({
     disabled: !interactive,
@@ -47,12 +53,20 @@ function Icon(props, ref) {
     }
   }
 
+  logger.warn(
+    interactive && !ariaLabel && !ariaLabelledby,
+    "'aria-label' or 'aria-labelledby' are required props for interactive icons",
+    props['data-ui-name'] || Icon.displayName,
+  );
+
   return (
     <SIcon
       {...propsForElement(propsWithKeyboardEnhance)}
       style={Object.assign({}, style, propsWithKeyboardEnhance.style, props.style)}
       className={cn(className, propsWithKeyboardEnhance.className, props.className) || undefined}
       onKeyDown={onKeyDown}
+      role={interactive ? 'button' : undefined}
+      aria-hidden={interactive ? undefined : 'true'}
     />
   );
 }

--- a/semcore/pagination/__tests__/index.test.tsx
+++ b/semcore/pagination/__tests__/index.test.tsx
@@ -214,13 +214,13 @@ describe('Pagination.PageInput', () => {
         <Pagination currentPage={1} totalPages={1234}>
           <Pagination.PageInput>
             <Pagination.PageInput.Value />
-            <Pagination.PageInput.Addon tag={Return} interactive />
+            <Pagination.PageInput.Addon tag={Return} interactive aria-label="Confirm page number" />
           </Pagination.PageInput>
         </Pagination>
         <Pagination currentPage={1} totalPages={1234}>
           <Pagination.PageInput>
             <Pagination.PageInput.Value id="page-number" />
-            <Pagination.PageInput.Addon tag={Return} interactive />
+            <Pagination.PageInput.Addon tag={Return} interactive aria-label="Confirm page number" />
           </Pagination.PageInput>
         </Pagination>
       </snapshot.ProxyProps>
@@ -240,7 +240,7 @@ describe('Pagination.PageInput', () => {
         <Pagination currentPage={1234} totalPages={1234}>
           <Pagination.PageInput>
             <Pagination.PageInput.Value id="page-number" />
-            <Pagination.PageInput.Addon tag={Return} interactive />
+            <Pagination.PageInput.Addon tag={Return} interactive aria-label="Confirm page number" />
           </Pagination.PageInput>
         </Pagination>
       </snapshot.ProxyProps>

--- a/semcore/pagination/src/Pagination.jsx
+++ b/semcore/pagination/src/Pagination.jsx
@@ -306,9 +306,11 @@ class PageInput extends Component {
           ) : (
             <>
               <Pagination.PageInput.Value id={`pagination-input-${uid}`} />
-              <Pagination.PageInput.Addon interactive>
-                <Return />
-              </Pagination.PageInput.Addon>
+              <Pagination.PageInput.Addon
+                tag={Return}
+                interactive
+                aria-label="Confirm page number"
+              />
             </>
           )}
         </SPageInput>

--- a/semcore/select/src/InputSearch.jsx
+++ b/semcore/select/src/InputSearch.jsx
@@ -55,6 +55,7 @@ class InputSearch extends Component {
           hide={hideClose}
           aria-hidden={hideClose}
           interactive
+          aria-label="Clear search field"
           onClick={this.handleClear}
         >
           <IconClose />

--- a/website/docs/components/card/examples/card-heading.jsx
+++ b/website/docs/components/card/examples/card-heading.jsx
@@ -9,7 +9,7 @@ export default () => (
   <Card>
     <Card.Header>
       <Card.Title hint={tooltipContent}>Card heading</Card.Title>
-      <SettingsM style={{ float: 'right' }} color="stone" interactive />
+      <SettingsM style={{ float: 'right' }} color="stone" interactive aria-label="Open settings" />
       <Card.Description>This is card additional information or insights.</Card.Description>
     </Card.Header>
     <Card.Body>

--- a/website/docs/components/card/examples/card-new.jsx
+++ b/website/docs/components/card/examples/card-new.jsx
@@ -28,7 +28,7 @@ export default () => (
           <Text size={200} color="#6C6E79" mr={2}>
             Info about data (optiona)
           </Text>
-          <Close color="stone" ml="auto" interactive />
+          <Close color="stone" ml="auto" interactive aria-label="Close card" />
         </Flex>
       </Flex>
       <Card.Description tag="div">

--- a/website/docs/components/checkbox/examples/withIconAndLink.jsx
+++ b/website/docs/components/checkbox/examples/withIconAndLink.jsx
@@ -14,10 +14,10 @@ const Demo = () => (
       <div key={item}>
         <Checkbox mb={2}>
           <Checkbox.Value />
-          <Checkbox.Text>{`Пункт ${item + 1}`}</Checkbox.Text>
+          <Checkbox.Text>{`Note ${item + 1}`}</Checkbox.Text>
         </Checkbox>
         <Tooltip title="There is information about point." placement="right" ml={1}>
-          <InfoXS color="stone" interactive />
+          <InfoXS color="stone" interactive aria-label="Additional info" />
         </Tooltip>
       </div>
     ))}
@@ -27,7 +27,7 @@ const Demo = () => (
         <Checkbox mb={2}>
           <Checkbox.Value />
           <Checkbox.Text>
-            {`Пункт ${item + 1}`} <Link onClick={noop}>Link to somewhere</Link>
+            {`Note ${item + 1}`} <Link onClick={noop}>Link to somewhere</Link>
           </Checkbox.Text>
         </Checkbox>
       </div>

--- a/website/docs/components/input-phone/examples/basic.jsx
+++ b/website/docs/components/input-phone/examples/basic.jsx
@@ -8,9 +8,12 @@ const Demo = () => {
     <Input w={180}>
       <Input.Value value={value} onChange={(v) => updateValue(v)} />
       {value.length > 1 && (
-        <Input.Addon>
-          <CloseXS interactive onClick={() => updateValue('+')} />
-        </Input.Addon>
+        <Input.Addon
+          tag={CloseXS}
+          interactive
+          aria-label="Clear field"
+          onClick={() => updateValue('+')}
+        />
       )}
     </Input>
   );

--- a/website/docs/components/input-phone/examples/mask.jsx
+++ b/website/docs/components/input-phone/examples/mask.jsx
@@ -328,14 +328,12 @@ const Demo = () => {
           mask={valueMask.replace(/_/g, '9')}
         />
         {value !== valueMask && (
-          <Input.Addon>
-            <CloseXS
-              interactive
-              onClick={() => {
-                updateValue(valueMask);
-              }}
-            />
-          </Input.Addon>
+          <Input.Addon
+            tag={CloseXS}
+            aria-label="Clear value"
+            interactive
+            onClick={() => updateValue(valueMask)}
+          />
         )}
       </InputMask>
     </NeighborLocation>

--- a/website/docs/components/input-phone/examples/medium.jsx
+++ b/website/docs/components/input-phone/examples/medium.jsx
@@ -12,9 +12,12 @@ const Demo = () => {
       </Input.Addon>
       <Input.Value value={value} onChange={(v) => updateValue(v)} />
       {value > 2 && (
-        <Input.Addon>
-          <CloseXS interactive onClick={() => updateValue('+1')} />
-        </Input.Addon>
+        <Input.Addon
+          tag={CloseXS}
+          interactive
+          aria-label="Clear field"
+          onClick={() => updateValue('+1')}
+        />
       )}
     </Input>
   );

--- a/website/docs/components/input/examples/2addon.jsx
+++ b/website/docs/components/input/examples/2addon.jsx
@@ -24,9 +24,14 @@ const Demo = () => {
         onChange={(v) => setValue(v)}
       />
       {value && (
-        <Input.Addon pl={2} pr={1} interactive onClick={() => setValue('')}>
-          <CloseXS />
-        </Input.Addon>
+        <Input.Addon
+          tag={CloseXS}
+          pl={2}
+          pr={1}
+          interactive
+          aria-label="Clear password field"
+          onClick={() => setValue('')}
+        />
       )}
       <Input.Addon px={1}>
         <Link>Forget?</Link>

--- a/website/docs/components/input/examples/clear.jsx
+++ b/website/docs/components/input/examples/clear.jsx
@@ -13,9 +13,12 @@ const Demo = () => {
         onChange={(v) => setValue(v)}
       />
       {value && (
-        <Input.Addon interactive onClick={() => setValue('')}>
-          <CloseXS />
-        </Input.Addon>
+        <Input.Addon
+          tag={CloseXS}
+          interactive
+          aria-label="Clear field"
+          onClick={() => setValue('')}
+        />
       )}
     </Input>
   );

--- a/website/docs/components/input/examples/password.jsx
+++ b/website/docs/components/input/examples/password.jsx
@@ -14,9 +14,12 @@ const Demo = () => {
   return (
     <Input w={240}>
       <Input.Value defaultValue="IlikeCATS" placeholder="Password" type={type} />
-      <Input.Addon interactive onClick={() => setType(MAP_TYPES[type])}>
-        {type === 'password' ? <ShowYesXS /> : <ShowNoXS />}
-      </Input.Addon>
+      <Input.Addon
+        tag={type === 'password' ? <ShowYesXS /> : <ShowNoXS />}
+        aria-label={type === 'password' ? 'View password' : 'Hide password'}
+        interactive
+        onClick={() => setType(MAP_TYPES[type])}
+      />
     </Input>
   );
 };

--- a/website/docs/components/input/examples/submit.jsx
+++ b/website/docs/components/input/examples/submit.jsx
@@ -12,11 +12,7 @@ const Demo = () => {
         onBlur={() => setFocus(false)}
         onFocus={() => setFocus(true)}
       />
-      {focus && (
-        <Input.Addon interactive>
-          <ActionReturnXS />
-        </Input.Addon>
-      )}
+      {focus && <Input.Addon interactive tag={ActionReturnXS} aria-label="Submit field value" />}
     </Input>
   );
 };

--- a/website/docs/data-display/donut-chart/examples/complex-recharts.jsx
+++ b/website/docs/data-display/donut-chart/examples/complex-recharts.jsx
@@ -8,7 +8,7 @@ import Checkbox from '@semcore/checkbox';
 import InfoXS from '@semcore/icon/Info/m';
 import SettingsS from '@semcore/icon/Settings/m';
 
-let data = [
+const data = [
   { domain: 'tut.by', value: 35844 },
   { domain: 'onliner.by', value: 17239 },
   { domain: 'news.ru', value: 13186 },
@@ -72,7 +72,7 @@ class Demo extends PureComponent {
               <InfoXS ml="4px" color="gray-300" cursor="help" />
             </Tooltip>
           </Text>
-          <SettingsS color="gray-300" interactive />
+          <SettingsS color="gray-300" interactive aria-label="Open settings" />
         </Flex>
         <Flex mt={3} alignItems="flex-start" flexWrap>
           <PieChart height={196} width={196} style={{ margin: '0 20px 24px 0' }}>

--- a/website/docs/data-display/donut-chart/examples/simple-recharts.jsx
+++ b/website/docs/data-display/donut-chart/examples/simple-recharts.jsx
@@ -8,7 +8,7 @@ import Checkbox from '@semcore/checkbox';
 import InfoXS from '@semcore/icon/Info/m';
 import SettingsS from '@semcore/icon/Settings/m';
 
-let data = [
+const data = [
   { domain: 'tut.by', value: 35844 },
   { domain: 'onliner.by', value: 17239 },
   { domain: 'roga&kopita.ru', value: 13186 },
@@ -64,7 +64,7 @@ class Demo extends PureComponent {
               <InfoXS ml="4px" color="gray-300" cursor="help" />
             </Tooltip>
           </Text>
-          <SettingsS color="gray-300" interactive />
+          <SettingsS color="gray-300" interactive aria-label="Open settings" />
         </Flex>
         <Flex mt={3} alignItems="flex-start" flexWrap="wrap">
           <PieChart height={80} width={80} style={{ margin: '0 28px 24px 0' }}>
@@ -109,7 +109,7 @@ class Demo extends PureComponent {
             onMouseLeave={this.handleMouseLeave}
           >
             {domains.map((name, id) => {
-              let { domain, value } = data[id];
+              const { domain, value } = data[id];
 
               return (
                 <tr>

--- a/website/docs/data-display/line-chart/examples/layout.jsx
+++ b/website/docs/data-display/line-chart/examples/layout.jsx
@@ -21,7 +21,13 @@ class Demo extends Component {
               <InfoM ml={1} color="gray-300" cursor="help" />
             </TooltipUI>
             <Dropdown placement="bottom-end">
-              <Dropdown.Trigger tag={SettingsS} ml="auto" color="gray-300" interactive />
+              <Dropdown.Trigger
+                tag={SettingsS}
+                ml="auto"
+                color="gray-300"
+                interactive
+                aria-label="Open settings"
+              />
               <Dropdown.Popper>
                 <Box p={3}>
                   <Text size={100} bold mb={3}>

--- a/website/docs/data-display/line-chart/examples/line-recharts.jsx
+++ b/website/docs/data-display/line-chart/examples/line-recharts.jsx
@@ -84,7 +84,13 @@ const Demo = () => {
       <Flex mb={2} alignItems="center">
         <Card.Title hint="This is just an example of line chart">Chart heading</Card.Title>
         <Dropdown placement="bottom-end">
-          <Dropdown.Trigger tag={SettingsS} ml="auto" color="gray-300" interactive />
+          <Dropdown.Trigger
+            tag={SettingsS}
+            ml="auto"
+            color="gray-300"
+            interactive
+            aria-label="Open settings"
+          />
           <Dropdown.Popper>
             <Box p={3}>
               <Text size={100} bold mb={3}>

--- a/website/docs/data-display/venn-chart/examples/complex-recharts.jsx
+++ b/website/docs/data-display/venn-chart/examples/complex-recharts.jsx
@@ -47,10 +47,10 @@ const Demo = () => {
         <Text tag="h3" size={400} medium mt={0} mx={0} mb={2}>
           Chart heading
           <Tooltip title="Awesome hint text">
-            <InfoXS ml="4px" color="gray-300" interactive />
+            <InfoXS ml="4px" color="gray-300" interactive aria-label="Open additional info" />
           </Tooltip>
         </Text>
-        <SettingsS color="gray-300" interactive />
+        <SettingsS color="gray-300" interactive aria-label="Open settings" />
       </Flex>
       <Flex mt={3} alignItems="flex-start" justifyContent="flex-start" flexWrap={true}>
         <VennChart

--- a/website/docs/filter-group/advanced-filters/examples/conditions.jsx
+++ b/website/docs/filter-group/advanced-filters/examples/conditions.jsx
@@ -21,7 +21,16 @@ const Filter = ({ closable, onClose, ...props }) => (
     <Input>
       <Input.Value />
     </Input>
-    {closable ? <TrashXS color="stone" interactive ml={2} py={2} onClick={onClose} /> : null}
+    {closable ? (
+      <TrashXS
+        color="stone"
+        interactive
+        aria-label="Clear filters"
+        ml={2}
+        py={2}
+        onClick={onClose}
+      />
+    ) : null}
   </Flex>
 );
 

--- a/website/docs/filter-group/filter-search/examples/DynamicSearch.jsx
+++ b/website/docs/filter-group/filter-search/examples/DynamicSearch.jsx
@@ -24,9 +24,7 @@ const Demo = () => {
       </Input.Addon>
       <Input.Value placeholder="Filter by keyword" value={value} onChange={handleChange} />
       {value && (
-        <Input.Addon>
-          <CloseXS interactive onClick={handleClick} />
-        </Input.Addon>
+        <Input.Addon tag={CloseXS} interactive onClick={handleClick} aria-label="Clear filters" />
       )}
     </Input>
   );

--- a/website/docs/filter-group/filter-search/examples/SearchByButton.jsx
+++ b/website/docs/filter-group/filter-search/examples/SearchByButton.jsx
@@ -24,9 +24,7 @@ const Demo = () => {
       <Input w={200}>
         <Input.Value placeholder="Filter by keyword" value={value} onChange={handleChange} />
         {value && (
-          <Input.Addon>
-            <CloseXS interactive onClick={handleClick} />
-          </Input.Addon>
+          <Input.Addon tag={CloseXS} interactive onClick={handleClick} aria-label="Clear filter" />
         )}
       </Input>
       <Button aria-label="Search">

--- a/website/docs/filter-group/filter-search/examples/SearchWithSelect.jsx
+++ b/website/docs/filter-group/filter-search/examples/SearchWithSelect.jsx
@@ -33,9 +33,7 @@ const Demo = () => {
       <Input w={200}>
         <Input.Value ml={2} placeholder="Filter by keyword" value={value} onChange={handleChange} />
         {value && (
-          <Input.Addon>
-            <CloseXS interactive onClick={handleClick} />
-          </Input.Addon>
+          <Input.Addon tag={CloseXS} interactive onClick={handleClick} aria-label="Clear filter" />
         )}
       </Input>
       <Button aria-label="Search">

--- a/website/docs/patterns/form/examples/reactHookForm.jsx
+++ b/website/docs/patterns/form/examples/reactHookForm.jsx
@@ -264,14 +264,12 @@ export default function App() {
                     mask={valueMask.replace(/_/g, '9')}
                   />
                   {value !== valueMask && (
-                    <Input.Addon>
-                      <CloseXS
-                        interactive
-                        onClick={() => {
-                          updateValue(valueMask);
-                        }}
-                      />
-                    </Input.Addon>
+                    <Input.Addon
+                      tag={CloseXS}
+                      interactive
+                      onClick={() => updateValue(valueMask)}
+                      aria-label="Clear field"
+                    />
                   )}
                 </InputMask>
               }

--- a/website/docs/style/icon/components/index.jsx
+++ b/website/docs/style/icon/components/index.jsx
@@ -57,9 +57,12 @@ const SuggestSearch = connectAutoComplete(
           placeholder="Fill this field with 'happy smile' text :)"
         />
         {!!currentRefinement && (
-          <Input.Addon>
-            <CloseXS interactive onClick={() => handleChangeValue('')} />
-          </Input.Addon>
+          <Input.Addon
+            tag={CloseXS}
+            interactive
+            onClick={() => handleChangeValue('')}
+            aria-label="Clear field"
+          />
         )}
       </Search>
     );

--- a/website/docs/style/icon/examples/interactive.jsx
+++ b/website/docs/style/icon/examples/interactive.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import LinkExternalS from '@semcore/icon/LinkExternal/m';
 
-const Demo = () => <LinkExternalS interactive color="stone" />;
+const Demo = () => (
+  <LinkExternalS interactive aria-label="Go to our awesome article" color="stone" />
+);
 
 export default Demo;

--- a/website/src/components/SideBarHeading.jsx
+++ b/website/src/components/SideBarHeading.jsx
@@ -41,8 +41,12 @@ function SideBarHeading({ headings }) {
           </Link>
         ))}
       </nav>
-      <span className={styles.buttonUp} onClick={() => animateScroll.scrollToTop({ smooth: true })}>
-        <ArrowUpM interactive />
+      <span
+        aria-hidden="true"
+        className={styles.buttonUp}
+        onClick={() => animateScroll.scrollToTop({ smooth: true })}
+      >
+        <ArrowUpM interactive aria-label="Scroll page to the top" />
       </span>
     </>
   );


### PR DESCRIPTION
<!--- Commit was signed off by phytonmk@gmail.com with GPG key ID CF2DC815AE956C1F -->

Made aria-label required for interactive icons

## Description

If `interactive` prop is provided for icon but `aria-label` or `aria-labelledby` are not, a warning is logged in non-production env.

Non-interactive icons are aria-hidden now.

## How has this been tested?

I have not added any new tests but updated lot of them (by adding aria-label). Suppose if now axe errors are appeared and no new warnings during jest run changes may be considered as working.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.