### PR TITLE
[time-picker] introduced a11y

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1451,6 +1451,8 @@ importers:
 
   semcore/time-picker:
     specifiers:
+      '@guidepup/playwright': 0.6.1
+      '@playwright/test': 1.25.1
       '@semcore/button': ^4
       '@semcore/flex-box': ^4
       '@semcore/input': ^3.0.0
@@ -1465,6 +1467,8 @@ importers:
       '@semcore/select': link:../select
       '@semcore/utils': link:../utils
     devDependencies:
+      '@guidepup/playwright': 0.6.1_@playwright+test@1.25.1
+      '@playwright/test': 1.25.1
       '@semcore/jest-preset-ui': link:../../tools/jest-preset-ui
       '@types/react': 18.0.21
 

--- a/semcore/time-picker/CHANGELOG.md
+++ b/semcore/time-picker/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.2.4] - 2022-10-30
+
+### Fixed
+
+- Fixed that some secret combination of arrows pressing was causing infinite focus call and temporary freeze of browser.
+- Fixed Screen readers support.
+
 ## [3.2.3] - 2022-10-24
 
 ### Changed

--- a/semcore/time-picker/__tests__/time-picker.vo-test.ts
+++ b/semcore/time-picker/__tests__/time-picker.vo-test.ts
@@ -1,0 +1,43 @@
+import { expect } from '@playwright/test';
+import { voTest as test } from '@guidepup/playwright';
+import { e2eStandToHtml } from '@semcore/jest-preset-ui/e2e-stand';
+import { resolve as resolvePath } from 'path';
+import { writeFile } from 'fs/promises';
+import { getReportHeader, makeVoiceOverReporter } from '@semcore/jest-preset-ui/vo-reporter';
+
+test('Users can interact with TimePicker via VoiceOver', async ({
+  page,
+  voiceOver: pureVoiceOver,
+}) => {
+  const standPath = resolvePath(
+    __dirname,
+    '../../../website/docs/components/time-picker/examples/expanded.jsx',
+  );
+  const reportPath = resolvePath(
+    __dirname,
+    '../../../website/docs/components/time-picker/time-picker-a11y-report.md',
+  );
+
+  const htmlContent = await e2eStandToHtml(standPath, 'en');
+  await page.reload();
+  await page.setContent(htmlContent);
+  const { voiceOver, getReport } = await makeVoiceOverReporter(pureVoiceOver);
+  await voiceOver.interact();
+  expect(await voiceOver.itemText()).toBe('Time input, no time entered group');
+  await voiceOver.interact();
+  expect(await voiceOver.lastSpokenPhrase()).toBe('hours field 00 edit text');
+  await voiceOver.interact();
+  await voiceOver.type('04', { application: 'Playwright' });
+  await voiceOver.stopInteracting();
+  await voiceOver.next();
+  await voiceOver.interact();
+  await voiceOver.type('20', { application: 'Playwright' });
+  await voiceOver.stopInteracting();
+  await voiceOver.previous();
+  await voiceOver.stopInteracting();
+  expect(await voiceOver.itemText()).toBe('Time input, entered time is 4:20 AM group');
+
+  const report = (await getReportHeader()) + '\n\n' + (await getReport(standPath));
+
+  await writeFile(reportPath, report);
+});

--- a/semcore/time-picker/package.json
+++ b/semcore/time-picker/package.json
@@ -13,11 +13,11 @@
     "test": "jest --no-cache"
   },
   "dependencies": {
-    "@semcore/utils": "^3.15",
-    "@semcore/flex-box": "^4",
     "@semcore/button": "^4",
+    "@semcore/flex-box": "^4",
     "@semcore/input": "^3.0.0",
-    "@semcore/select": "^3.0.0"
+    "@semcore/select": "^3.0.0",
+    "@semcore/utils": "^3.15"
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
@@ -32,7 +32,9 @@
     "directory": "semcore/time-picker"
   },
   "devDependencies": {
-    "@types/react": "18.0.21",
-    "@semcore/jest-preset-ui": "1.0.0"
+    "@guidepup/playwright": "0.6.1",
+    "@playwright/test": "1.25.1",
+    "@semcore/jest-preset-ui": "1.0.0",
+    "@types/react": "18.0.21"
   }
 }

--- a/semcore/time-picker/src/PickerFormat.jsx
+++ b/semcore/time-picker/src/PickerFormat.jsx
@@ -10,8 +10,10 @@ class TimePickerFormat extends Component {
     const { Children, meridiem, styles } = this.asProps;
     const SPickerFormatText = 'span';
 
+    const label = `Time format ${meridiem}`;
+
     return sstyled(styles)(
-      <SPickerFormat render={Box} type="button" tag="button">
+      <SPickerFormat render={Box} type="button" tag="button" role="switch" aria-label={label}>
         {Children.origin ? <Children /> : <SPickerFormatText>{meridiem}</SPickerFormatText>}
       </SPickerFormat>,
     );

--- a/semcore/time-picker/src/PickerInput.jsx
+++ b/semcore/time-picker/src/PickerInput.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Input from '@semcore/input';
 import Select from '@semcore/select';
-import { intOrDefault, nextInput, prevInput, withLeadingZero } from './TimePicker';
+import { intOrDefault, withLeadingZero } from './TimePicker';
 import { Component, sstyled, Root } from '@semcore/core';
 import { callAllEventHandlers } from '@semcore/utils/lib/assignProps';
 
@@ -35,7 +35,7 @@ class ItemPicker extends Component {
     placeholder: '00',
   };
 
-  $input = React.createRef();
+  inputRef = React.createRef();
 
   minMax() {
     return [];
@@ -78,7 +78,7 @@ class ItemPicker extends Component {
   handleBlur = (e) => this.submitChanges(e);
 
   handleFocus = () => {
-    this.$input?.current.select();
+    // this.inputRef?.current.select();
   };
 
   /* rewrite method */
@@ -110,23 +110,28 @@ class ItemPicker extends Component {
         value={timeValue}
       >
         <SPickerInput
-          interaction="focus"
           render={Select.Trigger}
           tag={Input.Value}
-          aria-autocomplete={undefined}
-          aria-expanded={visible}
-          ref={this.$input}
+          ref={this.inputRef}
           size={size}
           disabled={disabled}
           neighborLocation={false}
           value={value}
-          aria-label={`Search ${this.field}`}
+          role="input"
+          aria-label={`${this.field} field`}
+          aria-autocomplete=""
+          aria-expanded=""
+          aria-flowto=""
+          aria-controls=""
+          aria-haspopup=""
           onChange={this.handleChange}
           onBlur={this.handleBlur}
           onFocus={this.handleFocus}
           onKeyDown={this.handleKeyDown}
         />
-        <Select.Menu hMax={180}>{getOptions(min, max, step)}</Select.Menu>
+        <Select.Menu aria-hidden="true" hMax={180}>
+          {getOptions(min, max, step)}
+        </Select.Menu>
       </Select>,
     );
   }
@@ -145,12 +150,9 @@ class Hours extends ItemPicker {
   }
 
   nextInput() {
-    if (this.$input.current) {
-      const $input = nextInput(this.$input.current);
-      if ($input) {
-        this.setState({ visible: false });
-        $input.focus();
-      }
+    if (this.asProps.minutesInputRef.current) {
+      this.setState({ visible: false });
+      this.asProps.minutesInputRef.current.focus();
     }
   }
 
@@ -186,12 +188,9 @@ class Minutes extends ItemPicker {
   }
 
   prevFocus() {
-    if (this.$input.current) {
-      const $input = prevInput(this.$input.current);
-      if ($input) {
-        this.setState({ visible: false });
-        $input.focus();
-      }
+    if (this.asProps.hoursInputRef.current) {
+      this.setState({ visible: false });
+      this.asProps.hoursInputRef.current.focus();
     }
   }
 

--- a/semcore/time-picker/src/PickerInput.jsx
+++ b/semcore/time-picker/src/PickerInput.jsx
@@ -117,13 +117,15 @@ class ItemPicker extends Component {
           disabled={disabled}
           neighborLocation={false}
           value={value}
-          role="input"
           aria-label={`${this.field} field`}
-          aria-autocomplete=""
-          aria-expanded=""
-          aria-flowto=""
-          aria-controls=""
-          aria-haspopup=""
+          __excludeProps={[
+            'aria-haspopup',
+            'aria-controls',
+            'aria-flowto',
+            'aria-expanded',
+            'aria-autocomplete',
+            'role',
+          ]}
           onChange={this.handleChange}
           onBlur={this.handleBlur}
           onFocus={this.handleFocus}

--- a/semcore/time-picker/src/PickerInput.jsx
+++ b/semcore/time-picker/src/PickerInput.jsx
@@ -77,10 +77,6 @@ class ItemPicker extends Component {
 
   handleBlur = (e) => this.submitChanges(e);
 
-  handleFocus = () => {
-    // this.inputRef?.current.select();
-  };
-
   /* rewrite method */
   handleKeyDown = () => {};
 
@@ -128,7 +124,6 @@ class ItemPicker extends Component {
           ]}
           onChange={this.handleChange}
           onBlur={this.handleBlur}
-          onFocus={this.handleFocus}
           onKeyDown={this.handleKeyDown}
         />
         <Select.Menu aria-hidden="true" hMax={180}>

--- a/semcore/time-picker/src/TimePicker.jsx
+++ b/semcore/time-picker/src/TimePicker.jsx
@@ -205,7 +205,12 @@ class TimePickerRoot extends Component {
       : `Time input, no time entered`;
 
     return sstyled(styles)(
-      <STimePicker render={Input} aria-label={label} aria-valuenow={value} tabIndex={0}>
+      <STimePicker
+        render={Input}
+        aria-label={label}
+        aria-valuenow={value || undefined}
+        tabIndex={0}
+      >
         <Children />
       </STimePicker>,
     );

--- a/semcore/time-picker/src/TimePicker.jsx
+++ b/semcore/time-picker/src/TimePicker.jsx
@@ -16,20 +16,6 @@ const MAP_FIELD_TO_TIME = {
   minutes: 1,
 };
 
-export function nextInput(element) {
-  do {
-    element = element.nextElementSibling;
-  } while (element && element.tagName !== 'INPUT');
-  return element;
-}
-
-export function prevInput(element) {
-  do {
-    element = element.previousElementSibling;
-  } while (element && element.tagName !== 'INPUT');
-  return element;
-}
-
 export function intOrDefault(value, def = 0) {
   const number = Number.parseInt(value);
   return Number.isNaN(number) ? def : number;
@@ -87,6 +73,9 @@ class TimePickerRoot extends Component {
       </>
     ),
   });
+
+  hoursInputRef = React.createRef();
+  minutesInputRef = React.createRef();
 
   _lastMeridiem = 'AM'; // default AM
 
@@ -179,6 +168,8 @@ class TimePickerRoot extends Component {
       is12Hour,
       disabled,
       $onValueChange: this.handleValueChange,
+      minutesInputRef: this.minutesInputRef,
+      hoursInputRef: this.hoursInputRef,
     };
   };
 
@@ -188,15 +179,19 @@ class TimePickerRoot extends Component {
   getSeparatorProps() {
     return {
       disabled: this.asProps.disabled,
+      hoursInputRef: this.hoursInputRef,
     };
   }
 
   getFormatProps() {
-    const { size, disabled, disablePortal } = this.asProps;
+    const { size, disabled, disablePortal, value } = this.asProps;
+    const valueFulfilled = value?.split(':').every((chunk) => chunk.length > 0);
+
     return {
       size,
       disabled,
       disablePortal,
+      ['aria-hidden']: !valueFulfilled,
       meridiem: this.meridiem,
       onClick: this.handleMeridiemClick,
     };
@@ -204,10 +199,13 @@ class TimePickerRoot extends Component {
 
   render() {
     const STimePicker = Root;
-    const { styles, Children } = this.asProps;
+    const { styles, Children, value, is12Hour } = this.asProps;
+    const label = value
+      ? `Time input, entered time is ${value} ${is12Hour ? this.meridiem : ''}`
+      : `Time input, no time entered`;
 
     return sstyled(styles)(
-      <STimePicker render={Input}>
+      <STimePicker render={Input} aria-label={label} aria-valuenow={value} tabIndex={0}>
         <Children />
       </STimePicker>,
     );
@@ -219,17 +217,15 @@ class Separator extends Component {
     children: ':',
   };
 
-  $el = React.createRef();
-
   handlerClick = () => {
-    if (this.$el.current) {
-      prevInput(this.$el.current)?.focus();
+    if (this.asProps.hoursInputRef.current) {
+      this.asProps.hoursInputRef.current?.focus();
     }
   };
 
   render() {
     const STimePickerSeparator = Root;
-    return <STimePickerSeparator render={Box} ref={this.$el} onClick={this.handlerClick} />;
+    return <STimePickerSeparator render={Box} onClick={this.handlerClick} aria-hidden="true" />;
   }
 }
 

--- a/website/docs/components/time-picker/time-picker-a11y-report.md
+++ b/website/docs/components/time-picker/time-picker-a11y-report.md
@@ -1,0 +1,29 @@
+## Automated screen reader testing
+
+_Intergalactic v13.0.1, React v18.2.0, Playwright v1.25.1,
+Guidepup v0.13.1, MacOS Monterey 12._
+
+**Running screen reader against [this file](https://github.com/semrush/intergalactic/blob/master/website/docs/components/time-picker/examples/expanded.jsx).**
+
+1. Screen reader goes into the active element.
+2. Screen reader says "Time input, no time entered group".
+3. Screen reader goes into the active element.
+4. Screen reader says "hours field 00 edit text".
+5. Screen reader goes into the active element.
+6. Screen reader says "In edit text".
+7. Screen reader types "04".
+8. Screen reader says "04".
+9. Screen reader goes out of active element.
+10. Screen reader says "Out of edit text".
+11. Screen reader goes to the next element.
+12. Screen reader says "minutes field 00 edit text".
+13. Screen reader goes into the active element.
+14. Screen reader says "In edit text".
+15. Screen reader types "20".
+16. Screen reader says "20".
+17. Screen reader goes out of active element.
+18. Screen reader says "Out of edit text".
+19. Screen reader goes to the previous element.
+20. Screen reader says "04 Insertion at end of text. hours field edit text".
+21. Screen reader goes out of active element.
+22. Screen reader says "Time input, entered time is 4:20 AM group".

--- a/website/docs/components/time-picker/time-picker-a11y.md
+++ b/website/docs/components/time-picker/time-picker-a11y.md
@@ -21,3 +21,5 @@ fileSource: time-picker
 @## Other recommendations
 
 See more accessibility recommendations in the common [Accessibility guide](/core-principles/a11y/).
+
+@include time-picker-a11y-report


### PR DESCRIPTION
Made time-picker accessible for Screen readers.

## Description

I have hid combobox popups for screen readers and added several necessary labels. Also I have removed weird searching for sibling inputs to focus it and replaced with predictable refs. 


## How has this been tested?

I have added VO tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
