### PR TITLE
[d3-chart] fixed typings of `CProps`

### DIFF
--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.4.3] - 2022-10-20
+
+### Fixed
+
+- Fixed typings of render functions.
+
 ## [2.4.2] - 2022-10-20
 
 ### Changed

--- a/semcore/d3-chart/src/RadialTree.tsx
+++ b/semcore/d3-chart/src/RadialTree.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { transition } from 'd3-transition';
-import { Component, sstyled, CProps, ReturnEl } from '@semcore/core';
+import { Component, sstyled, ReturnEl } from '@semcore/core';
 import uniqueIDEnhancement from '@semcore/utils/lib/uniqueID';
 import { shade } from '@semcore/utils/lib/color';
 import assignProps from '@semcore/utils/lib/assignProps';
@@ -10,6 +10,7 @@ import { measureText } from './utils';
 import { DataHintsHandler } from './a11y/hints';
 
 import style from './style/radial-tree.shadow.css';
+import type { MapProps } from './types';
 
 const baseAngle = -Math.PI / 2; // The top vertical line
 
@@ -777,14 +778,14 @@ const Title: React.FC<RadialTreeTitleAsProps> = ({
 };
 
 const RadialTree = createElement(RadialTreeBase, { Title, Radian }) as (<T>(
-  props: CProps<IRadialTreeProps & T>,
+  props: MapProps<IRadialTreeProps & T>,
 ) => ReturnEl) & {
-  Title: <T>(props: CProps<IRadialTreeTitleProps & T>) => ReturnEl;
-  Radian: (<T>(props: CProps<IRadialTreeRadianProps & T>) => ReturnEl) & {
-    Line: <T>(props: CProps<IRadialTreeRadianLineProps & T>) => ReturnEl;
-    Cap: <T>(props: CProps<IRadialTreeRadianCapProps & T>) => ReturnEl;
-    Icon: <T>(props: CProps<IRadialTreeRadianIconProps & T>) => ReturnEl;
-    Label: <T>(props: CProps<IRadialTreeRadianLabelProps & T>) => ReturnEl;
+  Title: <T>(props: MapProps<IRadialTreeTitleProps & T>) => ReturnEl;
+  Radian: (<T>(props: MapProps<IRadialTreeRadianProps & T>) => ReturnEl) & {
+    Line: <T>(props: MapProps<IRadialTreeRadianLineProps & T>) => ReturnEl;
+    Cap: <T>(props: MapProps<IRadialTreeRadianCapProps & T>) => ReturnEl;
+    Icon: <T>(props: MapProps<IRadialTreeRadianIconProps & T>) => ReturnEl;
+    Label: <T>(props: MapProps<IRadialTreeRadianLabelProps & T>) => ReturnEl;
   };
 };
 

--- a/semcore/d3-chart/src/types/Area.d.ts
+++ b/semcore/d3-chart/src/types/Area.d.ts
@@ -1,4 +1,5 @@
-import { CProps, ReturnEl } from '@semcore/core';
+import { ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 import IContext from './context';
 import { CurveFactory } from 'd3-shape';
 
@@ -39,10 +40,10 @@ export interface IAreaNullProps extends IContext {
   hide?: boolean;
 }
 
-declare const Area: (<T>(props: CProps<IAreaProps & T>) => ReturnEl) & {
-  Dots: <T>(props: CProps<IAreaDotsProps & T, IAreaDotsContext>) => ReturnEl;
-  Null: <T>(props: CProps<IAreaNullProps & T>) => ReturnEl;
-  Line: <T>(props: CProps<IContext & T>) => ReturnEl;
+declare const Area: (<T>(props: MapProps<IAreaProps & T>) => ReturnEl) & {
+  Dots: <T>(props: MapProps<IAreaDotsProps & T, IAreaDotsContext>) => ReturnEl;
+  Null: <T>(props: MapProps<IAreaNullProps & T>) => ReturnEl;
+  Line: <T>(props: MapProps<IContext & T>) => ReturnEl;
 };
 
 export default Area;

--- a/semcore/d3-chart/src/types/Axis.d.ts
+++ b/semcore/d3-chart/src/types/Axis.d.ts
@@ -1,4 +1,5 @@
-import { CProps, ReturnEl } from '@semcore/core';
+import { ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 import IContext from './context';
 
 export interface IXAxisProps extends IContext {
@@ -49,16 +50,16 @@ export interface IAxisTicksContext {
   index: number;
 }
 
-declare const XAxis: (<T>(props: CProps<IXAxisProps & T>) => ReturnEl) & {
-  Ticks: <T>(props: CProps<IAxisTicksProps & T, IAxisTicksContext>) => ReturnEl;
-  Grid: <T>(props: CProps<IAxisGridProps & T>) => ReturnEl;
-  Title: <T>(props: CProps<IAxisTitleProps & T>) => ReturnEl;
+declare const XAxis: (<T>(props: MapProps<IXAxisProps & T>) => ReturnEl) & {
+  Ticks: <T>(props: MapProps<IAxisTicksProps & T, IAxisTicksContext>) => ReturnEl;
+  Grid: <T>(props: MapProps<IAxisGridProps & T>) => ReturnEl;
+  Title: <T>(props: MapProps<IAxisTitleProps & T>) => ReturnEl;
 };
 
-declare const YAxis: (<T>(props: CProps<IYAxisProps & T>) => ReturnEl) & {
-  Ticks: <T>(props: CProps<IAxisTicksProps & T, IAxisTicksContext>) => ReturnEl;
-  Grid: <T>(props: CProps<IAxisGridProps & T>) => ReturnEl;
-  Title: <T>(props: CProps<IAxisTitleProps & T>) => ReturnEl;
+declare const YAxis: (<T>(props: MapProps<IYAxisProps & T>) => ReturnEl) & {
+  Ticks: <T>(props: MapProps<IAxisTicksProps & T, IAxisTicksContext>) => ReturnEl;
+  Grid: <T>(props: MapProps<IAxisGridProps & T>) => ReturnEl;
+  Title: <T>(props: MapProps<IAxisTitleProps & T>) => ReturnEl;
 };
 
 export { XAxis, YAxis };

--- a/semcore/d3-chart/src/types/Bar.d.ts
+++ b/semcore/d3-chart/src/types/Bar.d.ts
@@ -1,4 +1,5 @@
-import { CProps, ReturnEl } from '@semcore/core';
+import { ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 import IContext from './context';
 
 export interface IBarProps extends IContext {
@@ -45,8 +46,8 @@ export interface IBackgroundProps extends IContext {
   height?: number | string;
 }
 
-declare const Bar: (<T>(props: CProps<IBarProps & T, IBarContext>) => ReturnEl) & {
-  Background: <T>(props: CProps<IBackgroundProps & T>) => ReturnEl;
+declare const Bar: (<T>(props: MapProps<IBarProps & T, IBarContext>) => ReturnEl) & {
+  Background: <T>(props: MapProps<IBackgroundProps & T>) => ReturnEl;
 };
 
 export default Bar;

--- a/semcore/d3-chart/src/types/Bubble.d.ts
+++ b/semcore/d3-chart/src/types/Bubble.d.ts
@@ -1,4 +1,5 @@
-import { CProps, ReturnEl } from '@semcore/core';
+import { ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 import IContext from './context';
 
 export interface IBubbleProps extends IContext {
@@ -27,6 +28,6 @@ export interface IBubbleContext {
   index: number;
 }
 
-declare const Bubble: <T>(props: CProps<IBubbleProps & T, IBubbleContext>) => ReturnEl;
+declare const Bubble: <T>(props: MapProps<IBubbleProps & T, IBubbleContext>) => ReturnEl;
 
 export default Bubble;

--- a/semcore/d3-chart/src/types/ClipPath.d.ts
+++ b/semcore/d3-chart/src/types/ClipPath.d.ts
@@ -1,5 +1,6 @@
 import React from 'react';
-import { CProps, ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
+import { ReturnEl } from '@semcore/core';
 
 export interface IClipPath {
   /**
@@ -21,6 +22,6 @@ export interface IClipPath {
   setAttributeTag?: (rect: React.ReactNode) => void;
 }
 
-declare const ClipPath: <T>(props: CProps<IClipPath & T>) => ReturnEl;
+declare const ClipPath: <T>(props: MapProps<IClipPath & T>) => ReturnEl;
 
 export default ClipPath;

--- a/semcore/d3-chart/src/types/Donut.d.ts
+++ b/semcore/d3-chart/src/types/Donut.d.ts
@@ -1,4 +1,5 @@
-import { CProps, ReturnEl } from '@semcore/core';
+import { ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 import IContext from './context';
 
 export interface IDonutProps extends IContext {
@@ -37,10 +38,10 @@ export interface IEmptyDataProps extends IContext {}
 
 export interface ILabelProps extends IContext {}
 
-declare const Donut: (<T>(props: CProps<IDonutProps & T>) => ReturnEl) & {
-  Pie: <T>(props: CProps<IPieProps & T>) => ReturnEl;
-  EmptyData: <T>(props: CProps<IEmptyDataProps & T>) => ReturnEl;
-  Label: <T>(props: CProps<ILabelProps & T>) => ReturnEl;
+declare const Donut: (<T>(props: MapProps<IDonutProps & T>) => ReturnEl) & {
+  Pie: <T>(props: MapProps<IPieProps & T>) => ReturnEl;
+  EmptyData: <T>(props: MapProps<IEmptyDataProps & T>) => ReturnEl;
+  Label: <T>(props: MapProps<ILabelProps & T>) => ReturnEl;
 };
 
 export default Donut;

--- a/semcore/d3-chart/src/types/GroupBar.d.ts
+++ b/semcore/d3-chart/src/types/GroupBar.d.ts
@@ -1,4 +1,5 @@
-import { CProps, ReturnEl } from '@semcore/core';
+import { ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 import { IBarContext, IBarProps } from './Bar';
 import { IHorizontalBarProps } from './HorizontalBar';
 import IContext from './context';
@@ -12,9 +13,9 @@ export interface IGroupBarProps extends IContext {
   scaleGroup?: any;
 }
 
-declare const GroupBar: (<T>(props: CProps<IGroupBarProps & T>) => ReturnEl) & {
-  Bar: <T>(props: CProps<IBarProps & T, IBarContext>) => ReturnEl;
-  HorizontalBar: <T>(props: CProps<IHorizontalBarProps & T, IBarContext>) => ReturnEl;
+declare const GroupBar: (<T>(props: MapProps<IGroupBarProps & T>) => ReturnEl) & {
+  Bar: <T>(props: MapProps<IBarProps & T, IBarContext>) => ReturnEl;
+  HorizontalBar: <T>(props: MapProps<IHorizontalBarProps & T, IBarContext>) => ReturnEl;
 };
 
 export default GroupBar;

--- a/semcore/d3-chart/src/types/HorizontalBar.d.ts
+++ b/semcore/d3-chart/src/types/HorizontalBar.d.ts
@@ -1,4 +1,5 @@
-import { CProps, ReturnEl } from '@semcore/core';
+import { ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 import IContext from './context';
 import { IBarContext, IBackgroundProps } from './Bar';
 
@@ -21,9 +22,9 @@ export interface IHorizontalBarProps extends IContext {
 }
 
 declare const HorizontalBar: (<T>(
-  props: CProps<IHorizontalBarProps & T, IBarContext>,
+  props: MapProps<IHorizontalBarProps & T, IBarContext>,
 ) => ReturnEl) & {
-  Background: <T>(props: CProps<IBackgroundProps & T>) => ReturnEl;
+  Background: <T>(props: MapProps<IBackgroundProps & T>) => ReturnEl;
 };
 
 export default HorizontalBar;

--- a/semcore/d3-chart/src/types/Hover.d.ts
+++ b/semcore/d3-chart/src/types/Hover.d.ts
@@ -1,4 +1,5 @@
-import { CProps, ReturnEl } from '@semcore/core';
+import { ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 import IContext from './context';
 
 export interface IHoverProps extends IContext {
@@ -8,8 +9,8 @@ export interface IHoverProps extends IContext {
   y?: string;
 }
 
-declare const HoverLine: <T>(props: CProps<IHoverProps & T>) => ReturnEl;
+declare const HoverLine: <T>(props: MapProps<IHoverProps & T>) => ReturnEl;
 
-declare const HoverRect: <T>(props: CProps<IHoverProps & T>) => ReturnEl;
+declare const HoverRect: <T>(props: MapProps<IHoverProps & T>) => ReturnEl;
 
 export { HoverLine, HoverRect };

--- a/semcore/d3-chart/src/types/Line.d.ts
+++ b/semcore/d3-chart/src/types/Line.d.ts
@@ -1,4 +1,5 @@
-import { CProps, ReturnEl } from '@semcore/core';
+import { ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 import IContext from './context';
 import { CurveFactory } from 'd3-shape';
 import { IFadeInOutProps } from '@semcore/animation';
@@ -42,9 +43,9 @@ export interface ILineNullProps extends IContext {
   hide?: boolean;
 }
 
-declare const Line: (<T>(props: CProps<ILineProps & T>) => ReturnEl) & {
-  Dots: <T>(props: CProps<ILineDotsProps & T, ILineDotsContext>) => ReturnEl;
-  Null: <T>(props: CProps<ILineNullProps & T>) => ReturnEl;
+declare const Line: (<T>(props: MapProps<ILineProps & T>) => ReturnEl) & {
+  Dots: <T>(props: MapProps<ILineDotsProps & T, ILineDotsContext>) => ReturnEl;
+  Null: <T>(props: MapProps<ILineNullProps & T>) => ReturnEl;
 };
 
 export default Line;

--- a/semcore/d3-chart/src/types/Plot.d.ts
+++ b/semcore/d3-chart/src/types/Plot.d.ts
@@ -1,5 +1,6 @@
 import { IBoxProps } from '@semcore/flex-box';
-import { CProps, ReturnEl } from '@semcore/core';
+import { ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 import IContext from './context';
 
 export interface IPlotProps extends IContext, IBoxProps {
@@ -86,6 +87,12 @@ export type PlotSummarizerConfig = {
   groupsLimit?: number;
 };
 
-declare const Plot: <T>(props: CProps<IPlotProps & T>) => ReturnEl;
+export type MapProps<Props, Ctx = {}, UCProps = {}> = Props & {
+  children?:
+    | ((props: Props & Ctx, handlers: UCProps) => Props | React.PropsWithChildren)
+    | React.ReactNode;
+};
+
+declare const Plot: <T>(props: MapProps<IPlotProps & T>) => ReturnEl;
 
 export default Plot;

--- a/semcore/d3-chart/src/types/ReferenceLine.d.ts
+++ b/semcore/d3-chart/src/types/ReferenceLine.d.ts
@@ -1,4 +1,5 @@
-import { CProps, ReturnEl } from '@semcore/core';
+import { ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 import IContext from './context';
 
 export interface IReferenceLineProps extends IContext {
@@ -23,9 +24,9 @@ export interface IReferenceLineBackgroundProps extends IContext {
   value: any;
 }
 
-declare const ReferenceLine: (<T>(props: CProps<IReferenceLineProps & T>) => ReturnEl) & {
-  Title: <T>(props: CProps<IReferenceLineTitleProps & T>) => ReturnEl;
-  Background: <T>(props: CProps<IReferenceLineBackgroundProps & T>) => ReturnEl;
+declare const ReferenceLine: (<T>(props: MapProps<IReferenceLineProps & T>) => ReturnEl) & {
+  Title: <T>(props: MapProps<IReferenceLineTitleProps & T>) => ReturnEl;
+  Background: <T>(props: MapProps<IReferenceLineBackgroundProps & T>) => ReturnEl;
 };
 
 export default ReferenceLine;

--- a/semcore/d3-chart/src/types/ResponsiveContainer.d.ts
+++ b/semcore/d3-chart/src/types/ResponsiveContainer.d.ts
@@ -1,5 +1,6 @@
 import { IBoxProps } from '@semcore/flex-box';
-import { CProps, ReturnEl } from '@semcore/core';
+import { ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 
 export interface IResponsiveContainerProps extends IBoxProps {
   /** Relation between height and width dimensions block */
@@ -14,7 +15,7 @@ export interface IResponsiveContainerContext {
 }
 
 declare const ResponsiveContainer: <T>(
-  props: CProps<IResponsiveContainerProps & T, IResponsiveContainerContext>,
+  props: MapProps<IResponsiveContainerProps & T, IResponsiveContainerContext>,
 ) => ReturnEl;
 
 export default ResponsiveContainer;

--- a/semcore/d3-chart/src/types/ScatterPlot.d.ts
+++ b/semcore/d3-chart/src/types/ScatterPlot.d.ts
@@ -1,4 +1,5 @@
-import { CProps, ReturnEl } from '@semcore/core';
+import { ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 import IContext from './context';
 
 export interface IScatterPlotProps extends IContext {
@@ -22,6 +23,6 @@ export interface IScatterPlotProps extends IContext {
   r?: number;
 }
 
-declare const ScatterPlot: <T>(props: CProps<IScatterPlotProps & T>) => ReturnEl;
+declare const ScatterPlot: <T>(props: MapProps<IScatterPlotProps & T>) => ReturnEl;
 
 export default ScatterPlot;

--- a/semcore/d3-chart/src/types/StackBar.d.ts
+++ b/semcore/d3-chart/src/types/StackBar.d.ts
@@ -1,4 +1,5 @@
-import { CProps, ReturnEl } from '@semcore/core';
+import { ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 import IContext from './context';
 import { IBarContext, IBarProps } from './Bar';
 import { IHorizontalBarProps } from './HorizontalBar';
@@ -18,9 +19,9 @@ export interface IStackBarContext {
   series: any[];
 }
 
-declare const StackBar: (<T>(props: CProps<IStackBarProps & T, IStackBarContext>) => ReturnEl) & {
-  Bar: <T>(props: CProps<IBarProps & T, IBarContext>) => ReturnEl;
-  HorizontalBar: <T>(props: CProps<IHorizontalBarProps & T, IBarContext>) => ReturnEl;
+declare const StackBar: (<T>(props: MapProps<IStackBarProps & T, IStackBarContext>) => ReturnEl) & {
+  Bar: <T>(props: MapProps<IBarProps & T, IBarContext>) => ReturnEl;
+  HorizontalBar: <T>(props: MapProps<IHorizontalBarProps & T, IBarContext>) => ReturnEl;
 };
 
 export default StackBar;

--- a/semcore/d3-chart/src/types/StackedArea.d.ts
+++ b/semcore/d3-chart/src/types/StackedArea.d.ts
@@ -1,4 +1,5 @@
-import { CProps, ReturnEl } from '@semcore/core';
+import { ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 import IContext from './context';
 import Area from './Area';
 
@@ -18,7 +19,7 @@ export interface IStackedAreaContext {
 }
 
 declare const StackedArea: (<T>(
-  props: CProps<IStackedAreaProps & T, IStackedAreaContext>,
+  props: MapProps<IStackedAreaProps & T, IStackedAreaContext>,
 ) => ReturnEl) & {
   Area: typeof Area;
 };

--- a/semcore/d3-chart/src/types/Tooltip.d.ts
+++ b/semcore/d3-chart/src/types/Tooltip.d.ts
@@ -1,6 +1,7 @@
 import { ComponentProps } from 'react';
 import Popper, { IPopperProps, IPopperTriggerProps } from '@semcore/popper';
-import { CProps, PropGetterFn, ReturnEl } from '@semcore/core';
+import { PropGetterFn, ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 import { IBoxProps } from '@semcore/flex-box';
 import IContext from './context';
 
@@ -21,13 +22,13 @@ export interface ITooltipChartContext {
 }
 
 declare const Tooltip: (<T>(
-  props: CProps<ITooltipChartProps & T, ITooltipChartContext>,
+  props: MapProps<ITooltipChartProps & T, ITooltipChartContext>,
 ) => ReturnEl) & {
-  Trigger: <T>(props: CProps<ComponentProps<typeof Popper.Trigger> & T>) => ReturnEl;
-  Popper: <T>(props: CProps<ComponentProps<typeof Popper.Popper> & T>) => ReturnEl;
-  Title: <T>(props: CProps<IBoxProps & T>) => ReturnEl;
-  Dot: <T>(props: CProps<IBoxProps & { color?: string } & T>) => ReturnEl;
-  Footer: <T>(props: CProps<T>) => null;
+  Trigger: <T>(props: MapProps<ComponentProps<typeof Popper.Trigger> & T>) => ReturnEl;
+  Popper: <T>(props: MapProps<ComponentProps<typeof Popper.Popper> & T>) => ReturnEl;
+  Title: <T>(props: MapProps<IBoxProps & T>) => ReturnEl;
+  Dot: <T>(props: MapProps<IBoxProps & { color?: string } & T>) => ReturnEl;
+  Footer: <T>(props: MapProps<T>) => null;
 };
 
 export default Tooltip;

--- a/semcore/d3-chart/src/types/Venn.d.ts
+++ b/semcore/d3-chart/src/types/Venn.d.ts
@@ -1,4 +1,5 @@
-import { CProps, ReturnEl } from '@semcore/core';
+import { ReturnEl } from '@semcore/core';
+import { MapProps } from './Plot';
 import IContext from './context';
 import { IFadeInOutProps } from '@semcore/animation';
 
@@ -37,9 +38,9 @@ export interface IIntersectionProps extends IContext, IFadeInOutProps {
   dataKey: string;
 }
 
-declare const Venn: (<T>(props: CProps<IVennProps & T>) => ReturnEl) & {
-  Circle: <T>(props: CProps<ICircleProps & T>) => ReturnEl;
-  Intersection: <T>(props: CProps<IIntersectionProps & T>) => ReturnEl;
+declare const Venn: (<T>(props: MapProps<IVennProps & T>) => ReturnEl) & {
+  Circle: <T>(props: MapProps<ICircleProps & T>) => ReturnEl;
+  Intersection: <T>(props: MapProps<IIntersectionProps & T>) => ReturnEl;
 };
 
 export default Venn;


### PR DESCRIPTION
## Description

I have replaced core typings of `CProps` (which represents replacement of children as render function) with locally introduced `MapsProps` (which represents mapper of the component props).  

## Motivation and Context

Nothing changed in runtime. Types were just tuned to be compatible with runtime. You may ask how it was working before. The answer - it wasn't.

## How has this been tested?

I have tried to use several `@semcore/d3-chart` examples from website. Seems like previously non-working examples now may be compiled successfully and nothing makes me suppose it may be broken.

Also I have ensured that no other component rather `@semcore/d3-chart` and `@secore/data-table` requires such typing. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.