### PR TITLE
[date-picker] fix InputTrigger subcomponent types

### DIFF
--- a/semcore/date-picker/CHANGELOG.md
+++ b/semcore/date-picker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.4.14] - 2022-11-29
+
+### Fixed
+
+- Fixed InputTrigger subcomponent types.
+
 ## [3.4.13] - 2022-11-28
 
 ### Changed

--- a/semcore/date-picker/src/index.d.ts
+++ b/semcore/date-picker/src/index.d.ts
@@ -289,7 +289,7 @@ declare const DatePicker: ((
     Addon: typeof BaseTrigger.Addon;
     Text: typeof BaseTrigger.Text;
   };
-  InputTrigger: InputTrigger;
+  InputTrigger: typeof InputTrigger;
   Popper: typeof Dropdown.Popper;
   Header: typeof Box;
   Title: <T>(props: CProps<IDatePickerProps & IBoxProps & T, IDatePickerContext>) => ReturnEl;
@@ -326,7 +326,7 @@ declare const DateRangePicker: ((
     Addon: typeof BaseTrigger.Addon;
     Text: typeof BaseTrigger.Text;
   };
-  InputTrigger: InputTrigger;
+  InputTrigger: typeof InputTrigger;
   Popper: <T>(props: ComponentProps<typeof Dropdown.Popper> & T) => ReturnEl;
   Header: typeof Box;
   Title: <T>(
@@ -366,7 +366,7 @@ declare const MonthPicker: ((
     Addon: typeof BaseTrigger.Addon;
     Text: typeof BaseTrigger.Text;
   };
-  InputTrigger: InputTrigger;
+  InputTrigger: typeof InputTrigger;
   Popper: typeof Dropdown.Popper;
   Header: typeof Box;
   Title: <T>(props: CProps<IDatePickerProps & IBoxProps & T, IMonthPickerContext>) => ReturnEl;
@@ -402,7 +402,7 @@ declare const MonthRangePicker: ((
     Addon: typeof BaseTrigger.Addon;
     Text: typeof BaseTrigger.Text;
   };
-  InputTrigger: InputTrigger;
+  InputTrigger: typeof InputTrigger;
   Popper: typeof Dropdown.Popper;
   Header: typeof Box;
   Title: <T>(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 
InputTrigger is declared as const, so we need to use `typeof`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.