### PR TITLE
[notice-bubble, animation] Added prop `initialAnimation` to run anima…

### DIFF
--- a/semcore/animation/CHANGELOG.md
+++ b/semcore/animation/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [1.8.0] - 2022-12-05
+
+### Added
+
+- Added prop `initialAnimation` to run animation on the first rendering
+
 ## [1.7.3] - 2022-11-30
 
 ### Changed

--- a/semcore/animation/src/Animation.jsx
+++ b/semcore/animation/src/Animation.jsx
@@ -16,14 +16,12 @@ class Animation extends Component {
     duration: 0,
     delay: 0,
     keyframes: [],
+    initialAnimation: false,
   };
 
   static getDerivedStateFromProps(props, state) {
     const wasInvisible = state.wasInvisible || !props.visible;
-    if (props.visible || props.preserveNode) {
-      return { render: true, wasInvisible };
-    }
-    if (state.wasInvisible !== wasInvisible) {
+    if (props.visible || props.preserveNode || state.wasInvisible !== wasInvisible) {
       return { render: true, wasInvisible };
     }
     return state;
@@ -43,7 +41,7 @@ class Animation extends Component {
 
   render() {
     const SAnimation = Root;
-    const { styles, keyframes } = this.asProps;
+    const { styles, keyframes, initialAnimation } = this.asProps;
     const duration = propToArray(this.asProps.duration);
     const delay = propToArray(this.asProps.delay);
     const { render, wasInvisible } = this.state;
@@ -58,7 +56,7 @@ class Animation extends Component {
         durationFinalize={`${duration[1]}ms`}
         delayInitialize={`${delay[0]}ms`}
         delayFinalize={`${delay[1]}ms`}
-        keyframesInitialize={wasInvisible ? keyframes[0] : undefined}
+        keyframesInitialize={wasInvisible || initialAnimation ? keyframes[0] : undefined}
         keyframesFinalize={keyframes[1]}
       />,
     );

--- a/semcore/animation/src/index.d.ts
+++ b/semcore/animation/src/index.d.ts
@@ -16,6 +16,10 @@ export interface IAnimationProps extends IBoxProps {
   keyframes?: [string, string];
   /** If it set to `true`, animated node is persisted in dom even if `visible=false`   */
   preserveNode?: boolean;
+  /** Enables animation on first rendering
+   * @default false
+   */
+  initialAnimation: boolean;
 }
 
 export interface ICollapseProps extends IAnimationProps {

--- a/semcore/notice-bubble/CHANGELOG.md
+++ b/semcore/notice-bubble/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.3.0] - 2022-12-05
+
+### Added
+
+- Added prop `initialAnimation` to run animation on the first rendering
+
 ## [4.2.12] - 2022-11-30
 
 ### Changed

--- a/semcore/notice-bubble/src/NoticeBubble.jsx
+++ b/semcore/notice-bubble/src/NoticeBubble.jsx
@@ -19,6 +19,7 @@ const Notices = (props) => {
     return sstyled(styles)(
       <Animation
         key={notice.uid}
+        initialAnimation={notice.initialAnimation}
         visible={notice.visible === undefined ? true : notice.visible}
         duration={250}
         keyframes={[styles['@enter'], styles['@exit']]}

--- a/semcore/notice-bubble/src/index.d.ts
+++ b/semcore/notice-bubble/src/index.d.ts
@@ -13,6 +13,10 @@ export interface INoticeBubbleInfoProps extends INoticeBubbleProps {
    * @default 5000
    */
   duration?: number;
+  /** Enables animation on first rendering
+   * @default false
+   */
+  initialAnimation: boolean;
 }
 
 export interface INoticeBubbleWarningProps extends INoticeBubbleProps {
@@ -22,6 +26,10 @@ export interface INoticeBubbleWarningProps extends INoticeBubbleProps {
    * @default 0
    */
   duration?: number;
+  /** Enables animation on first rendering
+   * @default false
+   */
+  initialAnimation: boolean;
 }
 
 export interface INoticeBubbleProps extends IBoxProps {

--- a/website/docs/components/notice-bubble/notice-bubble-example.md
+++ b/website/docs/components/notice-bubble/notice-bubble-example.md
@@ -94,6 +94,8 @@ class DemoManager extends React.Component {
           /* It is advisable to change the notice's visible to close it instead
           of removing it from JSX since in this case there will be no animation */
           visible={visible}
+          /* Enables animation on first rendering */
+          initialAnimation
           /* onClose will be triggered either by
           a timer or by a user clicking on the cross */
           onClose={() => this.setState({ visible: false })}


### PR DESCRIPTION
…tion on the first rendering

<!--- Provide a general summary of your changes in the Title above -->
Notice bubbles in our application are showing without animation. Bubbles are always added with visible=true initially, so not being animated is intentional according to this logic. But it should

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

