### PR TITLE
[global] added react-dom to peer deps

### DIFF
--- a/semcore/accordion/CHANGELOG.md
+++ b/semcore/accordion/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/accordion/package.json
+++ b/semcore/accordion/package.json
@@ -20,7 +20,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/animation/CHANGELOG.md
+++ b/semcore/animation/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [1.8.3] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [1.8.2] - 2022-12-12
 
 ## [1.8.1] - 2022-12-09

--- a/semcore/animation/package.json
+++ b/semcore/animation/package.json
@@ -18,7 +18,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/badge/CHANGELOG.md
+++ b/semcore/badge/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/badge/package.json
+++ b/semcore/badge/package.json
@@ -18,7 +18,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/base-trigger/CHANGELOG.md
+++ b/semcore/base-trigger/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.3.2] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.3.1] - 2022-12-12
 
 ### Changed

--- a/semcore/base-trigger/package.json
+++ b/semcore/base-trigger/package.json
@@ -22,7 +22,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/breadcrumbs/CHANGELOG.md
+++ b/semcore/breadcrumbs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/breadcrumbs/package.json
+++ b/semcore/breadcrumbs/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/breakpoints/CHANGELOG.md
+++ b/semcore/breakpoints/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [1.2.7] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [1.2.6] - 2022-12-12
 
 ## [1.2.5] - 2022-11-30

--- a/semcore/breakpoints/package.json
+++ b/semcore/breakpoints/package.json
@@ -16,7 +16,8 @@
     "@semcore/utils": "^3.15"
   },
   "peerDependencies": {
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/button/CHANGELOG.md
+++ b/semcore/button/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/button/package.json
+++ b/semcore/button/package.json
@@ -20,7 +20,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/card/CHANGELOG.md
+++ b/semcore/card/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/card/package.json
+++ b/semcore/card/package.json
@@ -21,7 +21,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/carousel/CHANGELOG.md
+++ b/semcore/carousel/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [2.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/carousel/package.json
+++ b/semcore/carousel/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/chart/CHANGELOG.md
+++ b/semcore/chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [5.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/chart/package.json
+++ b/semcore/chart/package.json
@@ -41,7 +41,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/checkbox/CHANGELOG.md
+++ b/semcore/checkbox/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [6.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [6.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/checkbox/package.json
+++ b/semcore/checkbox/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/color-picker/CHANGELOG.md
+++ b/semcore/color-picker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [1.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [1.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/color-picker/package.json
+++ b/semcore/color-picker/package.json
@@ -23,7 +23,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.8.3",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "devDependencies": {
     "@guidepup/playwright": "0.6.1",

--- a/semcore/core/CHANGELOG.md
+++ b/semcore/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [1.13.8] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [1.13.7] - 2022-12-12
 
 ## [1.13.6] - 2022-11-30

--- a/semcore/core/package.json
+++ b/semcore/core/package.json
@@ -19,7 +19,8 @@
     "hoist-non-react-statics": "3.3.2"
   },
   "peerDependencies": {
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/counter/CHANGELOG.md
+++ b/semcore/counter/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [2.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/counter/package.json
+++ b/semcore/counter/package.json
@@ -18,7 +18,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.6.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [2.6.0] - 2022-12-12
 
 ### Added

--- a/semcore/d3-chart/package.json
+++ b/semcore/d3-chart/package.json
@@ -30,7 +30,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.12",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.6.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.6.0] - 2022-12-12
 
 ### Added

--- a/semcore/data-table/package.json
+++ b/semcore/data-table/package.json
@@ -43,7 +43,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/date-picker/CHANGELOG.md
+++ b/semcore/date-picker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.5.2] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.5.1] - 2022-12-12
 
 ### Changed

--- a/semcore/date-picker/package.json
+++ b/semcore/date-picker/package.json
@@ -28,7 +28,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/divider/CHANGELOG.md
+++ b/semcore/divider/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/divider/package.json
+++ b/semcore/divider/package.json
@@ -18,7 +18,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/dot/CHANGELOG.md
+++ b/semcore/dot/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/dot/package.json
+++ b/semcore/dot/package.json
@@ -20,7 +20,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/drag-and-drop/CHANGELOG.md
+++ b/semcore/drag-and-drop/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [2.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.5.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.5.0] - 2022-12-12
 
 ### Added

--- a/semcore/dropdown-menu/package.json
+++ b/semcore/dropdown-menu/package.json
@@ -21,7 +21,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.12",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/dropdown/CHANGELOG.md
+++ b/semcore/dropdown/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/dropdown/package.json
+++ b/semcore/dropdown/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/ellipsis/CHANGELOG.md
+++ b/semcore/ellipsis/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [1.1.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [1.1.0] - 2022-12-12
 
 ### Added

--- a/semcore/ellipsis/package.json
+++ b/semcore/ellipsis/package.json
@@ -20,7 +20,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.8.3",
-    "react": "16.8 - 17"
+    "react": "16.8 - 17",
+    "react-dom": "16.8 - 18"
   },
   "devDependencies": {
     "@semcore/jest-preset-ui": "1.0.0"

--- a/semcore/errors/CHANGELOG.md
+++ b/semcore/errors/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.6.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.6.0] - 2022-12-12
 
 ### Added

--- a/semcore/errors/package.json
+++ b/semcore/errors/package.json
@@ -22,7 +22,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/feature-popover/CHANGELOG.md
+++ b/semcore/feature-popover/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/feature-popover/package.json
+++ b/semcore/feature-popover/package.json
@@ -21,7 +21,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/feedback-form/CHANGELOG.md
+++ b/semcore/feedback-form/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [5.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/feedback-form/package.json
+++ b/semcore/feedback-form/package.json
@@ -25,7 +25,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/flags/CHANGELOG.md
+++ b/semcore/flags/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/flags/package.json
+++ b/semcore/flags/package.json
@@ -20,7 +20,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/flex-box/CHANGELOG.md
+++ b/semcore/flex-box/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.7.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.7.0] - 2022-12-12
 
 ### Added

--- a/semcore/flex-box/package.json
+++ b/semcore/flex-box/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/format-text/CHANGELOG.md
+++ b/semcore/format-text/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/format-text/package.json
+++ b/semcore/format-text/package.json
@@ -18,7 +18,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/fullscreen-modal/CHANGELOG.md
+++ b/semcore/fullscreen-modal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [2.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/fullscreen-modal/package.json
+++ b/semcore/fullscreen-modal/package.json
@@ -21,7 +21,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/grid/CHANGELOG.md
+++ b/semcore/grid/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/grid/package.json
+++ b/semcore/grid/package.json
@@ -18,7 +18,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/icon/CHANGELOG.md
+++ b/semcore/icon/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.4.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.4.0] - 2022-12-12
 
 ### Added

--- a/semcore/icon/package.json
+++ b/semcore/icon/package.json
@@ -21,7 +21,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/inline-edit/CHANGELOG.md
+++ b/semcore/inline-edit/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [2.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/inline-edit/package.json
+++ b/semcore/inline-edit/package.json
@@ -25,7 +25,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/inline-input/CHANGELOG.md
+++ b/semcore/inline-input/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/inline-input/package.json
+++ b/semcore/inline-input/package.json
@@ -28,7 +28,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/input-mask/CHANGELOG.md
+++ b/semcore/input-mask/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.4.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.4.0] - 2022-12-12
 
 ### Added

--- a/semcore/input-mask/package.json
+++ b/semcore/input-mask/package.json
@@ -21,7 +21,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/input-number/CHANGELOG.md
+++ b/semcore/input-number/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/input-number/package.json
+++ b/semcore/input-number/package.json
@@ -18,7 +18,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/input-tags/CHANGELOG.md
+++ b/semcore/input-tags/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/input-tags/package.json
+++ b/semcore/input-tags/package.json
@@ -20,7 +20,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/input/CHANGELOG.md
+++ b/semcore/input/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.5.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.5.0] - 2022-12-12
 
 ### Added

--- a/semcore/input/package.json
+++ b/semcore/input/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/link/CHANGELOG.md
+++ b/semcore/link/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.3.2] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.3.1] - 2022-12-12
 
 ### Changed

--- a/semcore/link/package.json
+++ b/semcore/link/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/modal/CHANGELOG.md
+++ b/semcore/modal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/modal/package.json
+++ b/semcore/modal/package.json
@@ -23,7 +23,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/neighbor-location/CHANGELOG.md
+++ b/semcore/neighbor-location/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.1.7] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.1.6] - 2022-12-12
 
 ## [3.1.5] - 2022-11-30

--- a/semcore/neighbor-location/package.json
+++ b/semcore/neighbor-location/package.json
@@ -17,7 +17,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/notice-bubble/CHANGELOG.md
+++ b/semcore/notice-bubble/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.4.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.4.0] - 2022-12-12
 
 ### Added

--- a/semcore/notice-bubble/package.json
+++ b/semcore/notice-bubble/package.json
@@ -21,7 +21,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/notice-global/CHANGELOG.md
+++ b/semcore/notice-global/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [1.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [1.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/notice-global/package.json
+++ b/semcore/notice-global/package.json
@@ -20,7 +20,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/notice/CHANGELOG.md
+++ b/semcore/notice/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/notice/package.json
+++ b/semcore/notice/package.json
@@ -21,7 +21,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/pagination/CHANGELOG.md
+++ b/semcore/pagination/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.4.2] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.4.1] - 2022-12-12
 
 ### Changed

--- a/semcore/pagination/package.json
+++ b/semcore/pagination/package.json
@@ -23,7 +23,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/pills/CHANGELOG.md
+++ b/semcore/pills/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.4.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.4.0] - 2022-12-12
 
 ### Added

--- a/semcore/pills/package.json
+++ b/semcore/pills/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.12",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.14.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.14.0] - 2022-12-12
 
 ### Added

--- a/semcore/popper/package.json
+++ b/semcore/popper/package.json
@@ -25,7 +25,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/product-head/CHANGELOG.md
+++ b/semcore/product-head/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/product-head/package.json
+++ b/semcore/product-head/package.json
@@ -18,7 +18,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/progress-bar/CHANGELOG.md
+++ b/semcore/progress-bar/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/progress-bar/package.json
+++ b/semcore/progress-bar/package.json
@@ -18,7 +18,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/radio/CHANGELOG.md
+++ b/semcore/radio/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [5.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/radio/package.json
+++ b/semcore/radio/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/select/CHANGELOG.md
+++ b/semcore/select/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.3.2] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.3.1] - 2022-12-12
 
 ### Changed

--- a/semcore/select/package.json
+++ b/semcore/select/package.json
@@ -24,7 +24,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/side-panel/CHANGELOG.md
+++ b/semcore/side-panel/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [2.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/side-panel/package.json
+++ b/semcore/side-panel/package.json
@@ -24,7 +24,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/skeleton/CHANGELOG.md
+++ b/semcore/skeleton/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.4.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.4.0] - 2022-12-12
 
 ### Added

--- a/semcore/skeleton/package.json
+++ b/semcore/skeleton/package.json
@@ -18,7 +18,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/slider/CHANGELOG.md
+++ b/semcore/slider/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/slider/package.json
+++ b/semcore/slider/package.json
@@ -18,7 +18,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.12",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/spin-container/CHANGELOG.md
+++ b/semcore/spin-container/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [6.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [6.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/spin-container/package.json
+++ b/semcore/spin-container/package.json
@@ -20,7 +20,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/spin/CHANGELOG.md
+++ b/semcore/spin/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/spin/package.json
+++ b/semcore/spin/package.json
@@ -18,7 +18,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/sticky/CHANGELOG.md
+++ b/semcore/sticky/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.4.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [2.4.0] - 2022-12-12
 
 ### Added

--- a/semcore/sticky/package.json
+++ b/semcore/sticky/package.json
@@ -18,7 +18,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/switch/CHANGELOG.md
+++ b/semcore/switch/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/switch/package.json
+++ b/semcore/switch/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/tab-line/CHANGELOG.md
+++ b/semcore/tab-line/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/tab-line/package.json
+++ b/semcore/tab-line/package.json
@@ -20,7 +20,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/tab-panel/CHANGELOG.md
+++ b/semcore/tab-panel/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/tab-panel/package.json
+++ b/semcore/tab-panel/package.json
@@ -18,7 +18,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/table/CHANGELOG.md
+++ b/semcore/table/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/table/package.json
+++ b/semcore/table/package.json
@@ -23,7 +23,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/tag/CHANGELOG.md
+++ b/semcore/tag/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/tag/package.json
+++ b/semcore/tag/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/textarea/CHANGELOG.md
+++ b/semcore/textarea/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/textarea/package.json
+++ b/semcore/textarea/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/time-picker/CHANGELOG.md
+++ b/semcore/time-picker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.3.2] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.3.1] - 2022-12-12
 
 ### Changed

--- a/semcore/time-picker/package.json
+++ b/semcore/time-picker/package.json
@@ -21,7 +21,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/tooltip/CHANGELOG.md
+++ b/semcore/tooltip/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [5.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/tooltip/package.json
+++ b/semcore/tooltip/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/typography/CHANGELOG.md
+++ b/semcore/typography/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.3.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [4.3.0] - 2022-12-12
 
 ### Added

--- a/semcore/typography/package.json
+++ b/semcore/typography/package.json
@@ -20,7 +20,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/widget-empty/CHANGELOG.md
+++ b/semcore/widget-empty/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.7.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [3.7.0] - 2022-12-12
 
 ### Added

--- a/semcore/widget-empty/package.json
+++ b/semcore/widget-empty/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"

--- a/semcore/wizard/CHANGELOG.md
+++ b/semcore/wizard/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [1.2.1] - 2022-12-13
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [1.2.0] - 2022-12-12
 
 ### Added

--- a/semcore/wizard/package.json
+++ b/semcore/wizard/package.json
@@ -20,7 +20,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.12",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "jest": {
     "preset": "@semcore/jest-preset-ui"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added react-dom to all packages that use @semcore/utils

## Motivation and Context

Because @semcore/utils require to provide react-dom at dependent packages.
It works because of Node resolving algorithm. But if we use a more strict protocol (PNP) it will not work because there is no dependency hoisting.

This commit makes dependencies correct.

## How has this been tested?

Not tested

## Screenshots (if appropriate):
<img width="851" alt="image" src="https://user-images.githubusercontent.com/6824923/207333936-72f845bc-31f8-46d2-a47e-2e56b13f6e5f.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
