### PR TITLE
[illustration] added react-dom to peer deps

### DIFF
--- a/semcore/illustration/CHANGELOG.md
+++ b/semcore/illustration/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [1.3.9] - 2022-12-16
+
+### Changed
+
+- Added `react-dom` to peer dependencies.
+
 ## [1.3.8] - 2022-12-16
 
 ### Changed

--- a/semcore/illustration/package.json
+++ b/semcore/illustration/package.json
@@ -20,7 +20,8 @@
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",
-    "react": "16.8 - 18"
+    "react": "16.8 - 18",
+    "react-dom": "16.8 - 18"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added missing react-dom to peers deps. Same as #484.

## Motivation and Context

Because @semcore/utils require to provide react-dom at dependent packages.
It works because of Node resolving algorithm. But if we use a more strict protocol (PNP) it will not work because there is no dependency hoisting.

This commit makes dependencies correct.

## How has this been tested?

Not tested

## Screenshots (if appropriate):
<img width="876" alt="image" src="https://user-images.githubusercontent.com/6824923/208112457-e7c5b529-d0fd-486e-b268-317c5f7baa63.png">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
