### PR TITLE
[dropdown-menu] popper closes when enter button is pressed

### DIFF
--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.6.3] - 2022-12-27
+
+### Changed
+
+- `DropdownMenu.Popper` closes when the `Enter` button is pressed.
+
 ## [3.6.2] - 2022-12-27
 
 ### Added

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -40,7 +40,7 @@ class DropdownMenuRoot extends Component {
     };
   }
 
-  handlerKeyDown = (e) => {
+  bindHandlerKeyDown = (place) => (e) => {
     const amount = e.shiftKey ? 5 : 1;
 
     if (e.key === ' ' && INTERACTION_TAGS.includes(e.target.tagName)) return;
@@ -62,7 +62,7 @@ class DropdownMenuRoot extends Component {
         if (this.highlightedItemRef.current) {
           this.highlightedItemRef.current.click();
         } else {
-          this.handlers.visible(false);
+          if (place === 'trigger') this.handlers.visible(false);
         }
         break;
     }
@@ -77,7 +77,7 @@ class DropdownMenuRoot extends Component {
       'aria-controls': visible ? `igc-${uid}-popper` : undefined,
       'aria-flowto': visible && !disablePortal ? `igc-${uid}-popper` : undefined,
       'aria-label': visible && !disablePortal ? getI18nText('triggerHint') : undefined,
-      onKeyDown: this.handlerKeyDown,
+      onKeyDown: this.bindHandlerKeyDown('trigger'),
     };
   }
 
@@ -94,7 +94,7 @@ class DropdownMenuRoot extends Component {
 
     return {
       tabIndex: 0,
-      onKeyDown: this.handlerKeyDown,
+      onKeyDown: this.bindHandlerKeyDown('popper'),
       id: `igc-${uid}-popper`,
       'aria-flowto': !disablePortal ? `igc-${uid}-trigger` : undefined,
     };

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -59,7 +59,11 @@ class DropdownMenuRoot extends Component {
         break;
       case ' ':
       case 'Enter':
-        if (this.highlightedItemRef.current) this.highlightedItemRef.current.click();
+        if (this.highlightedItemRef.current) {
+          this.highlightedItemRef.current.click();
+        } else {
+          this.handlers.visible(false);
+        }
         break;
     }
   };


### PR DESCRIPTION
## Description

`DropdownMenu.Popper` closes when the `Enter` button is pressed.

## Motivation and Context

for better a11y

## How has this been tested?

by hands and keyboard

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
