### PR TITLE
[docs] added i18n page

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -710,7 +710,7 @@ importers:
       '@semcore/button': ^4
       '@semcore/flex-box': ^4
       '@semcore/format-text': ^3.0.0
-      '@semcore/illustration': 1.3.10
+      '@semcore/illustration': 1.3.11
       '@semcore/jest-preset-ui': 1.0.0
       '@semcore/typography': ^4
       '@semcore/utils': ^3.27
@@ -1760,7 +1760,7 @@ importers:
   semcore/widget-empty:
     specifiers:
       '@semcore/flex-box': ^4
-      '@semcore/illustration': 1.3.10
+      '@semcore/illustration': 1.3.11
       '@semcore/jest-preset-ui': 1.0.0
       '@semcore/utils': ^3.27
       '@types/react': 18.0.21

--- a/semcore/i18n-unplugin/README.md
+++ b/semcore/i18n-unplugin/README.md
@@ -6,7 +6,7 @@
 
 > This component is part of the Intergalactic design system
 
-### 📖 [Component documentation](https://developer.semrush.com/intergalactic/i18n/#plugin)
+### 📖 [Component documentation](https://developer.semrush.com/intergalactic/utils/i18n/#locale_bundle_extracting)
 
 ### 🏠 [Design system](https://developer.semrush.com/intergalactic/)
 
@@ -40,11 +40,11 @@ export default defineConfig({
 ### Webpack
 
 ```js
-var { semcoreI18nVitePlugin } = require('@semcore/ui/i18n-unplugin');
+var { semcoreI18nWebpackPlugin } = require('@semcore/ui/i18n-unplugin');
 
 module.exports = {
   // ...
-  plugins: [semcoreI18nVitePlugin()],
+  plugins: [semcoreI18nWebpackPlugin()],
   // ...
 };
 ```

--- a/website/docs/utils/i18n/examples/pagination-i18n.jsx
+++ b/website/docs/utils/i18n/examples/pagination-i18n.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Box, Flex } from '@semcore/ui/flex-box';
+import Pagination from '@semcore/ui/pagination';
+
+function Demo() {
+  return (
+    <Flex>
+      <Box>
+        <Pagination
+          locale="epo"
+          i18n={{
+            epo: {
+              prevPageLabel: 'Antaŭa',
+              nextPageLabel: 'Sekva',
+              pageInputLabel: 'Paĝo:',
+              totalPagesLabel: 'de',
+              pagination: 'Paĝonumerado',
+              firstPage: 'Unua paĝo',
+              currentPage: 'Aktuala paĝo',
+              confirm: 'Konfirmi paĝnumeron',
+              lastPage: 'Lasta paĝo #{lastPageNumber}',
+              goToPage: 'Paĝo {pageNumber}',
+            },
+          }}
+          totalPages={123}
+        />
+      </Box>
+    </Flex>
+  );
+}
+
+export default Demo;

--- a/website/docs/utils/i18n/i18n.md
+++ b/website/docs/utils/i18n/i18n.md
@@ -5,13 +5,13 @@ tabName: i18n
 
 > i18n means Internationalization
 
-Some of components requires human readable texts translated into multiple languages. For example, [DatePicker](/components/date-picker/) has buttons such as "Apply", "Reset" and "Today" that should change their language depending on the application. By default components support following languages: `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `pt`, `tr`, `vi`, `zh`. Components with such translatable texts provides `locale` property that allows you to select locale of texts and `i18n` property to override texts of existing locales or provide texts for nonexisting ones.
+Some of the components requires human-readable texts translated into multiple languages. For example, [DatePicker](/components/date-picker/) has buttons such as "Apply", "Reset" and "Today" that should change their language depending on the application's one. By default, components support the following languages: `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `pt`, `tr`, `vi`, `zh`. Components with such translatable texts provides `locale` property that allows you to select locale of texts, and `i18n` property to override texts of existing locales or provide texts for non existing ones.
 
 @example pagination-i18n
 
 ## I18nProvider
 
-To set default locale for all components of the application or it's part you can use `I18nProvider` component.
+To set default locale for all components of the application, or it's part, you can use `I18nProvider` component.
 
 ```js
 import React from from 'react';

--- a/website/docs/utils/i18n/i18n.md
+++ b/website/docs/utils/i18n/i18n.md
@@ -1,0 +1,82 @@
+---
+title: i18n
+tabName: i18n
+---
+
+> i18n means Internationalization
+
+Some of components requires human readable texts translated into multiple languages. For example, [DatePicker](/components/date-picker/) has buttons such as "Apply", "Reset" and "Today" that should change their language depending on the application. By default components support following languages: `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `pt`, `tr`, `vi`, `zh`. Components with such translatable texts provides `locale` property that allows you to select locale of texts and `i18n` property to override texts of existing locales or provide texts for nonexisting ones.
+
+@example pagination-i18n
+
+## I18nProvider
+
+To set default locale for all components of the application or it's part you can use `I18nProvider` component.
+
+```js
+import React from from 'react';
+import ReactDOM from from 'react-dom';
+import { App } from 'App';
+import { I18nProvider } from '@semcore/utils/lib/enhances/WithI18n';
+
+ReactDOM.render(
+  <I18nProvider value="es">
+    <App />
+  </I18nProvider>,
+  document.querySelector('#root')
+);
+```
+
+## Locale bundle extracting
+
+By default, all translations are included into main chunk. You can configure your bundler with our plugin to put most needed translations into main chunk, less needed into separated chunks and do not include never needed translations.
+
+Plugins are provided in form of [unplugin](https://github.com/unjs/unplugin) for most popular bundling systems: [Vite](https://vitejs.dev/), [Rollup](https://rollupjs.org/guide/en/), [Webpack](https://webpack.js.org/) and [esbuild](https://esbuild.github.io/).
+
+> Note: These plugins affect only Intergalactic components translations and cannot be used for localization of your application.
+
+To use it, install `@semcore/ui` and import corresponding plugin from `@semcore/ui/i18n-unplugin`.
+
+Plugins have three optional configuration properties:
+
+1. `bundleLocales` – list of locales translations that should be included into main chunk. All other locales translations will go into their owns.
+2. `includeLocales` – list of default locales that will be included into bundled chunks. All other default locales will be ignored.
+3. `excludeLocales` – list of default locales that will be ignored and not included into bundled chunks.
+
+### Usage with Vite
+
+```js
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { semcoreI18nVitePlugin } from '@semcore/ui/i18n-unplugin';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [
+    react(),
+    semcoreI18nVitePlugin({
+      bundleLocales: ['es'],
+      includeLocales: ['en', 'es'],
+    }),
+  ],
+});
+```
+
+### Usage with Webpack
+
+```js
+var { semcoreI18nWebpackPlugin } = require('@semcore/ui/i18n-unplugin');
+
+module.exports = {
+  // ...
+  plugins: [semcoreI18nWebpackPlugin()],
+  // ...
+};
+```
+
+### Usage with Rollup & esbuild
+
+```js
+import { semcoreI18nRollupPlugin, semcoreI18nEsbuildPlugin } from '@semcore/ui/i18n-unplugin';
+// ...
+```

--- a/website/docs/utils/utils.md
+++ b/website/docs/utils/utils.md
@@ -6,3 +6,4 @@ title: Utils 🛠
 @page neighbor-location
 @page popper
 @page portal
+@page i18n


### PR DESCRIPTION
## Description

I have added pages to tell users about how to deal with internationalization of our components. I have covered following topics:
1. `locale` and `i18n` props of components
2. `I18nProvider`
3. `i18n-unplugin` 

## Motivation and Context

Previously we had no documentation about components internationalization. It became more important after introducing `i18n-inplugin` and covering more components with localization.

## Screenshot

<img width="1533" alt="image" src="https://user-images.githubusercontent.com/31261408/211363582-a8c6d610-23dd-4560-a269-3dbd73d2a5ea.png">
