### PR TITLE
[popper] fixed focus hijacking by non editable poppers

### DIFF
--- a/semcore/inline-input/src/InlineInput.tsx
+++ b/semcore/inline-input/src/InlineInput.tsx
@@ -270,9 +270,7 @@ const ConfirmControl: React.FC<ConfirmControlAsProps> = (props) => {
             className={sConfirmIconStyles.className}
             style={sConfirmIconStyles.style}
           />
-          <Tooltip.Popper p={3} disableEnforceFocus>
-            {title}
-          </Tooltip.Popper>
+          <Tooltip.Popper p={3}>{title}</Tooltip.Popper>
         </Tooltip>
       )}
     </SAddon>,
@@ -324,9 +322,7 @@ const CancelControl: React.FC<CancelControlAsProps> = (props) => {
             className={sCancelIconStyles.className}
             style={sCancelIconStyles.style}
           />
-          <Tooltip.Popper p={3} disableEnforceFocus>
-            {title}
-          </Tooltip.Popper>
+          <Tooltip.Popper p={3}>{title}</Tooltip.Popper>
         </Tooltip>
       )}
     </SAddon>,

--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
-## [4.14.5] - 2023-01-10
+## [4.15.0] - 2023-01-16
+
+### Fixed
+
+- Fixed focus hijacking by non editable poppers.
 
 ## [4.14.4] - 2023-01-09
 

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import FocusLock from 'react-focus-lock';
-import { getFocusabledIn } from 'focus-lock';
+import { getFocusableIn } from 'focus-lock';
 import ResizeObserver from 'resize-observer-polyfill';
 
 import createComponent, { Component, sstyled, Root } from '@semcore/core';
@@ -402,7 +402,15 @@ const FocusLockWrapper = React.forwardRef(function (
   const [nodesLock, setNodesLock] = useState(false);
 
   const popperRef = useCallbackRef(null, (node) => {
-    setNodesLock(node ? !getFocusabledIn(node).length : false);
+    if (!node) {
+      setNodesLock(false);
+      return;
+    }
+    const hasFocusableChild = [...(node.children ?? [])].some(
+      (child) => getFocusableIn(child).length > 0,
+    );
+
+    setNodesLock(!hasFocusableChild);
   });
 
   // eslint-disable-next-line ssr-friendly/no-dom-globals-in-react-fc


### PR DESCRIPTION
## Description

I have resoled the issue when plain tooltips were hijacking focus from inputs and so on.

Also I have replaced deprecated util function name.

## Motivation and Context

Issue appeared after adding to all poppers `tabIndex={0}`. Our focus lock enabling algorithm started supposing that popper has some focusable content such inputs and icons while focusable was only popper by itself.

Other words, it turned out that `focus-lock` function `getFocusableIn` not only checks provided node children for focusability but also checks the node by itself.

I have updated algorithm to pass only popper children to `getFocusableIn` to resolve this issue.

Also, no `disableEnforceFocus` hack needed in `InlineInput` any more (I haven't updated inline-input changelog because change seems to be more internal and inline-input publish will be triggered by popper update). 

## How has this been tested?

All existing tests should pass. Otherwise this fix will not be applied.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
