### PR TITLE
[ellipsis] supported passing tooltip props

### DIFF
--- a/semcore/ellipsis/CHANGELOG.md
+++ b/semcore/ellipsis/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
-## [1.1.10] - 2023-02-09
+## [1.2.0] - 2023-02-15
 
-## [1.1.9] - 2023-01-24
+### Added
+
+- Supported passing tooltip props.
+
+## [1.1.10] - 2023-02-09
 
 ### Fixed
 

--- a/semcore/ellipsis/src/index.d.ts
+++ b/semcore/ellipsis/src/index.d.ts
@@ -1,7 +1,9 @@
-import { CProps } from '@semcore/core';
+import { CProps, ReturnEl } from '@semcore/core';
 import { RefObject } from 'react';
+import { IBoxProps } from '@semcore/flex-box';
+import { ITooltipProps } from '@semcore/tooltip';
 
-export interface IEllipsisProps {
+export interface IEllipsisProps extends IBoxProps, ITooltipProps {
   /**
    * Rows count in multiline Ellipsis
    * @default 1
@@ -26,6 +28,10 @@ export interface IEllipsisProps {
    * Explicit sizes of container text should be trimmed in
    **/
   containerRect?: { width: number };
+  /** List of props that will be passed to tooltip
+   * @default ['title', 'theme', 'strategy', 'modifiers', 'placement', 'interaction', 'timeout', 'visible', 'defaultVisible', 'onVisibleChange', 'offset', 'preventOverflow', 'arrow', 'flip', 'computeStyles', 'eventListeners', 'onFirstUpdate']
+   */
+  includeTooltipProps?: string[];
 }
 
 declare const useResizeObserver: (


### PR DESCRIPTION
## Description

Now a defined list of props passed to ellipsis components are being passed to tooltip. A special prop `includeTooltipProps` allowes user to redefine a list of passed props. 

## Motivation and Context

No ability to pass tooltip props seems weird and unexpected. I've made passing of props similar to feedback form component and redefining list of passed props as in checkbox component.

## How has this been tested?

Manual testing was enough. The change is pretty easy.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.