### PR TITLE
[table] fix colgroup calculation for StickyHead

### DIFF
--- a/semcore/table/CHANGELOG.md
+++ b/semcore/table/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+
+## [3.3.22] - 2023-03-01
+
+### Fixed
+
+- Fixed colgroup calculation
+
 ## [3.3.21] - 2023-03-01
 
 ## [3.3.20] - 2023-02-24

--- a/semcore/table/src/StickyHead.jsx
+++ b/semcore/table/src/StickyHead.jsx
@@ -46,6 +46,18 @@ function getScrollParent(element) {
   return getScrollParent(getParentNode(element));
 }
 
+function getOffsetWidth(node) {
+  if (node == null) {
+    return undefined;
+  }
+
+  if (node.getBoundingClientRect == null) {
+    return node.offsetWidth;
+  }
+
+  return node.getBoundingClientRect().width;
+}
+
 function calculateWidthTh(nodeTable) {
   const thead = nodeTable && nodeTable.getElementsByTagName('thead')[0];
   if (!nodeTable || !thead) return [];
@@ -67,7 +79,7 @@ function calculateWidthTh(nodeTable) {
 
       if (th.colSpan === 1 && th.rowSpan === 1) {
         if (indexTr === 0) {
-          listWidthTh[indexTr].push(th.offsetWidth);
+          listWidthTh[indexTr].push(getOffsetWidth(th));
           currentCellCursor += 1;
         } else {
           while (
@@ -77,7 +89,7 @@ function calculateWidthTh(nodeTable) {
           ) {
             emptyCellIndex += 1;
           }
-          listWidthTh[indexTr][emptyCellIndex] = th.offsetWidth;
+          listWidthTh[indexTr][emptyCellIndex] = getOffsetWidth(th);
           currentCellCursor = emptyCellIndex;
         }
         continue;
@@ -85,12 +97,12 @@ function calculateWidthTh(nodeTable) {
       if (th.rowSpan > 1) {
         [...new Array(th.rowSpan)].map((_, indexRowSpan) => {
           listWidthTh[indexRowSpan] = listWidthTh[indexRowSpan] || [];
-          listWidthTh[indexRowSpan][currentCellCursor] = th.offsetWidth;
+          listWidthTh[indexRowSpan][currentCellCursor] = getOffsetWidth(th);
         });
         currentCellCursor += 1;
       }
       if (th.colSpan > 1) {
-        listWidthTh[indexTr].push(...[...new Array(th.colSpan)].map(() => undefined));
+        listWidthTh[indexTr].push(...new Array(th.colSpan).fill(undefined));
         currentCellCursor += th.colSpan;
       }
     }
@@ -105,7 +117,7 @@ function calculateWidthTh(nodeTable) {
     for (let indexTd = 0; indexTd < amountTd;) {
       const th = listTdInsideTr[indexTd];
       if (listWidthTh[firstRowIndex][indexTd] === undefined) {
-        listWidthTh[firstRowIndex][indexTd] = th.offsetWidth;
+        listWidthTh[firstRowIndex][indexTd] = getOffsetWidth(th);
       }
       indexTd += th.colSpan;
     }


### PR DESCRIPTION
Use getBoundingClientRect().width instead of offsetWidth

## Motivation and Context
getBoundingClientRect().width is a **float** while offsetWidth contains an **integer**

Сell borders in table body and header may not match, since the sizes in the header are calculated in the function using offsetWidth, and the table body itself is dynamic and can be a float

Previously it was imperceptible, there were no vertical borders in the design tables

## How has this been tested?
Tested on my internal tables, also on local website and successful tests in ci

## Screenshots (if appropriate):

**Before:**
<img width="835" alt="Снимок экрана 2023-02-28 в 20 06 10" src="https://user-images.githubusercontent.com/12624143/222181349-9b7496d1-1e9a-42da-aba1-355c8830ee4d.png">

**After:**
<img width="725" alt="Снимок экрана 2023-02-28 в 20 06 40" src="https://user-images.githubusercontent.com/12624143/222181382-a38c7898-45bf-4515-85ea-dc4d971719fc.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
