### PR TITLE
[website] use amplitude device id as user token for algolia

### DIFF
--- a/website/src/components/SearchHome.jsx
+++ b/website/src/components/SearchHome.jsx
@@ -22,6 +22,9 @@ import { getCookie, AMPLITUDE_COOKIE_NAME } from '../utils/cookie';
 import styles from './SearchHome.module.css';
 
 const algoliaClient = algoliasearch(CONFIG.ALGOLIA_APP, CONFIG.ALGOLIA_OPEN_KEY);
+/* To utilize synonyms in Algolia, a userToken parameter is required. However, since the website 
+does not have any registered usernames or users, the randomly generated string known as the deviceId, 
+which is stored in cookies, is used as the userToken instead, sourced from Amplitude. */
 const userToken = getCookie(AMPLITUDE_COOKIE_NAME);
 const searchClient = {
   search(requests) {

--- a/website/src/components/SearchHome.jsx
+++ b/website/src/components/SearchHome.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { withRouter, useLocation } from 'react-router-dom';
-import { InstantSearch, Highlight } from 'react-instantsearch/dom';
+import { InstantSearch, Highlight, Configure } from 'react-instantsearch/dom';
 import { connectAutoComplete, connectStateResults } from 'react-instantsearch/connectors';
 import algoliasearch from 'algoliasearch/lite';
 import { logEvent } from '../utils/amplitude';
@@ -18,9 +18,11 @@ const ru = require('convert-layout/ru');
 import observatory from '../static/search/observatory.svg';
 import CONFIG from '../algolia';
 import Divider from '@semcore/divider';
+import { getCookie, AMPLITUDE_COOKIE_NAME } from '../utils/cookie';
 import styles from './SearchHome.module.css';
 
 const algoliaClient = algoliasearch(CONFIG.ALGOLIA_APP, CONFIG.ALGOLIA_OPEN_KEY);
+const userToken = getCookie(AMPLITUDE_COOKIE_NAME);
 const searchClient = {
   search(requests) {
     if (requests.every(({ params }) => !params.query)) {
@@ -210,6 +212,7 @@ const SuggestSearch = withRouter(connectAutoComplete(connectStateResults(Search)
 function SearchHome(props) {
   return (
     <InstantSearch searchClient={searchClient} indexName={CONFIG.ALGOLIA_INDEX}>
+      <Configure userToken={userToken} />
       <SuggestSearch {...props} visible={true} />
     </InstantSearch>
   );

--- a/website/src/utils/amplitude-client.js
+++ b/website/src/utils/amplitude-client.js
@@ -1,35 +1,6 @@
 import 'whatwg-fetch';
 import { nanoid } from 'nanoid';
-
-/**
- *
- * @param {string} name
- * @returns {string}
- */
-const getCookie = (name) => {
-  const cookie = {};
-
-  document.cookie.split(';').forEach((el) => {
-    const [k, v] = el.split('=');
-    cookie[k.trim()] = v;
-  });
-
-  return cookie[name] || '';
-};
-
-/**
- *
- * @param {string} cname
- * @param {string} cvalue
- * @param {number} exdays
- */
-const setCookie = (cname, cvalue, exdays) => {
-  const d = new Date();
-  d.setTime(d.getTime() + exdays * 24 * 60 * 60 * 1000);
-  const expires = `expires=${d.toUTCString()}`;
-
-  document.cookie = `${cname}=${cvalue};${expires};path=/;SameSite=None;Secure`;
-};
+import { getCookie, setCookie, AMPLITUDE_COOKIE_NAME, AMPLITUDE_COOKIE_EXP_DATE } from './cookie';
 
 /**
  *
@@ -51,8 +22,6 @@ const getIsConsented = (getExternalProviderConsentStatus) => {
 
 const AMPLITUDE_HTTP_HANDLER = 'https://api.amplitude.com/2/httpapi';
 const AMPLITUDE_HTTP_IDENTIFY_HANDLER = 'https://api.amplitude.com/identify';
-const AMPLITUDE_COOKIE_NAME = '_ampl';
-const AMPLITUDE_COOKIE_EXP_DATE = 30;
 
 const amplitudeHttp = {
   /**

--- a/website/src/utils/cookie.ts
+++ b/website/src/utils/cookie.ts
@@ -1,0 +1,21 @@
+export const AMPLITUDE_COOKIE_NAME = '_ampl';
+export const AMPLITUDE_COOKIE_EXP_DATE = 30;
+
+export const getCookie = (name: string): string => {
+  const cookie = {};
+
+  document.cookie.split(';').forEach((el) => {
+    const [k, v] = el.split('=');
+    cookie[k.trim()] = v;
+  });
+
+  return cookie[name] || '';
+};
+
+export const setCookie = (cname: string, cvalue: string, exdays: number) => {
+  const d = new Date();
+  d.setTime(d.getTime() + exdays * 24 * 60 * 60 * 1000);
+  const expires = `expires=${d.toUTCString()}`;
+
+  document.cookie = `${cname}=${cvalue};${expires};path=/;SameSite=None;Secure`;
+};


### PR DESCRIPTION
Added synonyms to site search in Algolia.

## Description

To have possibility to use synonyms in algolia we need the `userToken` parameter but we don't have users. For amplitude analytics we have the `deviceId` parameter (a randomly generated string that is stored in cookies). What happens if we use the `deviceId` parameter as the `userToken` parameter?