### PR TITLE
[icon] Removed automatic setting of aria-hidden to true

### DIFF
--- a/semcore/icon/CHANGELOG.md
+++ b/semcore/icon/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.13.2] - 2023-03-02
+
+### Removed
+
+- Removed automatic setting of aria-hidden to true.
+
 ## [3.13.1] - 2023-02-28
 
 ### Fixed

--- a/semcore/icon/CHANGELOG.md
+++ b/semcore/icon/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Removed
 
-- Removed automatic setting of aria-hidden to true.
+- Removed automatic setting of `aria-hidden` to `true`.
 
 ## [3.13.1] - 2023-02-28
 

--- a/semcore/icon/__tests__/index.test.jsx
+++ b/semcore/icon/__tests__/index.test.jsx
@@ -32,6 +32,16 @@ describe('Icon', () => {
     expect(getByTestId('icon').attributes['style'].value).toMatch('margin-right: 8px;');
   });
 
+  test('should aria-hidden be true if interactive is false', () => {
+    const { getByTestId } = render(<Icon data-testid="icon" mr={2} interactive={false} />);
+    expect(getByTestId('icon').attributes['aria-hidden'].value).toEqual('true');
+  });
+
+  test('should not be aria-hidden if interactive is true', () => {
+    const { getByTestId } = render(<Icon data-testid="icon" mr={2} interactive={true} />);
+    expect(getByTestId('icon').attributes['aria-hidden']?.value).toEqual(undefined);
+  });
+
   test('should support children', () => {
     const { getByTestId } = render(
       <Icon>

--- a/semcore/icon/src/Icon.jsx
+++ b/semcore/icon/src/Icon.jsx
@@ -19,7 +19,6 @@ function Icon(props, ref) {
       width: 16,
       height: 16,
       viewBox: '0 0 16 16',
-      'aria-hidden': true,
       focusable: props.interactive,
       ...props,
     },


### PR DESCRIPTION
Removed automatic setting of `aria-hidden` to `true` because of some problems with a11y. If icon has `interactive` prop `aria-hidden` should be `false` (now it is always `true`).