### PR TITLE
Perfect focus lock

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1197,8 +1197,6 @@ importers:
       '@semcore/portal': ^2
       '@semcore/utils': ^3.24
       '@types/react': 18.0.21
-      focus-lock: 0.11.3
-      react-focus-lock: 2.9.1
       resize-observer-polyfill: 1.5.1
     dependencies:
       '@popperjs/core': 2.9.2
@@ -1208,8 +1206,6 @@ importers:
       '@semcore/outside-click': link:../outside-click
       '@semcore/portal': link:../portal
       '@semcore/utils': link:../utils
-      focus-lock: 0.11.3
-      react-focus-lock: 2.9.1_@types+react@18.0.21
       resize-observer-polyfill: 1.5.1
     devDependencies:
       '@semcore/jest-preset-ui': link:../../tools/jest-preset-ui
@@ -1748,6 +1744,7 @@ importers:
       '@types/react-dom': 18.0.6
       classnames: 2.2.6
       fast-glob: 3.2.11
+      focus-lock: 0.11.3
       hoist-non-react-statics: 3.3.2
       nano-css: 5.3.4
       postcss: ^8.4.19
@@ -1755,6 +1752,7 @@ importers:
     dependencies:
       '@babel/runtime': 7.19.0
       classnames: 2.2.6
+      focus-lock: 0.11.3
       hoist-non-react-statics: 3.3.2
       nano-css: 5.3.4
     devDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1045,7 +1045,6 @@ importers:
       '@semcore/typography': ^4
       '@semcore/utils': ^3.31.2
       '@types/react': 18.0.21
-      react-focus-lock: 2.9.1
     dependencies:
       '@semcore/animation': link:../animation
       '@semcore/flex-box': link:../flex-box
@@ -1054,7 +1053,6 @@ importers:
       '@semcore/portal': link:../portal
       '@semcore/typography': link:../typography
       '@semcore/utils': link:../utils
-      react-focus-lock: 2.9.1_@types+react@18.0.21
     devDependencies:
       '@guidepup/playwright': 0.6.1_@playwright+test@1.25.1
       '@playwright/test': 1.25.1
@@ -1324,7 +1322,6 @@ importers:
       '@semcore/typography': ^4.0.1
       '@semcore/utils': ^3.31.2
       '@types/react': 18.0.21
-      react-focus-lock: 2.9.1
     dependencies:
       '@semcore/animation': link:../animation
       '@semcore/flex-box': link:../flex-box
@@ -1333,7 +1330,6 @@ importers:
       '@semcore/portal': link:../portal
       '@semcore/typography': link:../typography
       '@semcore/utils': link:../utils
-      react-focus-lock: 2.9.1_@types+react@18.0.21
     devDependencies:
       '@semcore/jest-preset-ui': link:../../tools/jest-preset-ui
       '@types/react': 18.0.21

--- a/semcore/modal/CHANGELOG.md
+++ b/semcore/modal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.5.8] - 2023-03-09
+
+### Fixed
+
+- Fixed focus locking and returning.
+
 ## [3.5.7] - 2023-03-03
 
 ### Changed

--- a/semcore/modal/package.json
+++ b/semcore/modal/package.json
@@ -19,8 +19,7 @@
     "@semcore/outside-click": "^2",
     "@semcore/portal": "^2",
     "@semcore/typography": "^4",
-    "@semcore/utils": "^3.31.2",
-    "react-focus-lock": "2.9.1"
+    "@semcore/utils": "^3.31.2"
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",

--- a/semcore/modal/src/Modal.jsx
+++ b/semcore/modal/src/Modal.jsx
@@ -1,5 +1,4 @@
 import React, { useRef, useEffect } from 'react';
-import FocusLock from 'react-focus-lock';
 import { FadeInOut, Slide } from '@semcore/animation';
 import createComponent, { Component, sstyled, Root } from '@semcore/core';
 import Portal, { PortalProvider } from '@semcore/portal';
@@ -16,6 +15,7 @@ import i18nEnhance from '@semcore/utils/lib/enhances/i18nEnhance';
 import { Text } from '@semcore/typography';
 import uniqueIDEnhancement from '@semcore/utils/lib/uniqueID';
 import { cssVariableEnhance } from '@semcore/utils/lib/useCssVariable';
+import { usePopupFocusLock } from '@semcore/utils/lib/use/useFocusLock';
 
 class ModalRoot extends Component {
   static displayName = 'Modal';
@@ -117,14 +117,12 @@ class ModalRoot extends Component {
   }
 }
 
-const FocusLockWrapper = React.forwardRef(function (props, ref) {
-  return <FocusLock ref={ref} {...props} lockProps={{ style: { display: 'contents' } }} />;
-});
-
 function Window(props) {
   const SWindow = Root;
   const { Children, styles, visible, closable, duration } = props;
   const windowRef = useRef(null);
+
+  usePopupFocusLock(windowRef, true, 'auto', !visible);
 
   return sstyled(styles)(
     <SWindow
@@ -135,13 +133,12 @@ function Window(props) {
       role="dialog"
       aria-modal={true}
       duration={duration}
+      ref={windowRef}
     >
-      <FocusLockWrapper returnFocus={true} autoFocus={true} ref={windowRef} tabIndex={-1}>
-        <PortalProvider value={windowRef}>
-          {closable && <Modal.Close />}
-          <Children />
-        </PortalProvider>
-      </FocusLockWrapper>
+      <PortalProvider value={windowRef}>
+        {closable && <Modal.Close />}
+        <Children />
+      </PortalProvider>
     </SWindow>,
   );
 }

--- a/semcore/modal/src/Modal.jsx
+++ b/semcore/modal/src/Modal.jsx
@@ -15,7 +15,7 @@ import i18nEnhance from '@semcore/utils/lib/enhances/i18nEnhance';
 import { Text } from '@semcore/typography';
 import uniqueIDEnhancement from '@semcore/utils/lib/uniqueID';
 import { cssVariableEnhance } from '@semcore/utils/lib/useCssVariable';
-import { usePopupFocusLock } from '@semcore/utils/lib/use/useFocusLock';
+import { useFocusLock } from '@semcore/utils/lib/use/useFocusLock';
 
 class ModalRoot extends Component {
   static displayName = 'Modal';
@@ -122,7 +122,7 @@ function Window(props) {
   const { Children, styles, visible, closable, duration } = props;
   const windowRef = useRef(null);
 
-  usePopupFocusLock(windowRef, true, 'auto', !visible);
+  useFocusLock(windowRef, true, 'auto', !visible);
 
   return sstyled(styles)(
     <SWindow

--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.16.5] - 2023-03-09
+
+### Fixed
+
+- Fixed focus locking and returning.
+
 ## [4.16.4] - 2023-03-01
 
 ### Fixed

--- a/semcore/popper/package.json
+++ b/semcore/popper/package.json
@@ -20,8 +20,6 @@
     "@semcore/outside-click": "^2",
     "@semcore/portal": "^2",
     "@semcore/utils": "^3.24",
-    "focus-lock": "0.11.3",
-    "react-focus-lock": "2.9.1",
     "resize-observer-polyfill": "1.5.1"
   },
   "peerDependencies": {

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -8,7 +8,7 @@ import OutsideClick from '@semcore/outside-click';
 import Portal, { PortalProvider } from '@semcore/portal';
 import NeighborLocation from '@semcore/neighbor-location';
 import { setRef } from '@semcore/utils/lib/ref';
-import { usePopupFocusLock } from '@semcore/utils/lib/use/useFocusLock';
+import { useFocusLock } from '@semcore/utils/lib/use/useFocusLock';
 import { callAllEventHandlers } from '@semcore/utils/lib/assignProps';
 import pick from '@semcore/utils/lib/pick';
 import logger from '@semcore/utils/lib/logger';
@@ -439,7 +439,7 @@ function PopperPopper(props) {
   // https://github.com/facebook/react/issues/11387
   const handlerStopPropagation = useCallback((e) => e.stopPropagation(), []);
 
-  usePopupFocusLock(
+  useFocusLock(
     ref,
     autoFocus,
     interaction === 'click' ? triggerRef : null,

--- a/semcore/side-panel/CHANGELOG.md
+++ b/semcore/side-panel/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.3.8] - 2023-03-09
+
+### Fixed
+
+- Fixed focus locking and returning.
+
 ## [2.3.7] - 2023-03-03
 
 ### Changed

--- a/semcore/side-panel/package.json
+++ b/semcore/side-panel/package.json
@@ -19,8 +19,7 @@
     "@semcore/portal": "^2",
     "@semcore/typography": "^4.0.1",
     "@semcore/outside-click": "^2",
-    "@semcore/icon": "2.16 - 3",
-    "react-focus-lock": "2.9.1"
+    "@semcore/icon": "2.16 - 3"
   },
   "peerDependencies": {
     "@semcore/core": "^1.11",

--- a/semcore/side-panel/src/SidePanel.jsx
+++ b/semcore/side-panel/src/SidePanel.jsx
@@ -12,7 +12,7 @@ import usePreventScroll from '@semcore/utils/lib/use/usePreventScroll';
 import { Text } from '@semcore/typography';
 import ArrowLeft from '@semcore/icon/ArrowLeft/m';
 import { cssVariableEnhance } from '@semcore/utils/lib/useCssVariable';
-import { usePopupFocusLock } from '@semcore/utils/lib/use/useFocusLock';
+import { useFocusLock } from '@semcore/utils/lib/use/useFocusLock';
 
 import style from './style/side-panel.shadow.css';
 
@@ -138,7 +138,7 @@ function Panel(props) {
 
   const sidebarRef = useRef(null);
 
-  usePopupFocusLock(sidebarRef, true, 'auto', !visible);
+  useFocusLock(sidebarRef, true, 'auto', !visible);
 
   return sstyled(styles)(
     <>

--- a/semcore/side-panel/src/SidePanel.jsx
+++ b/semcore/side-panel/src/SidePanel.jsx
@@ -1,5 +1,4 @@
 import React, { useRef } from 'react';
-import FocusLock from 'react-focus-lock';
 import createComponent, { Component, Root, sstyled } from '@semcore/core';
 import { Flex, Box } from '@semcore/flex-box';
 import { FadeInOut, Slide } from '@semcore/animation';
@@ -13,6 +12,7 @@ import usePreventScroll from '@semcore/utils/lib/use/usePreventScroll';
 import { Text } from '@semcore/typography';
 import ArrowLeft from '@semcore/icon/ArrowLeft/m';
 import { cssVariableEnhance } from '@semcore/utils/lib/useCssVariable';
+import { usePopupFocusLock } from '@semcore/utils/lib/use/useFocusLock';
 
 import style from './style/side-panel.shadow.css';
 
@@ -127,20 +127,6 @@ function Overlay(props) {
   return sstyled(props.styles)(<SOverlay render={FadeInOut} />);
 }
 
-const FocusLockWrapper = React.forwardRef(function (
-  { disableEnforceFocus, returnFocus, ...other },
-  ref,
-) {
-  return (
-    <FocusLock
-      ref={ref}
-      disabled={disableEnforceFocus}
-      {...other}
-      lockProps={{ ...other, returnFocus, style: { display: 'contents', ...(other.style ?? {}) } }}
-    />
-  );
-});
-
 function Panel(props) {
   const SPanel = Root;
   const { Children, styles, visible, closable, placement, onOutsideClick } = props;
@@ -152,6 +138,8 @@ function Panel(props) {
 
   const sidebarRef = useRef(null);
 
+  usePopupFocusLock(sidebarRef, true, 'auto', !visible);
+
   return sstyled(styles)(
     <>
       {visible && <OutsideClick onOutsideClick={onOutsideClick} excludeRefs={[sidebarRef]} />}
@@ -162,18 +150,16 @@ function Panel(props) {
         slideOrigin={placement}
         ref={sidebarRef}
       >
-        <FocusLockWrapper tabIndex={-1} returnFocus={true} autoFocus={true}>
-          <PortalProvider value={sidebarRef}>
-            {closable && <SidePanel.Close />}
-            {advanceMode ? (
+        <PortalProvider value={sidebarRef}>
+          {closable && <SidePanel.Close />}
+          {advanceMode ? (
+            <Children />
+          ) : (
+            <SidePanel.Body>
               <Children />
-            ) : (
-              <SidePanel.Body>
-                <Children />
-              </SidePanel.Body>
-            )}
-          </PortalProvider>
-        </FocusLockWrapper>
+            </SidePanel.Body>
+          )}
+        </PortalProvider>
       </SPanel>
     </>,
   );

--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.47.2] - 2023-03-09
+
+### Added
+
+- Added `lib/use/useFocusLock` util to control focus lock in popup components (like `Popper`-based, `Modal` and `Sidebar`).
+
 ## [3.47.1] - 2023-02-21
 
 ### Fixed

--- a/semcore/utils/package.json
+++ b/semcore/utils/package.json
@@ -25,7 +25,8 @@
     "@babel/runtime": "^7.17.9",
     "classnames": "2.2.6",
     "hoist-non-react-statics": "3.3.2",
-    "nano-css": "5.3.4"
+    "nano-css": "5.3.4",
+    "focus-lock": "0.11.3"
   },
   "peerDependencies": {
     "@semcore/core": "^1",

--- a/semcore/utils/src/use/useFocusLock.ts
+++ b/semcore/utils/src/use/useFocusLock.ts
@@ -1,0 +1,116 @@
+import canUseDOM from '../canUseDOM';
+import { useUID } from '../uniqueID';
+import moveFocusInside, { focusInside, getFocusableIn } from 'focus-lock';
+import React from 'react';
+
+const focusBordersConsumers = new Set();
+const focusBordersRefs = { before: null, after: null } as {
+  // eslint-disable-next-line ssr-friendly/no-dom-globals-in-module-scope
+  before: null | HTMLElement;
+  // eslint-disable-next-line ssr-friendly/no-dom-globals-in-module-scope
+  after: null | HTMLElement;
+};
+const useFocusBorders = (disabled) => {
+  const id = useUID('focus-borders-consumer');
+  const addBorders = React.useCallback(() => {
+    if (!focusBordersRefs.before) {
+      focusBordersRefs.before = document.createElement('div');
+      focusBordersRefs.before.setAttribute('tabindex', '0');
+      focusBordersRefs.before.style.position = 'absolute';
+      focusBordersRefs.before.dataset.id = '__intergalactic-focus-border-before';
+      document.body.prepend(focusBordersRefs.before);
+    }
+    if (!focusBordersRefs.after) {
+      focusBordersRefs.after = document.createElement('div');
+      focusBordersRefs.after.setAttribute('tabindex', '0');
+      focusBordersRefs.after.dataset.id = '__intergalactic-focus-border-after';
+      focusBordersRefs.after.style.position = 'absolute';
+      document.body.append(focusBordersRefs.after);
+    }
+  }, []);
+  const removeBorders = React.useCallback(() => {
+    focusBordersRefs.before?.remove();
+    focusBordersRefs.after?.remove();
+    focusBordersRefs.before = null;
+    focusBordersRefs.after = null;
+  }, []);
+  const areBordersPlacedCorrectly = React.useCallback(() => {
+    if (!focusBordersRefs.before || !focusBordersRefs.after) return true;
+    if (document.body.children[0] !== focusBordersRefs.before) return false;
+    if (document.body.children[document.body.children.length - 1] !== focusBordersRefs.after)
+      return false;
+    return true;
+  }, []);
+  React.useEffect(() => {
+    if (!disabled) {
+      focusBordersConsumers.add(id);
+    }
+
+    if (!areBordersPlacedCorrectly()) removeBorders();
+    if (focusBordersConsumers.size > 0) addBorders();
+
+    return () => {
+      focusBordersConsumers.delete(id);
+      if (focusBordersConsumers.size === 0) removeBorders();
+    };
+  }, [id, disabled]);
+};
+
+export const usePopupFocusLock = (
+  popupRef: React.RefObject<HTMLElement>,
+  autoFocus: boolean,
+  returnFocusRef: React.RefObject<HTMLElement> | null | 'auto',
+  disabled: boolean,
+) => {
+  useFocusBorders(disabled);
+
+  const autoTriggerRef = React.useRef<HTMLElement | null>(null);
+  const lastUserInteractionRef = React.useRef<'mouse' | 'keyboard' | undefined>(undefined);
+
+  const handleFocusIn = React.useCallback((event) => {
+    if (event.relatedTarget && !autoTriggerRef.current)
+      autoTriggerRef.current = event.relatedTarget;
+    Promise.resolve().then(() => {
+      if (!popupRef.current) return;
+      if (focusInside(popupRef.current)) return;
+
+      moveFocusInside(popupRef.current, event.target);
+    });
+  }, []);
+  const handleMouseDown = React.useCallback(() => (lastUserInteractionRef.current = 'mouse'), []);
+  const handleKeyDown = React.useCallback(() => (lastUserInteractionRef.current = 'keyboard'), []);
+  const returnFocus = React.useCallback(() => {
+    if (lastUserInteractionRef.current === 'mouse') return;
+    if (typeof returnFocusRef === 'object' && returnFocusRef?.current)
+      moveFocusInside(returnFocusRef?.current, popupRef.current!);
+    if (returnFocusRef === 'auto' && autoTriggerRef.current) {
+      moveFocusInside(autoTriggerRef.current, popupRef.current!);
+    }
+  }, []);
+  React.useEffect(() => {
+    if (disabled) return;
+    if (!canUseDOM()) return;
+    if (!popupRef.current) return;
+    if (getFocusableIn(popupRef.current).length === 0) return;
+
+    document.body.addEventListener('focusin', handleFocusIn);
+    document.body.addEventListener('mousedown', handleMouseDown);
+    document.body.addEventListener('touchstart', handleMouseDown);
+    document.body.addEventListener('keydown', handleKeyDown);
+
+    if (autoFocus)
+      moveFocusInside(
+        popupRef.current,
+        typeof returnFocusRef === 'object' ? returnFocusRef?.current! : document.body,
+      );
+
+    return () => {
+      document.body.removeEventListener('focusin', handleFocusIn);
+      document.body.removeEventListener('mousedown', handleMouseDown);
+      document.body.removeEventListener('touchstart', handleMouseDown);
+      document.body.removeEventListener('keydown', handleKeyDown);
+      returnFocus();
+      autoTriggerRef.current = null;
+    };
+  }, [disabled, autoFocus]);
+};


### PR DESCRIPTION
## Description

I have removed `react-focus-lock` and build React integration on top of `focus-lock`. This integration doesn't create extra wrappers over element and both works perfectly with our popup components.

## Motivation and Context

Our current focus lock mechanism a based on combination of react-focus-lock with some messy and non understandable by everyone in the team wrappers that work some-times. We got lot of reports about non working focus-lock and after animation update situation became even worse.  

## How has this been tested?

Lot of manual testing for now.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
