### PR TITLE
[utils] update value for chart-x-axis-accent-period token

### DIFF
--- a/semcore/utils/theme/tokens.json
+++ b/semcore/utils/theme/tokens.json
@@ -2287,7 +2287,7 @@
       },
       "x-axis-accent": {
         "period-active": {
-          "value": "{gray.400}",
+          "value": "{gray.500}",
           "type": "color",
           "description": "Background color for the clickable date on the X-axis of the chart grid."
         },


### PR DESCRIPTION
Updated value for `chart-x-axis-accent-period-active` from `--gray-400` to `--gray-500` after recommendations from Level Access.