### PR TITLE
Radar chart a11y

### DIFF
--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.11.0] - 2023-03-13
+
+### Changed
+
+- Much improved a11y summary generation for `Radar` chart.
+
 ## [2.10.0] - 2023-03-07
 
 ### Added

--- a/semcore/d3-chart/src/Radar.jsx
+++ b/semcore/d3-chart/src/Radar.jsx
@@ -12,15 +12,12 @@ import { CONSTANT, eventToPoint, measureText } from './utils';
 import style from './style/radar.shadow.css';
 
 function getAngle(i, range, func, total) {
-  const angle = (total - i) * 2 * Math.PI / total;
+  const angle = ((total - i) * 2 * Math.PI) / total;
   return range * (1 - func(angle)) - range;
 }
 
 function getRadianPosition(i, range, total) {
-  return [
-    getAngle(i, range, Math.sin, total),
-    getAngle(i, range, Math.cos, total),
-  ];
+  return [getAngle(i, range, Math.sin, total), getAngle(i, range, Math.cos, total)];
 }
 
 function getLabelDirection(i, total) {
@@ -176,8 +173,8 @@ class RadarRoot extends Component {
       <SRadar
         aria-hidden
         id={this.id}
-        render='g'
-        childrenPosition='inside'
+        render="g"
+        childrenPosition="inside"
         transform={`translate(${width / 2},${height / 2})`}
       />,
     );
@@ -189,7 +186,7 @@ class PolygonRoot extends Component {
   static style = style;
 
   static defaultProps = ({ scale, curve = curveLinearClosed, size, offset }) => {
-    scale.range([0, (Math.min(size[0], size[1]) / 2) - offset]);
+    scale.range([0, Math.min(size[0], size[1]) / 2 - offset]);
 
     return {
       d3: lineRadial()
@@ -198,7 +195,7 @@ class PolygonRoot extends Component {
           return scale(d || 0);
         })
         .angle((d, i, data) => {
-          return ((i / data.length) * 2 * Math.PI);
+          return (i / data.length) * 2 * Math.PI;
         }),
     };
   };
@@ -225,16 +222,14 @@ class PolygonRoot extends Component {
 
   render() {
     const { Element: SPolygon, styles, d3, data, color, fill } = this.asProps;
-    return sstyled(styles)(
-      <SPolygon render='path' d={d3(data)} color={fill || color} />,
-    );
+    return sstyled(styles)(<SPolygon render="path" d={d3(data)} color={fill || color} />);
   }
 }
 
 function PolygonLine(props) {
   const { Element: SPolygonLine, styles, d3, color, data, transparent } = props;
   return sstyled(styles)(
-    <SPolygonLine render='path' d={d3(data)} color={color} transparent={transparent} />,
+    <SPolygonLine render="path" d={d3(data)} color={color} transparent={transparent} />,
   );
 }
 
@@ -247,7 +242,7 @@ function PolygonDots(props) {
     return sstyled(styles)(
       <SPolygonDot
         key={i}
-        render='circle'
+        render="circle"
         cx={cx}
         cy={cy}
         color={color}
@@ -281,13 +276,13 @@ class AxisRoot extends Component {
         return radius;
       })
       .angle((d, i) => {
-        return ((i / total) * 2 * Math.PI);
+        return (i / total) * 2 * Math.PI;
       });
   }
 
   getTicksProps({ tickSize = 100 }) {
     const { data, offset, categories, size, type } = this.asProps;
-    const radius = (Math.min(size[0], size[1]) / 2) - offset;
+    const radius = Math.min(size[0], size[1]) / 2 - offset;
     return {
       type,
       data,
@@ -315,7 +310,10 @@ class AxisRoot extends Component {
 
   componentDidMount() {
     const { eventEmitter } = this.asProps;
-    this.unsubscribeTooltipVisible = eventEmitter.subscribe('onTooltipVisible', this.handlerTooltipVisible);
+    this.unsubscribeTooltipVisible = eventEmitter.subscribe(
+      'onTooltipVisible',
+      this.handlerTooltipVisible,
+    );
   }
 
   componentWillUnmount() {
@@ -327,13 +325,16 @@ class AxisRoot extends Component {
   render() {
     const { Element: SAxis, styles, categories, size, offset, type } = this.asProps;
     const { activeLineIndex } = this.state;
-    const radius = (Math.min(size[0], size[1]) / 2) - offset;
+    const radius = Math.min(size[0], size[1]) / 2 - offset;
     const total = categories.length;
 
     return sstyled(styles)(
       <>
-        {type === 'circle' ? <SAxis render='circle' cx={0} cy={0} r={radius} /> :
-          <SAxis render='path' d={this.createLineRadial(radius, total)(categories)} />}
+        {type === 'circle' ? (
+          <SAxis render="circle" cx={0} cy={0} r={radius} />
+        ) : (
+          <SAxis render="path" d={this.createLineRadial(radius, total)(categories)} />
+        )}
         {categories.map((category, i) => {
           const [x, y] = getRadianPosition(i, radius, total);
           const { className } = sstyled(styles).cn('SAxisLine', {
@@ -348,20 +349,23 @@ class AxisRoot extends Component {
 
 function AxisTicks(props) {
   const { Element: SAxisTick, styles, size, ticks, d3, categories, offset, type } = props;
-  const radius = (Math.min(size[0], size[1]) / 2) - offset;
+  const radius = Math.min(size[0], size[1]) / 2 - offset;
 
   return ticks.map((tick, i) => {
     d3.radius(() => radius * tick);
     return sstyled(styles)(
-      type === 'circle' ? <SAxisTick key={i} render='circle' cx={0} cy={0} r={radius * tick} /> :
-        <SAxisTick render='path' key={i} d={d3(categories)} />,
+      type === 'circle' ? (
+        <SAxisTick key={i} render="circle" cx={0} cy={0} r={radius * tick} />
+      ) : (
+        <SAxisTick render="path" key={i} d={d3(categories)} />
+      ),
     );
   });
 }
 
 function AxisLabels(props) {
   const { Element: SAxisLabel, styles, textSize, size, offset, categories } = props;
-  const radius = (Math.min(size[0], size[1]) / 2) - offset;
+  const radius = Math.min(size[0], size[1]) / 2 - offset;
 
   return categories.map((category, i) => {
     const [x, y] = getRadianPosition(i, radius, categories.length);
@@ -371,8 +375,8 @@ function AxisLabels(props) {
       return sstyled(styles)(
         <SAxisLabel
           key={i}
-          render='text'
-          childrenPosition='inside'
+          render="text"
+          childrenPosition="inside"
           x={x}
           y={y}
           xDirection={xDirection}
@@ -403,7 +407,6 @@ function AxisLabels(props) {
 }
 
 class Hover extends Component {
-
   state = {
     index: null,
   };
@@ -421,7 +424,7 @@ class Hover extends Component {
     const { categories, size, offset } = this.asProps;
     const total = categories.length;
     const diam = Math.min(size[0], size[1]);
-    const radius = (diam / 2) - offset;
+    const radius = diam / 2 - offset;
     const prevIndex = (index - 1 + total) % total;
     const nextIndex = (index + 1 + total) % total;
     const [prevX1, prevY1] = getRadianPosition(prevIndex, radius, total);
@@ -437,13 +440,9 @@ class Hover extends Component {
 
   getPie(index) {
     const { categories, size, offset } = this.asProps;
-    const angle = Math.PI * 2 / categories.length;
+    const angle = (Math.PI * 2) / categories.length;
     const radius = Math.min(size[0], size[1]) / 2 - offset;
-    return [
-      index * angle - angle / 2,
-      (index + 1) * angle - angle / 2,
-      radius,
-    ];
+    return [index * angle - angle / 2, (index + 1) * angle - angle / 2, radius];
   }
 
   getIndex(point) {
@@ -473,24 +472,25 @@ class Hover extends Component {
 
     const index = this.getIndex([centerX, centerY]);
 
-    this.setState({
-      index,
-    }, () => {
-      eventEmitter.emit(
-        'onTooltipVisible',
-        index !== null,
-        { index },
-        this.virtualElement,
-      );
-    });
+    this.setState(
+      {
+        index,
+      },
+      () => {
+        eventEmitter.emit('onTooltipVisible', index !== null, { index }, this.virtualElement);
+      },
+    );
   });
 
   handlerMouseLeaveRoot = trottle(() => {
-    this.setState({
-      index: null,
-    }, () => {
-      this.asProps.eventEmitter.emit('onTooltipVisible', false, { index: null });
-    });
+    this.setState(
+      {
+        index: null,
+      },
+      () => {
+        this.asProps.eventEmitter.emit('onTooltipVisible', false, { index: null });
+      },
+    );
   });
 
   componentDidMount() {
@@ -529,7 +529,7 @@ class Hover extends Component {
           .endAngle(endAngle);
         return sstyled(styles)(
           <SPieRect
-            render='path'
+            render="path"
             // @ts-ignore
             d={circle()}
           />,
@@ -537,7 +537,7 @@ class Hover extends Component {
       } else {
         return sstyled(styles)(
           <SPieRect
-            render='path'
+            render="path"
             // @ts-ignore
             d={line()(this.getPolygon(index))}
           />,

--- a/semcore/d3-chart/src/Radar.jsx
+++ b/semcore/d3-chart/src/Radar.jsx
@@ -155,6 +155,8 @@ class RadarRoot extends Component {
     const { Children, style, size, data, offset } = this.asProps;
     const [width, height] = size;
 
+    this.asProps.dataHintsHandler.establishDataType('indexed-groups');
+
     let dataKey;
     React.Children.toArray(getOriginChildren(Children)).forEach((child) => {
       if (React.isValidElement(child) && child.type === Radar.Axis) {
@@ -201,12 +203,14 @@ class PolygonRoot extends Component {
   };
 
   getDotsProps() {
-    const { data, scale, color, transparent } = this.asProps;
+    const { data, scale, color, transparent, dataKey, dataHintsHandler } = this.asProps;
     return {
       data,
       scale,
       color,
       transparent,
+      categoryKey: dataKey,
+      dataHintsHandler,
     };
   }
 
@@ -234,10 +238,11 @@ function PolygonLine(props) {
 }
 
 function PolygonDots(props) {
-  const { Element: SPolygonDot, styles, color, data, scale, transparent } = props;
+  const { Element: SPolygonDot, styles, color, data, scale, transparent, categoryKey } = props;
   return data.map((value, i) => {
     if (value === null || value === undefined) return;
     const radius = scale(value);
+    props.dataHintsHandler.describeGroupedValues(categoryKey, `${categoryKey}.${i}`);
     const [cx, cy] = getRadianPosition(i, radius, data.length);
     return sstyled(styles)(
       <SPolygonDot
@@ -371,6 +376,8 @@ function AxisLabels(props) {
     const [x, y] = getRadianPosition(i, radius, categories.length);
     const [xDirection, yDirection] = getLabelDirection(i, categories.length);
     if (typeof category === 'string') {
+      props.dataHintsHandler.labelKey('value', i, category);
+
       const lines = category.split('\n');
       return sstyled(styles)(
         <SAxisLabel

--- a/semcore/d3-chart/src/a11y/insights.ts
+++ b/semcore/d3-chart/src/a11y/insights.ts
@@ -54,7 +54,12 @@ export type ClusterNode = {
 };
 export type Insight = TrendNode | GeneralTrendNode | ComparisonNode | ClusterNode;
 
-export type SerializableDataType = 'time-series' | 'points-cloud' | 'values-set' | 'grouped-values';
+export type SerializableDataType =
+  | 'time-series'
+  | 'points-cloud'
+  | 'values-set'
+  | 'grouped-values'
+  | 'indexed-groups';
 
 export type AnalyzedData = {
   insights: Insight[];
@@ -595,6 +600,48 @@ export const extractDataInsights = (
       values,
       priority: 1,
     });
+  }
+  if (dataType === 'indexed-groups') {
+    const groups = [...hints.groups].map((groupKey) => {
+      const values = [...hints.fields.values]
+        .filter((fieldPath) => String(fieldPath).startsWith(`${groupKey}.`))
+        .map((fieldPath) => ({
+          label: getPropByPath(
+            hints.titles.valuesAxes,
+            String(fieldPath).substring(String(groupKey).length + 1),
+          ),
+          value: getPropByPath(data, String(fieldPath)),
+        }));
+
+      values.sort((a, b) => {
+        if (typeof a.value !== 'number' || typeof b.value !== 'number') return 0;
+        return b.value - a.value;
+      });
+      const averageValue =
+        values.reduce((sum, { value }) => sum + (value as number), 0) / values.length;
+      return {
+        label: getPropByPath(hints.titles.valuesAxes, String(groupKey)) ?? groupKey,
+        values,
+        averageValue: !Number.isNaN(averageValue) ? averageValue : undefined,
+      };
+    });
+
+    groups.sort((a, b) => {
+      if (typeof a.averageValue !== 'number' || typeof b.averageValue !== 'number') return 0;
+      return b.averageValue - a.averageValue;
+    });
+    entitiesCount = groups.length;
+    insights.push(
+      ...groups.map(
+        (group) =>
+          ({
+            type: 'comparison',
+            label: group.label,
+            values: group.values,
+            priority: 1,
+          } as ComparisonNode),
+      ),
+    );
   }
 
   const hasHighPriorityInsights = insights.some((insight) => insight.priority > 0);

--- a/semcore/d3-chart/src/a11y/serialize.ts
+++ b/semcore/d3-chart/src/a11y/serialize.ts
@@ -118,7 +118,7 @@ const formatValuesList = (
 
     const value = formatValue(intl, rawValue, { datesWithTime, maxListSymbols });
 
-    if (value === label) return value;
+    if (String(value) === String(label)) return value;
 
     return intl.formatMessage({ id: 'value-labeled' }, { label, value });
   });
@@ -314,7 +314,7 @@ export const serialize = (
     );
 
     return sumamry;
-  } else if (dataType === 'grouped-values') {
+  } else if (dataType === 'grouped-values' || dataType === 'indexed-groups') {
     const groupInsights = insights as ComparisonNode[];
     const valueCounts = groupInsights.map((group) => group.values.length);
     const minValuesCount = Math.min(...valueCounts);


### PR DESCRIPTION
## Description

I've improved Radar chart a11y by adding new data type for a11y module of d3-chart. It reuses existing translations and serialization.

## Motivation and Context

Radar chart uses unusual format of data so existing a11y module while providing real summary of data wasn't helping users much. Adding new group much improved usefulness of generated summary. 

## Screenshots:
![image](https://user-images.githubusercontent.com/31261408/224360784-34bb00c2-abde-4396-a837-f897ee290e2a.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
