### PR TITLE
[tooltip] Added possibility to set popper width in non-expanded variant

### DIFF
--- a/semcore/tooltip/CHANGELOG.md
+++ b/semcore/tooltip/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
-## [5.4.0] - 2023-03-20
+## [5.3.18] - 2023-03-20
 
-### Changed
+### Added
 
-- Changed direction of outside props from `Tooltip.Trigger` to `Tooltip.Popper`.
+- Added the ability to set the width of the `Tooltip.Popper` when using the component in a non-expanded variant by throwing props.
 
 ## [5.3.17] - 2023-03-16
 

--- a/semcore/tooltip/CHANGELOG.md
+++ b/semcore/tooltip/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.4.0] - 2023-03-20
+
+### Changed
+
+- Changed direction of outside props from `Tooltip.Trigger` to `Tooltip.Popper`.
+
 ## [5.3.17] - 2023-03-16
 
 ### Changed

--- a/semcore/tooltip/src/Tooltip.jsx
+++ b/semcore/tooltip/src/Tooltip.jsx
@@ -46,7 +46,7 @@ class TooltipRoot extends Component {
 
   render() {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { Children, title, offset, ...other } = this.asProps;
+    const { Children, title, offset, w, ...other } = this.asProps;
 
     const advanceMode = isAdvanceMode(Children, [
       Tooltip.Trigger.displayName,
@@ -65,10 +65,10 @@ class TooltipRoot extends Component {
           <Children />
         ) : (
           <>
-            <Tooltip.Trigger>
+            <Tooltip.Trigger {...other}>
               <Children />
             </Tooltip.Trigger>
-            <Tooltip.Popper {...other}>{title}</Tooltip.Popper>
+            <Tooltip.Popper w={w}>{title}</Tooltip.Popper>
           </>
         )}
       </Root>

--- a/semcore/tooltip/src/Tooltip.jsx
+++ b/semcore/tooltip/src/Tooltip.jsx
@@ -65,10 +65,10 @@ class TooltipRoot extends Component {
           <Children />
         ) : (
           <>
-            <Tooltip.Trigger {...other}>
+            <Tooltip.Trigger>
               <Children />
             </Tooltip.Trigger>
-            <Tooltip.Popper>{title}</Tooltip.Popper>
+            <Tooltip.Popper {...other}>{title}</Tooltip.Popper>
           </>
         )}
       </Root>


### PR DESCRIPTION
## Description

Added the ability to set the width of the `Tooltip.Popper` when using the component in a non-expanded variant by throwing props.

You can reproduce bug in the example https://codesandbox.io/s/compassionate-dirac-lmk9pf?file=/src/App.js.

<img width="1043" alt="Screenshot 2023-03-17 at 23 11 36" src="https://user-images.githubusercontent.com/44463016/226062007-ec69537a-0b73-428a-9504-e802d69a4323.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.