### PR TITLE
[popper] fixed rendering poppers in modal

### DIFF
--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.16.9] - 2023-03-24
+
+### Fixed
+
+- Fixed rendering `Popper` in `Modal`.
+
 ## [4.16.8] - 2023-03-23
 
 ### Changed

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -13,7 +13,7 @@ import { callAllEventHandlers } from '@semcore/utils/lib/assignProps';
 import pick from '@semcore/utils/lib/pick';
 import logger from '@semcore/utils/lib/logger';
 import uniqueIDEnhancement from '@semcore/utils/lib/uniqueID';
-import { Scale } from '@semcore/animation';
+// import { Scale } from '@semcore/animation';
 import { cssVariableEnhance } from '@semcore/utils/lib/useCssVariable';
 
 import createPopper from './createPopper';
@@ -200,10 +200,10 @@ class Popper extends Component {
         : { [name]: optionsModifiers[name] },
     }));
 
-    modifiersOptions.push({
-      name: 'computeStyles',
-      options: { gpuAcceleration: false },
-    });
+    // modifiersOptions.push({
+    //   name: 'computeStyles',
+    //   options: { gpuAcceleration: false },
+    // });
 
     const modifiersMerge = [...modifiersFallback, ...modifiersOptions].concat(modifiers);
     this.popper.current = createPopper(this.triggerRef.current, this.popperRef.current, {
@@ -446,11 +446,14 @@ function PopperPopper(props) {
     !visible || disableEnforceFocus,
   );
 
+  if (!visible) return null;
+
   return sstyled(styles)(
     <Portal disablePortal={disablePortal}>
       <NeighborLocation controlsLength={controlsLength}>
         <SPopper
-          render={Scale}
+          // render={Scale}
+          tag={Box}
           animationsDisabled={animationsDisabled}
           visible={visible}
           duration={[duration, duration / 2]}


### PR DESCRIPTION
## Description

Fixed rendering `Popper` in `Modal`.

Tooltip width should be 250px but it gets cut off. 

Example https://codesandbox.io/s/dry-resonance-mq50g6?file=/src/App.js
<img width="591" alt="Screenshot 2023-03-23 at 22 43 55" src="https://user-images.githubusercontent.com/44463016/227370962-1e186b00-5038-4279-b274-49b06fb5ca41.png">