### PR TITLE
[global] supported ignoring parent portals nesting

### DIFF
--- a/semcore/animation/CHANGELOG.md
+++ b/semcore/animation/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [1.10.0] - 2023-03-27
+
+### Added
+
+- Animation context that allows children components react to parent animation execution.
+
 ## [1.9.9] - 2023-03-28
 
 ### Changed

--- a/semcore/animation/src/Animation.jsx
+++ b/semcore/animation/src/Animation.jsx
@@ -1,12 +1,29 @@
 import React from 'react';
 import createComponent, { Component, Root, sstyled } from '@semcore/core';
 import { Box } from '@semcore/flex-box';
-
+import contextEnhance from '@semcore/utils/lib/enhances/contextEnhance';
 import style from './style/animate.shadow.css';
 
 function propToArray(prop) {
   return Array.isArray(prop) ? prop : [prop, prop];
 }
+
+const makeAnimationContextValue = () => {
+  const context = {
+    onAnimationStartSubscribers: [],
+    onAnimationStart: (callback) => {
+      context.onAnimationStartSubscribers.push(callback);
+      return () => context.onAnimationStartSubscribers.filter((cb) => cb !== callback);
+    },
+    onAnimationEndSubscribers: [],
+    onAnimationEnd: (callback) => {
+      context.onAnimationEndSubscribers.push(callback);
+      return () => context.onAnimationEndSubscribers.filter((cb) => cb !== callback);
+    },
+  };
+  return context;
+};
+export const animationContext = React.createContext(null);
 
 class Animation extends Component {
   static displayName = 'Animation';
@@ -20,6 +37,7 @@ class Animation extends Component {
     timingFunction: 'ease-out',
     animationsDisabled: false,
   };
+  static enhance = [contextEnhance(animationContext, 'parentAnimationContext')];
 
   static getDerivedStateFromProps(props, state) {
     const wasInvisible = state.wasInvisible || !props.visible;
@@ -30,39 +48,64 @@ class Animation extends Component {
   }
 
   state = {
+    animationRunning: false,
     render: this.props.visible || this.props.preserveNode,
     wasInvisible: !this.props.visible,
   };
 
-  onAnimationEnd = (e) => {
-    e.stopPropagation();
+  animationContext = makeAnimationContextValue(); // TBD TO MAKE NESTED !!!!!!!!!!!!!!
+
+  onAnimationStart = () => {
+    const { animationsDisabled, parentAnimationContext } = this.asProps;
+    const duration = animationsDisabled ? [0, 0] : propToArray(this.asProps.duration);
+    const animationContext = parentAnimationContext ?? this.animationContext;
+    animationContext.onAnimationStartSubscribers.forEach((callback) => callback(duration[0]));
+  };
+
+  onAnimationEnd = (event) => {
+    event.stopPropagation();
     if (!this.asProps.visible && !this.props.preserveNode) {
       this.setState({ render: false });
     }
+    const { parentAnimationContext } = this.asProps;
+    const animationContext = parentAnimationContext ?? this.animationContext;
+    animationContext.onAnimationEndSubscribers.forEach((callback) => callback());
   };
 
   render() {
     const SAnimation = Root;
-    const { styles, keyframes, initialAnimation, timingFunction, animationsDisabled } =
-      this.asProps;
+    const {
+      styles,
+      keyframes,
+      initialAnimation,
+      timingFunction,
+      animationsDisabled,
+      parentAnimationContext,
+    } = this.asProps;
+    const animationContextValue = parentAnimationContext ?? this.animationContext;
     const duration = animationsDisabled ? [0, 0] : propToArray(this.asProps.duration);
     const delay = animationsDisabled ? [0, 0] : propToArray(this.asProps.delay);
     const { render, wasInvisible } = this.state;
 
     if (!render) return null;
 
-    return sstyled(styles)(
-      <SAnimation
-        render={Box}
-        onAnimationEnd={this.onAnimationEnd}
-        durationInitialize={`${duration[0]}ms`}
-        durationFinalize={`${duration[1]}ms`}
-        delayInitialize={`${delay[0]}ms`}
-        delayFinalize={`${delay[1]}ms`}
-        timingFunction={timingFunction}
-        keyframesInitialize={wasInvisible || initialAnimation ? keyframes[0] : undefined}
-        keyframesFinalize={keyframes[1]}
-      />,
+    return (
+      <animationContext.Provider value={animationContextValue}>
+        {sstyled(styles)(
+          <SAnimation
+            render={Box}
+            onAnimationStart={this.onAnimationStart}
+            onAnimationEnd={this.onAnimationEnd}
+            durationInitialize={`${duration[0]}ms`}
+            durationFinalize={`${duration[1]}ms`}
+            delayInitialize={`${delay[0]}ms`}
+            delayFinalize={`${delay[1]}ms`}
+            timingFunction={timingFunction}
+            keyframesInitialize={wasInvisible || initialAnimation ? keyframes[0] : undefined}
+            keyframesFinalize={keyframes[1]}
+          />,
+        )}
+      </animationContext.Provider>
     );
   }
 }

--- a/semcore/animation/src/Animation.jsx
+++ b/semcore/animation/src/Animation.jsx
@@ -53,7 +53,7 @@ class Animation extends Component {
     wasInvisible: !this.props.visible,
   };
 
-  animationContext = makeAnimationContextValue(); // TBD TO MAKE NESTED !!!!!!!!!!!!!!
+  animationContext = makeAnimationContextValue();
 
   onAnimationStart = () => {
     const { animationsDisabled, parentAnimationContext } = this.asProps;

--- a/semcore/animation/src/index.d.ts
+++ b/semcore/animation/src/index.d.ts
@@ -76,6 +76,11 @@ export interface ISlideProps extends IAnimationProps {
   slideOrigin?: 'top' | 'bottom' | 'left' | 'right';
 }
 
+type DisposeSubscription = () => void;
+declare const animationContext: React.Context<{
+  onAnimationStart: (callback: () => void) => DisposeSubscription;
+  onAnimationEnd: (callback: () => void) => DisposeSubscription;
+}>;
 declare const Animation: <T>(props: CProps<IAnimationProps & T>) => ReturnEl;
 declare const Collapse: <T>(props: CProps<ICollapseProps & T>) => ReturnEl;
 declare const FadeInOut: <T>(props: CProps<IFadeInOutProps & T>) => ReturnEl;
@@ -83,4 +88,4 @@ declare const Transform: <T>(props: CProps<ITransformProps & T>) => ReturnEl;
 declare const Scale: <T>(props: CProps<IScaleProps & T>) => ReturnEl;
 declare const Slide: <T>(props: CProps<ISlideProps & T>) => ReturnEl;
 
-export { Animation, Collapse, FadeInOut, Transform, Scale, Slide };
+export { Animation, Collapse, FadeInOut, Transform, Scale, Slide, animationContext };

--- a/semcore/animation/src/index.js
+++ b/semcore/animation/src/index.js
@@ -1,4 +1,4 @@
-export { default as Animation } from './Animation';
+export { default as Animation, animationContext } from './Animation';
 
 export { default as Transform } from './Transform';
 

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -94,13 +94,15 @@ class DropdownMenuRoot extends Component {
   }
 
   getPopperProps() {
-    const { uid, disablePortal } = this.asProps;
+    const { uid, disablePortal, ignorePortalsStacking } = this.asProps;
 
     return {
       tabIndex: 0,
       onKeyDown: this.bindHandlerKeyDown('popper'),
       id: `igc-${uid}-popper`,
       'aria-flowto': !disablePortal ? `igc-${uid}-trigger` : undefined,
+      disablePortal,
+      ignorePortalsStacking,
     };
   }
 

--- a/semcore/dropdown/src/Dropdown.jsx
+++ b/semcore/dropdown/src/Dropdown.jsx
@@ -83,12 +83,14 @@ class Dropdown extends Component {
   }
 
   getPopperProps() {
-    const { uid, disablePortal } = this.asProps;
+    const { uid, disablePortal, ignorePortalsStacking } = this.asProps;
 
     return {
       id: `igc-${uid}-popper`,
       'aria-flowto': !disablePortal ? `igc-${uid}-trigger` : undefined,
       tabIndex: 0,
+      disablePortal,
+      ignorePortalsStacking,
     };
   }
 

--- a/semcore/portal/CHANGELOG.md
+++ b/semcore/portal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.6.0] - 2023-03-27
+
+### Added
+
+- Supported ignoring parent portals nesting via `ignorePortalsStacking`.
+
 ## [2.5.17] - 2023-03-28
 
 ### Changed

--- a/semcore/portal/src/Portal.tsx
+++ b/semcore/portal/src/Portal.tsx
@@ -7,6 +7,8 @@ import { getNodeByRef, NodeByRef } from '@semcore/utils/lib/ref';
 export interface IPortalProps {
   /** Disables children rendering in React portal */
   disablePortal?: boolean;
+  /** Disabled attaching portals to the parent portals and enabling attaching directly to document.body */
+  ignorePortalsStacking?: boolean;
 }
 
 const PortalContext = register.get(
@@ -16,13 +18,15 @@ const PortalContext = register.get(
 );
 
 function Portal(props: IFunctionProps<IPortalProps>) {
-  const { Children, disablePortal } = props;
+  const { Children, disablePortal, ignorePortalsStacking } = props;
   const container = useContext(PortalContext);
-  const [mountNode, setMountNode] = useState(getNodeByRef(container));
+  const [mountNode, setMountNode] = useState(
+    ignorePortalsStacking ? document.body : getNodeByRef(container),
+  );
 
   useEffect(() => {
     if (!disablePortal) {
-      setMountNode(getNodeByRef(container));
+      setMountNode(ignorePortalsStacking ? document.body : getNodeByRef(container));
     }
   }, [container, disablePortal]);
 

--- a/semcore/tooltip/src/Tooltip.jsx
+++ b/semcore/tooltip/src/Tooltip.jsx
@@ -37,10 +37,12 @@ class TooltipRoot extends Component {
   }
 
   getPopperProps() {
-    const { theme, uid } = this.asProps;
+    const { theme, uid, disablePortal, ignorePortalsStacking } = this.asProps;
     return {
       id: `igc-${uid}-popper`,
       theme,
+      disablePortal,
+      ignorePortalsStacking,
     };
   }
 

--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.50.0] - 2023-03-27
+
+### Added
+
+- Small internal util for context consuming in class-based components.
+
 ## [3.49.1] - 2023-03-28
 
 ### Fixed

--- a/semcore/utils/src/enhances/contextEnhance.tsx
+++ b/semcore/utils/src/enhances/contextEnhance.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+function contextEnhance(context: React.Context<any>, setOnProp: string) {
+  return (props) => {
+    const { ...other } = props;
+    const value = React.useContext(context);
+    return {
+      ...other,
+      [setOnProp]: value,
+    };
+  };
+}
+
+export default contextEnhance;


### PR DESCRIPTION
## Description

I have added prop `ignorePortalsStacking` for portals.

## Motivation and Context

After animation update we faced following issue with tooltips in modals when tooltip is applied to elements which width is close to the width of the modal.

![image](https://user-images.githubusercontent.com/31261408/227963668-ab87ab96-0672-4f47-8afd-a34629762cd4.png)

Going deeper showed that the reason is nested portals:  modal is rendered in portal, but creates portal provider inside of that. It ensured z-index are correct and position of inner poppers is related to position of modal (what is very important in animations!) on other hand in such situation popperjs modifier `computeStyles` finds parent node with scrolling and tries to place popper inside of that scrollable parent.

Such behavior is very good for most cases except cases when tooltip trigger size is almost equal to the size of scrollable parent, where popper is going to be placed. 

After implementing portals prop to disable stacking another issue was faced. When position of popper is not related to position of the animated container, position calculation is initiated on the first frame of animation and doesn't update later.

https://user-images.githubusercontent.com/31261408/227966292-34336837-d6ae-4b58-bd9e-b9268bd72367.mov

To deal with it I've added animation context – it allows popper in case of disabled portal stacking to listen to the animation start and end. When animation stars, popper is being updated every animation frame until animation ends (or timeout happens).

It doesn't work perfect because in cases of low performance browser will not give enough requested animation frame callbacks but in most cases it much increases UX while preserving working animations both from nested portals and from document root

https://user-images.githubusercontent.com/31261408/227967731-c39fdda2-8461-48ea-aa9d-0eb20d1d9d3e.mov 


## How has this been tested?

Only manual testing.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
