### PR TITLE
[docs] fix typo in the dropdown-menu doc

### DIFF
--- a/website/docs/components/dropdown-menu/dropdown-menu.md
+++ b/website/docs/components/dropdown-menu/dropdown-menu.md
@@ -68,7 +68,7 @@ As the user enters a value into the input, only the items that match the input s
 
 |                     | Appearance                                                                           | Tokens                                |
 | ------------------- | ------------------------------------------------------------------------------------ | ------------------------------------- |
-| Default             | ![](static/item-default.png)                           | `--dropdown-menu-item)`               |
+| Default             | ![](static/item-default.png)                           | `--dropdown-menu-item`               |
 | Hover               | ![](static/item-hover.png)                    | `--dropdown-menu-item-hover`          |
 | Selected            | ![](static/item-active.png)                | `--dropdown-menu-item-selected`       |
 | Selected with hover | ![](static/item-active-hover.png) | `--dropdown-menu-item-selected-hover` |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix an out of place round bracket in the DropdownMenu documentation.


## Screenshots:

<img width="752" alt="image" src="https://user-images.githubusercontent.com/4928316/231242781-e2ad5ee1-42f6-4248-ae47-132674964a21.png">