### PR TITLE
[d3-chart] Removed passing styles from charts to tooltip

### DIFF
--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.14.0] - 2023-04-14
+
+### Removed
+
+- Removed passing styles from charts to tooltip
+
 ## [2.13.11] - 2023-04-14
 
 ### Added

--- a/semcore/d3-chart/src/Tooltip.jsx
+++ b/semcore/d3-chart/src/Tooltip.jsx
@@ -37,6 +37,7 @@ class TooltipRoot extends Component {
     this.unsubscribeTooltipVisible = eventEmitter.subscribe(
       'onTooltipVisible',
       (visible, data, node) => {
+        delete data.style;
         this.setState(
           {
             ...data,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In charts that do not use a hoverLine/hoverBar for Tooltip, the styles of the chart itself were also applied to the styles of the tooltip, which led to undesirable effects

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

