### PR TITLE
[animation] fixed collapse animations in Safari

### DIFF
--- a/semcore/animation/CHANGELOG.md
+++ b/semcore/animation/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [1.10.4] - 2023-04-25
+
+### Fixed
+
+- Fixed collapse animations (e.g. used in `<Accordion />) in Safari.
+
 ## [1.10.3] - 2023-04-24
 
 ## [1.10.2] - 2023-04-17

--- a/semcore/animation/CHANGELOG.md
+++ b/semcore/animation/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Fixed
 
-- Fixed collapse animations (e.g. used in `<Accordion />) in Safari.
+- Fixed collapse animations (e.g. used in `<Accordion />`) in Safari.
 
 ## [1.10.3] - 2023-04-24
 

--- a/semcore/animation/src/Collapse.jsx
+++ b/semcore/animation/src/Collapse.jsx
@@ -1,22 +1,40 @@
-import React, { useCallback, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { createBaseComponent, sstyled } from '@semcore/core';
 import Animation from './Animation';
 import style from './style/keyframes.shadow.css';
+import { useForkRef } from '@semcore/utils/lib/ref';
 
 function Collapse({ onAnimationStart, onAnimationEnd, overflowHidden = true, ...props }, ref) {
   const SCollapse = Animation;
-  const [height, setHeightVar] = useState('auto');
   const overflowRef = useRef('initial');
+  const innerRef = useRef(null);
+  const forkedRef = useForkRef(innerRef, ref);
 
-  const handlerAnimationStart = useCallback((e) => {
-    if (e.currentTarget !== e.target) return;
-    if (onAnimationStart) onAnimationStart(e);
-    if (overflowHidden) {
-      overflowRef.current = window.getComputedStyle(e.currentTarget).overflow;
-      e.currentTarget.style.overflow = 'hidden';
-    }
-    setHeightVar(e.currentTarget.scrollHeight + 'px');
+  useEffect(() => {
+    if (!innerRef.current) return;
+    innerRef.current.style.height = 'auto';
   }, []);
+
+  const handlerAnimationStart = useCallback(
+    (e) => {
+      if (e.currentTarget !== e.target) return;
+      if (onAnimationStart) onAnimationStart(e);
+      if (overflowHidden) {
+        overflowRef.current = window.getComputedStyle(e.currentTarget).overflow;
+        e.currentTarget.style.overflow = 'hidden';
+      }
+
+      const el = e.currentTarget;
+
+      if (props.visible) el.style.height = 0 + 'px';
+      else el.style.height = el.scrollHeight + 'px';
+      setTimeout(() => {
+        if (props.visible) el.style.height = el.scrollHeight + 'px';
+        else el.style.height = 0 + 'px';
+      }, 0);
+    },
+    [props.visible],
+  );
 
   const handlerAnimationEnd = useCallback((e) => {
     if (e.currentTarget !== e.target) return;
@@ -30,16 +48,19 @@ function Collapse({ onAnimationStart, onAnimationEnd, overflowHidden = true, ...
         }
       }, 0);
     }
-    setHeightVar('auto');
+
+    const el = e.currentTarget;
+    setTimeout(() => {
+      el.style.height = 'auto';
+    }, 0);
   }, []);
 
   return sstyled(style)(
     <SCollapse
-      ref={ref}
+      ref={forkedRef}
       {...props}
       onAnimationStart={handlerAnimationStart}
       onAnimationEnd={handlerAnimationEnd}
-      height={height}
       keyframes={[style['@collapse-enter'], style['@collapse-exit']]}
     />,
   );

--- a/semcore/animation/src/Collapse.jsx
+++ b/semcore/animation/src/Collapse.jsx
@@ -15,43 +15,38 @@ function Collapse({ onAnimationStart, onAnimationEnd, overflowHidden = true, ...
     innerRef.current.style.height = 'auto';
   }, []);
 
-  const handlerAnimationStart = useCallback(
-    (e) => {
-      if (e.currentTarget !== e.target) return;
-      if (onAnimationStart) onAnimationStart(e);
+  const handleAnimationStart = useCallback(
+    (event) => {
+      if (event.currentTarget !== event.target) return;
+      if (onAnimationStart) onAnimationStart(event);
       if (overflowHidden) {
-        overflowRef.current = window.getComputedStyle(e.currentTarget).overflow;
-        e.currentTarget.style.overflow = 'hidden';
+        overflowRef.current = window.getComputedStyle(event.currentTarget).overflow;
+        event.currentTarget.style.overflow = 'hidden';
       }
 
-      const el = e.currentTarget;
+      const element = event.currentTarget;
 
-      if (props.visible) el.style.height = 0 + 'px';
-      else el.style.height = el.scrollHeight + 'px';
+      if (props.visible) element.style.height = 0 + 'px';
+      else element.style.height = element.scrollHeight + 'px';
       setTimeout(() => {
-        if (props.visible) el.style.height = el.scrollHeight + 'px';
-        else el.style.height = 0 + 'px';
+        if (props.visible) element.style.height = element.scrollHeight + 'px';
+        else element.style.height = 0 + 'px';
       }, 0);
     },
     [props.visible],
   );
 
-  const handlerAnimationEnd = useCallback((e) => {
-    if (e.currentTarget !== e.target) return;
-    if (onAnimationEnd) onAnimationEnd(e);
-    if (overflowHidden) {
-      // The timeout is needed because the overflow is first set, and then the node is removed via setState inside the animation
-      setTimeout(() => {
-        // The checking is needed because the node is being deleted
-        if (e.currentTarget) {
-          e.currentTarget.style.overflow = overflowRef.current;
-        }
-      }, 0);
-    }
+  const handleAnimationEnd = useCallback((event) => {
+    if (event.currentTarget !== event.target) return;
+    if (onAnimationEnd) onAnimationEnd(event);
+    const element = event.currentTarget;
 
-    const el = e.currentTarget;
     setTimeout(() => {
-      el.style.height = 'auto';
+      if (!element) return;
+      element.style.height = 'auto';
+      if (overflowHidden) {
+        element.style.overflow = overflowRef.current;
+      }
     }, 0);
   }, []);
 
@@ -59,8 +54,8 @@ function Collapse({ onAnimationStart, onAnimationEnd, overflowHidden = true, ...
     <SCollapse
       ref={forkedRef}
       {...props}
-      onAnimationStart={handlerAnimationStart}
-      onAnimationEnd={handlerAnimationEnd}
+      onAnimationStart={handleAnimationStart}
+      onAnimationEnd={handleAnimationEnd}
       keyframes={[style['@collapse-enter'], style['@collapse-exit']]}
     />,
   );

--- a/semcore/animation/src/style/animate.shadow.css
+++ b/semcore/animation/src/style/animate.shadow.css
@@ -4,11 +4,19 @@ SAnimation {
   animation-duration: var(--durationFinalize);
   animation-delay: var(--delayFinalize);
   animation-name: var(--keyframesFinalize);
+
+  transition-timing-function: var(--timingFunction);
+  transition-duration: var(--durationFinalize);
+  transition-delay: var(--delayFinalize);
 }
 SAnimation[visible] {
   animation-duration: var(--durationInitialize);
   animation-delay: var(--delayInitialize);
   animation-name: var(--keyframesInitialize);
+
+  transition-timing-function: var(--timingFunction);
+  transition-duration: var(--durationInitialize);
+  transition-delay: var(--delayInitialize);
 }
 
 @media (prefers-reduced-motion) {

--- a/semcore/animation/src/style/keyframes.shadow.css
+++ b/semcore/animation/src/style/keyframes.shadow.css
@@ -1,20 +1,28 @@
 @keyframes collapse-enter {
   from {
     overflow: hidden;
-    height: 0;
   }
   to {
-    height: var(--height);
+    overflow: hidden;
   }
 }
 @keyframes collapse-exit {
   from {
-    height: var(--height);
+    overflow: hidden;
   }
   to {
-    height: 0;
+    overflow: hidden;
   }
 }
+SCollapse {
+  transition-property: height;
+  height: 0;
+}
+SCollapse[visible] {
+  transition-property: height;
+  height: 0;
+}
+
 @keyframes fade-in-out-enter {
   from {
     opacity: 0;


### PR DESCRIPTION
## Description

I have rebuild collapse animation from css `animation` to css `transition`.

## Motivation and Context

Currently collapse animation works fine except working in Safari.

## How has this been tested?

I have manually tested it in Safari, Chrome and Firefox. Seems to work fine in all modern browsers.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
