### PR TITLE
[data-table] added key on groupCell

### DIFF
--- a/semcore/data-table/src/Body.tsx
+++ b/semcore/data-table/src/Body.tsx
@@ -55,11 +55,11 @@ class Body extends Component<AsProps, State> {
   renderCells(cells: NestedCells, rowData: RowData, index: number) {
     const SCell = Flex;
     const { styles, columns, use } = this.asProps;
-    return cells.map((cell) => {
+    return cells.map((cell, cellIndex) => {
       if (Array.isArray(cell)) {
         const SGroupCell = 'div';
         return sstyled(styles)(
-          <SGroupCell role="rowgroup" data-ui-name="group-cell">
+          <SGroupCell key={cellIndex} role="rowgroup" data-ui-name="group-cell">
             {this.renderRows(cell as NestedCells[])}
           </SGroupCell>,
         );


### PR DESCRIPTION
Added a key to the **SGroupCell** component

## Description, Motivation and Context

When you use **ROW_GROUP** to merge cells, you get a missing key error

## How has this been tested?
Checked on the local version of the website

## Screenshots (if appropriate):
<img width="761" alt="Снимок экрана 2023-04-25 в 14 40 43" src="https://user-images.githubusercontent.com/12624143/234279314-5331d0f3-9d85-4565-a579-b58a619e3147.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

