### PR TITLE
[typography] added new property for Text component

### DIFF
--- a/semcore/typography/src/index.d.ts
+++ b/semcore/typography/src/index.d.ts
@@ -19,6 +19,12 @@ export interface ITextProps extends IBoxProps {
   underline?: boolean;
   /** Strikethrough text */
   lineThrough?: boolean;
+  /** Uppercase text */
+  uppercase?: boolean;
+  /** Lowercase text */
+  lowercase?: boolean;
+  /** Capitalized text */
+  capitalize?: boolean;
   /** Text color **/
   color?: string;
   /** Custom `font-size` */

--- a/semcore/typography/src/style/text.shadow.css
+++ b/semcore/typography/src/style/text.shadow.css
@@ -61,6 +61,18 @@ SText[italic] {
   font-style: italic;
 }
 
+SText[uppercase] {
+  text-transform: uppercase;
+}
+
+SText[lowercase] {
+  text-transform: lowercase;
+}
+
+SText[capitalize] {
+  text-transform: capitalize;
+}
+
 SText[decoration] {
   text-decoration: var(--decoration);
 }

--- a/website/docs/style/typography/examples/text-emphasis.jsx
+++ b/website/docs/style/typography/examples/text-emphasis.jsx
@@ -18,5 +18,14 @@ export default () => (
     <Text size={300} tag="p" mb={2} mt={0}>
       But I do love the taste of a <Text tag="s">good burger</Text>. Mm-mm-mm.
     </Text>
+    <Text size={300} tag="p" mb={2} mt={0} uppercase>
+        uppercase text
+    </Text>
+    <Text size={300} tag="p" mb={2} mt={0} capitalize>
+        capitalize text
+    </Text>
+    <Text size={300} tag="p" mb={2} mt={0} lowercase>
+        LOWERCASE TEXT
+    </Text>
   </div>
 );


### PR DESCRIPTION
Added new property **uppercase**, **lowercase** and **capitalize** for Text component

## Description

This is my **proposal** for adding new properties to the Text component.

## Motivation and Context

Very often when developing, you need to do a basic text transformation and to do this you need to either add a **raw style** or write a **className**, it seems to me that such basic work with styles should be available out of the box.

For example like this:
`<Text uppercase>text</Text>`

## How has this been tested?

Just added an example to the documentation and it works :)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# If appropriate sections above are not fulfilled properly do not even review my pull request and never approve it! Only after fulfilling sections above I will also remove this note.
