### PR TITLE
added popper keyboard focus highlight

### DIFF
--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -6,658 +6,647 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Fixed
 
-* Fixed corner case of focus return with `interaction=focus`.
-* Added `disableEnforceFocus` api prop.
+- Fixed corner case of focus return with `interaction=focus`.
+- Added `disableEnforceFocus` api prop.
 
 ## [4.17.16] - 2023-05-31
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.13 ~> 1.10.14], `@semcore/flex-box` [4.7.26 ~> 4.7.27], `@semcore/neighbor-location` [3.1.32 ~> 3.1.33], `@semcore/outside-click` [2.5.31 ~> 2.5.32], `@semcore/utils` [3.52.0 ~> 3.53.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.13 ~> 1.10.14], `@semcore/flex-box` [4.7.26 ~> 4.7.27], `@semcore/neighbor-location` [3.1.32 ~> 3.1.33], `@semcore/outside-click` [2.5.31 ~> 2.5.32], `@semcore/utils` [3.52.0 ~> 3.53.0]).
 
 ## [4.17.15] - 2023-05-29
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.12 ~> 1.10.13]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.12 ~> 1.10.13]).
 
 ## [4.17.14] - 2023-05-25
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.11 ~> 1.10.12], `@semcore/flex-box` [4.7.25 ~> 4.7.26], `@semcore/neighbor-location` [3.1.31 ~> 3.1.32], `@semcore/outside-click` [2.5.30 ~> 2.5.31], `@semcore/utils` [3.51.1 ~> 3.52.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.11 ~> 1.10.12], `@semcore/flex-box` [4.7.25 ~> 4.7.26], `@semcore/neighbor-location` [3.1.31 ~> 3.1.32], `@semcore/outside-click` [2.5.30 ~> 2.5.31], `@semcore/utils` [3.51.1 ~> 3.52.0]).
 
 ## [4.17.13] - 2023-05-24
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.10 ~> 1.10.11], `@semcore/flex-box` [4.7.24 ~> 4.7.25], `@semcore/neighbor-location` [3.1.30 ~> 3.1.31], `@semcore/outside-click` [2.5.29 ~> 2.5.30], `@semcore/utils` [3.51.0 ~> 3.51.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.10 ~> 1.10.11], `@semcore/flex-box` [4.7.24 ~> 4.7.25], `@semcore/neighbor-location` [3.1.30 ~> 3.1.31], `@semcore/outside-click` [2.5.29 ~> 2.5.30], `@semcore/utils` [3.51.0 ~> 3.51.1]).
 
 ## [4.17.12] - 2023-05-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.9 ~> 1.10.10], `@semcore/flex-box` [4.7.23 ~> 4.7.24], `@semcore/neighbor-location` [3.1.29 ~> 3.1.30], `@semcore/outside-click` [2.5.28 ~> 2.5.29], `@semcore/utils` [3.50.7 ~> 3.51.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.9 ~> 1.10.10], `@semcore/flex-box` [4.7.23 ~> 4.7.24], `@semcore/neighbor-location` [3.1.29 ~> 3.1.30], `@semcore/outside-click` [2.5.28 ~> 2.5.29], `@semcore/utils` [3.50.7 ~> 3.51.0]).
 
 ## [4.17.11] - 2023-05-19
 
 ### Added
 
-* Set default color of popper for better support of dark themes.
+- Set default color of popper for better support of dark themes.
 
 ## [4.17.10] - 2023-05-11
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.8 ~> 1.10.9], `@semcore/flex-box` [4.7.22 ~> 4.7.23], `@semcore/neighbor-location` [3.1.28 ~> 3.1.29], `@semcore/outside-click` [2.5.27 ~> 2.5.28], `@semcore/utils` [3.50.6 ~> 3.50.7]).
-
-<<<<<<< 
-
-## [4.17.9] - 2023-05-11
-
-=======
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.8 ~> 1.10.9], `@semcore/flex-box` [4.7.22 ~> 4.7.23], `@semcore/neighbor-location` [3.1.28 ~> 3.1.29], `@semcore/outside-click` [2.5.27 ~> 2.5.28], `@semcore/utils` [3.50.6 ~> 3.50.7]).
 
 ## [4.17.9] - 2023-05-11
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.7 ~> 1.10.8], `@semcore/flex-box` [4.7.21 ~> 4.7.22], `@semcore/neighbor-location` [3.1.27 ~> 3.1.28], `@semcore/outside-click` [2.5.26 ~> 2.5.27], `@semcore/utils` [3.50.5 ~> 3.50.6]).
-
->>>>>>> 
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.7 ~> 1.10.8], `@semcore/flex-box` [4.7.21 ~> 4.7.22], `@semcore/neighbor-location` [3.1.27 ~> 3.1.28], `@semcore/outside-click` [2.5.26 ~> 2.5.27], `@semcore/utils` [3.50.5 ~> 3.50.6]).
 
 ## [4.17.8] - 2023-05-04
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.7 ~> 1.10.8], `@semcore/flex-box` [4.7.21 ~> 4.7.22], `@semcore/neighbor-location` [3.1.27 ~> 3.1.28], `@semcore/outside-click` [2.5.26 ~> 2.5.27], `@semcore/utils` [3.50.5 ~> 3.50.6]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.7 ~> 1.10.8], `@semcore/flex-box` [4.7.21 ~> 4.7.22], `@semcore/neighbor-location` [3.1.27 ~> 3.1.28], `@semcore/outside-click` [2.5.26 ~> 2.5.27], `@semcore/utils` [3.50.5 ~> 3.50.6]).
 
 ## [4.17.7] - 2023-05-04
 
 ### Fixed
 
-* Using `ignorePortalsStacking` on top-level poppers was causing application crash.
+- Using `ignorePortalsStacking` on top-level poppers was causing application crash.
 
 ## [4.17.6] - 2023-05-03
 
 ### Fixed
 
-* Fixed issue with popper first showing on multiple triggers
+- Fixed issue with popper first showing on multiple triggers
 
 ## [4.17.5] - 2023-05-02
 
 ### Fixed
 
-* `interaction=hover` poppers now might be triggered by keyboard focus (but not mouse focus).
+- `interaction=hover` poppers now might be triggered by keyboard focus (but not mouse focus).
 
 ## [4.17.1] - 2023-04-03
 
 ### Changed
 
-* Moved screen reader hint from `aria-label` attribute to `aria-live="polite"` alert block.
-* Improved keyboard navigation on exit from focus-triggered popovers.
+- Moved screen reader hint from `aria-label` attribute to `aria-live="polite"` alert block.
+- Improved keyboard navigation on exit from focus-triggered popovers.
 
 ## [4.16.12] - 2023-03-28
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.9.9 ~> 1.10.0], `@semcore/flex-box` [4.7.17 ~> 4.7.18], `@semcore/neighbor-location` [3.1.23 ~> 3.1.24], `@semcore/outside-click` [2.5.22 ~> 2.5.23], `@semcore/portal` [2.5.17 ~> 2.6.0], `@semcore/utils` [3.49.1 ~> 3.50.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.9.9 ~> 1.10.0], `@semcore/flex-box` [4.7.17 ~> 4.7.18], `@semcore/neighbor-location` [3.1.23 ~> 3.1.24], `@semcore/outside-click` [2.5.22 ~> 2.5.23], `@semcore/portal` [2.5.17 ~> 2.6.0], `@semcore/utils` [3.49.1 ~> 3.50.0]).
 
 ## [4.16.10] - 2023-03-24
 
 ### Fixed
 
-* Fixed local themes in poppers.
+- Fixed local themes in poppers.
 
 ## [4.16.9] - 2023-03-24
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.9.6 ~> 1.9.7], `@semcore/flex-box` [4.7.14 ~> 4.7.15], `@semcore/neighbor-location` [3.1.20 ~> 3.1.21], `@semcore/outside-click` [2.5.19 ~> 2.5.20], `@semcore/utils` [3.48.0 ~> 3.48.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.9.6 ~> 1.9.7], `@semcore/flex-box` [4.7.14 ~> 4.7.15], `@semcore/neighbor-location` [3.1.20 ~> 3.1.21], `@semcore/outside-click` [2.5.19 ~> 2.5.20], `@semcore/utils` [3.48.0 ~> 3.48.1]).
 
 ## [4.16.5] - 2023-03-09
 
 ### Fixed
 
-* Fixed focus locking and returning.
+- Fixed focus locking and returning.
 
 ## [4.16.4] - 2023-03-01
 
 ### Fixed
 
-* Fixed `animationsDisabled` prop passing.
+- Fixed `animationsDisabled` prop passing.
 
 ## [4.16.3] - 2023-02-28
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.9.1 ~> 1.9.2]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.9.1 ~> 1.9.2]).
 
 ## [4.16.2] - 2023-02-22
 
 ### Fixed
 
-* Fixed popper autofocus wasn't working if popper contains any focusable elements.
+- Fixed popper autofocus wasn't working if popper contains any focusable elements.
 
 ## [4.16.1] - 2023-02-21
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.9.0 ~> 1.9.1], `@semcore/flex-box` [4.7.9 ~> 4.7.10], `@semcore/neighbor-location` [3.1.15 ~> 3.1.16], `@semcore/outside-click` [2.5.14 ~> 2.5.15], `@semcore/utils` [3.47.0 ~> 3.47.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.9.0 ~> 1.9.1], `@semcore/flex-box` [4.7.9 ~> 4.7.10], `@semcore/neighbor-location` [3.1.15 ~> 3.1.16], `@semcore/outside-click` [2.5.14 ~> 2.5.15], `@semcore/utils` [3.47.0 ~> 3.47.1]).
 
 ## [4.16.0] - 2023-02-20
 
 ### Added
 
-* Added appear and disappear animation.
+- Added appear and disappear animation.
 
 ## [4.15.2] - 2023-01-20
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.6 ~> 4.7.7], `@semcore/neighbor-location` [3.1.12 ~> 3.1.13], `@semcore/outside-click` [2.5.11 ~> 2.5.12], `@semcore/utils` [3.45.0 ~> 3.46.0]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.6 ~> 4.7.7], `@semcore/neighbor-location` [3.1.12 ~> 3.1.13], `@semcore/outside-click` [2.5.11 ~> 2.5.12], `@semcore/utils` [3.45.0 ~> 3.46.0]).
 
 ## [4.15.0] - 2023-01-16
 
 ### Fixed
 
-* Fixed focus hijacking by non editable poppers.
+- Fixed focus hijacking by non editable poppers.
 
 ## [4.14.4] - 2023-01-09
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.3 ~> 4.7.4], `@semcore/neighbor-location` [3.1.9 ~> 3.1.10], `@semcore/outside-click` [2.5.8 ~> 2.5.9], `@semcore/utils` [3.44.1 ~> 3.44.2]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.3 ~> 4.7.4], `@semcore/neighbor-location` [3.1.9 ~> 3.1.10], `@semcore/outside-click` [2.5.8 ~> 2.5.9], `@semcore/utils` [3.44.1 ~> 3.44.2]).
 
 ## [4.14.1] - 2022-12-13
 
 ### Changed
 
-* Added `react-dom` to peer dependencies.
+- Added `react-dom` to peer dependencies.
 
 ## [4.14.0] - 2022-12-12
 
 ### Added
 
-* Design tokens based theming.
+- Design tokens based theming.
 
 ## [4.13.4] - 2022-10-30
 
 ### Changed
 
-* Updated `focus-lock`.
+- Updated `focus-lock`.
 
 ## [4.13.3] - 2022-10-28
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.6.2 ~> 4.6.3], `@semcore/neighbor-location` [3.1.2 ~> 3.1.3], `@semcore/outside-click` [2.5.2 ~> 2.5.3], `@semcore/utils` [3.40.0 ~> 3.40.0]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.6.2 ~> 4.6.3], `@semcore/neighbor-location` [3.1.2 ~> 3.1.3], `@semcore/outside-click` [2.5.2 ~> 2.5.3], `@semcore/utils` [3.40.0 ~> 3.40.0]).
 
 ## [4.13.0] - 2022-10-10
 
 ### Changed
 
-* Added support for React 18 🔥
+- Added support for React 18 🔥
 
 ## [4.12.0] - 2022-10-07
 
 ### Changed
 
-* Updated major dependency `@semcore/neighbor-location` [2.3.15 ~> 3.0.0]
+- Updated major dependency `@semcore/neighbor-location` [2.3.15 ~> 3.0.0]
 
 ## [4.11.31] - 2022-10-04
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.5.11 ~> 4.5.12], `@semcore/neighbor-location` [2.3.15 ~> 2.3.16], `@semcore/outside-click` [2.4.13 ~> 2.4.14], `@semcore/utils` [3.37.1 ~> 3.37.2]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.5.11 ~> 4.5.12], `@semcore/neighbor-location` [2.3.15 ~> 2.3.16], `@semcore/outside-click` [2.4.13 ~> 2.4.14], `@semcore/utils` [3.37.1 ~> 3.37.2]).
 
 ## [4.11.30] - 2022-09-30
 
 ### Fixed
 
-* Removed aria attributes that were breaking components a11y.
+- Removed aria attributes that were breaking components a11y.
 
 ## [4.11.29] - 2022-08-30
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.5.10 ~> 4.5.11], `@semcore/neighbor-location` [2.3.14 ~> 2.3.15], `@semcore/outside-click` [2.4.12 ~> 2.4.13], `@semcore/utils` [3.37.0 ~> 3.37.1]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.5.10 ~> 4.5.11], `@semcore/neighbor-location` [2.3.14 ~> 2.3.15], `@semcore/outside-click` [2.4.12 ~> 2.4.13], `@semcore/utils` [3.37.0 ~> 3.37.1]).
 
 ## [4.11.24] - 2022-07-18
 
 ### Fixed
 
-* Fixed possibility to insert render function into `Popper.Trigger`.
+- Fixed possibility to insert render function into `Popper.Trigger`.
 
 ## [4.11.23] - 2022-07-14
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/neighbor-location` [2.3.9 ~> 2.3.10]).
+- Version patch update due to children dependencies update (`@semcore/neighbor-location` [2.3.9 ~> 2.3.10]).
 
 ## [4.11.19] - 2022-05-19
 
 ### Fixed
 
-* Synced dependencies versions to remove duplicates in the single export package.
+- Synced dependencies versions to remove duplicates in the single export package.
 
 ## [4.11.17] - 2022-03-14
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.5.0 ~> 4.5.1], `@semcore/neighbor-location` [2.3.4 ~> 2.3.5], `@semcore/outside-click` [2.4.2 ~> 2.4.3], `@semcore/utils` [3.31.2 ~> 3.31.2]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.5.0 ~> 4.5.1], `@semcore/neighbor-location` [2.3.4 ~> 2.3.5], `@semcore/outside-click` [2.4.2 ~> 2.4.3], `@semcore/utils` [3.31.2 ~> 3.31.2]).
 
 ## [4.11.16] - 2022-02-24
 
 ### Added
 
-* Added repository field to package.json file.
+- Added repository field to package.json file.
 
 ## [4.11.15] - 2021-12-22
 
 ### Changed
 
-* remove functionality for stop propagation of events `onMouseEnter, onMouseLeave` from the `<Popper.Popper/>`.
+- remove functionality for stop propagation of events `onMouseEnter, onMouseLeave` from the `<Popper.Popper/>`.
 
 ## [4.11.14] - 2021-12-07
 
 ### Fixed
 
-* Property `root` for Popper set to `OutsideClick`.
+- Property `root` for Popper set to `OutsideClick`.
 
 ## [4.11.13] - 2021-10-18
 
 ### Changed
 
-* Up version package `focus-lock`.
+- Up version package `focus-lock`.
 
 ## [4.11.12] - 2021-8-26
 
 ### Changed
 
-* Add 'sideEffect=false' for more optimal build via webpack
+- Add 'sideEffect=false' for more optimal build via webpack
 
 ## [4.11.11] - 2021-07-06
 
 ### Fixed
 
-* Fixed cjs build package.
+- Fixed cjs build package.
 
 ## [4.11.10] - 2021-06-22
 
 ### Changed
 
-* Improved render performance
+- Improved render performance
 
 ## [4.11.9] - 2021-06-18
 
 ### Fixed
 
-* Fixed forwarding properties to the `Box` in `Popper.Popper`.
+- Fixed forwarding properties to the `Box` in `Popper.Popper`.
 
 ## [4.11.8] - 2021-06-10
 
 ### Fixed
 
-* Fixed set prop `returnFocus` for Focus-Lock
+- Fixed set prop `returnFocus` for Focus-Lock
 
 ## [4.11.7] - 2021-06-08
 
 ### Fixed
 
-* Fix TS type
+- Fix TS type
 
 ## [4.11.6] - 2021-06-04
 
 ### Fixed
 
-* [A11] Fixed set `aria-pressed` for `Popper.Trigger`.
+- [A11] Fixed set `aria-pressed` for `Popper.Trigger`.
 
 ## [4.11.5] - 2021-05-17
 
 ### Fixed
 
-* Add type for handlers for render function
+- Add type for handlers for render function
 
 ## [4.11.4] - 2021-05-11
 
 ### Fixed
 
-* Fix TS type
+- Fix TS type
 
 ## [4.11.3] - 2021-05-05
 
 ### Changed
 
-* Rewrite code from TS to JS 🧑‍💻
+- Rewrite code from TS to JS 🧑‍💻
 
 ### Fixed
 
-* Fix position arrow after change version `popperjs`.
+- Fix position arrow after change version `popperjs`.
 
 ## [4.10.1] - 2021-04-28
 
 ### Fixed
 
-* Fixed the setting of attributes in HTML.
+- Fixed the setting of attributes in HTML.
 
 ## [4.10.0] - 2021-4-26
 
 ### Changed
 
-* Version of dependence `@semcore/core` has been changed to `1.11`.
-* Improved performance. Removed one component wrapper.
-* The style processing system has been changed.
-* Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
+- Version of dependence `@semcore/core` has been changed to `1.11`.
+- Improved performance. Removed one component wrapper.
+- The style processing system has been changed.
+- Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
 
 ## [4.9.0] - 2021-04-20
 
 ### Added
 
-* Added functions `setTrigger, setPopper` in context for Popper.
+- Added functions `setTrigger, setPopper` in context for Popper.
 
 ### Changed
 
-* Bump `poperjs` to `2.9.2`.
+- Bump `poperjs` to `2.9.2`.
 
 ## [4.8.0] - 2020-12-17
 
 ### Added
 
-* Added supported react@17.
+- Added supported react@17.
 
 ## [4.7.2] - 2020-12-16
 
 ### Fixed
 
-* Сomponent has become friendlier to SSR. Replace random generate number to get uid from function `useUID`.
+- Сomponent has become friendlier to SSR. Replace random generate number to get uid from function `useUID`.
 
 ## [4.7.1] - 2020-11-25
 
 ### Fixed
 
-* Fixed import paths from `@popperjs`.
-* Refactor modifier `arrowOffset` that calculates arrow position.
+- Fixed import paths from `@popperjs`.
+- Refactor modifier `arrowOffset` that calculates arrow position.
 
 ## [4.7.0] - 2020-11-10
 
 ### Added
 
-* Added the ability to use one `<Popper.Popper/>` with multiple `<Popper.Trigger/>`
+- Added the ability to use one `<Popper.Popper/>` with multiple `<Popper.Trigger/>`
 
 ### Changed
 
-* Removed the display of the popper by focus when navigating from the keyboard, it caused many bugs 🤷‍♂️
+- Removed the display of the popper by focus when navigating from the keyboard, it caused many bugs 🤷‍♂️
 
 ## [4.6.2] - 2020-10-29
 
 ### Fixed
 
-* Added the placeholder for ID style tag to improve collision protection.
+- Added the placeholder for ID style tag to improve collision protection.
 
 ## [4.6.1] - 2020-09-30
 
 ### Added
 
-* Added generic for better `value` and `onChange` typings
+- Added generic for better `value` and `onChange` typings
 
 ### Changed
 
-* Update @semcore/core version to ^1.8
+- Update @semcore/core version to ^1.8
 
-
-* Update dependency package `@popperjs/core` version from `2.4.0` to `2.5.3`
-
-
+- Update dependency package `@popperjs/core` version from `2.4.0` to `2.5.3`
 
 ## [4.5.0] - 2020-09-11
 
 ### Added
 
-* Add functionality for stop propagation of events from the `<Popper.Popper/>`, more details [here](https://github.com/facebook/react/issues/11387).
+- Add functionality for stop propagation of events from the `<Popper.Popper/>`, more details [here](https://github.com/facebook/react/issues/11387).
 
 ## [4.4.2] - 2020-09-08
 
 ### Fixed
 
-* Fixed possible styles collisions between components with different versions, but same styles
+- Fixed possible styles collisions between components with different versions, but same styles
 
 ## [4.4.1] - 2020-08-17
 
 ### Fixed
 
-* Исправлены ts типы для `offset`
+- Исправлены ts типы для `offset`
 
 ## [4.4.0] - 2020-08-05
 
 ### Added
 
-* Зависимость от `neighbor-location` для обнуления расположения соседних элементов внутри `Popper.Popper`.
+- Зависимость от `neighbor-location` для обнуления расположения соседних элементов внутри `Popper.Popper`.
 
 ## [4.3.0] - 2020-07-22
 
 ### Fixed
 
-* Оптимизировали перерендеры триггера и поппера
+- Оптимизировали перерендеры триггера и поппера
 
 ### Added
 
-* Добавили `ResizeObserver` для слежения за изменением размеров триггера или поппера для правильного позиционирования поппера
+- Добавили `ResizeObserver` для слежения за изменением размеров триггера или поппера для правильного позиционирования поппера
 
 ## [4.2.2] - 2020-07-15
 
 ### Fixed
 
-* Зафиксирована версия `@popperjs/core`, так как последняя версия вызывает ошибку с бесконечным циклом
+- Зафиксирована версия `@popperjs/core`, так как последняя версия вызывает ошибку с бесконечным циклом
 
 ## [4.2.1] - 2020-07-06
 
 ### Fixed
 
-* Убраны `import type` из Popper.tsx
+- Убраны `import type` из Popper.tsx
 
 ## [4.2.0] - 2020-07-06
 
 ### Added
 
-* Добавлен кастомный модификатор `arrow` для корректного выравнивания стрелки в `Popper.Popper`
+- Добавлен кастомный модификатор `arrow` для корректного выравнивания стрелки в `Popper.Popper`
 
 ## [4.1.1] - 2020-06-26
 
 ### Fixed
 
-* Восстановлены экспорты типов `Placement`, `Modifiers`, `Strategy`
+- Восстановлены экспорты типов `Placement`, `Modifiers`, `Strategy`
 
 ## [4.1.0] - 2020-06-08
 
 ### Added
 
-* Добавлено свойство `interaction='none'` для выключения реакции на любые события.
+- Добавлено свойство `interaction='none'` для выключения реакции на любые события.
 
 ## [4.0.3] - 2020-06-02
 
 ### BREAK
 
-* Изменения описаны в [migration guide](/internal/migration-guide)
+- Изменения описаны в [migration guide](/internal/migration-guide)
 
 ## [3.6.3] - 2020-03-25
 
 ### Fixed
 
-* Добавлена пропущенная зависимость `@semcore/ui`
+- Добавлена пропущенная зависимость `@semcore/ui`
 
 ## [3.6.1] - 2019-12-27
 
 ### Fixed
 
-* Исправлена ошибка при который TS не мог найти типы, так как конфликтовали `Popper/index.ts` и `Popper.ts`.
+- Исправлена ошибка при который TS не мог найти типы, так как конфликтовали `Popper/index.ts` и `Popper.ts`.
 
 ## [3.6.0] - 2019-12-12
 
 ### Added
 
-* Появилась возможность добавления различных стилистических тем через css переменные
-* Появилась возможность оптицонально подключать адаптивноссть
-* Появилась возможность изолировать стили даже в пределах одной страницы
+- Появилась возможность добавления различных стилистических тем через css переменные
+- Появилась возможность оптицонально подключать адаптивноссть
+- Появилась возможность изолировать стили даже в пределах одной страницы
 
 ### Changed
 
-* Изменен алгоритм вставки стилей в head
+- Изменен алгоритм вставки стилей в head
 
 ### Removed
 
-* Убраны относительные единицы измерения(rem), которые использовались для адаптивности
+- Убраны относительные единицы измерения(rem), которые использовались для адаптивности
 
 ## [3.5.1] - 2019-11-14
 
 ### Fixed
 
-* Поправили доступ к `DOM` нодам `Trigger, Popper`
+- Поправили доступ к `DOM` нодам `Trigger, Popper`
 
 ## [3.5.0] - 2019-10-10
 
 ### Changed
 
-* Убрано `inline` свойство для дефолтного триггера
+- Убрано `inline` свойство для дефолтного триггера
 
 ## [3.4.0] - 2019-10-08
 
 ### Added
 
-* Добавлен `resize-observer` для автоматического выравнивания при изменении размеров
+- Добавлен `resize-observer` для автоматического выравнивания при изменении размеров
 
 ## [3.3.5] - 2019-09-30
 
 ### Changed
 
-* Нужные зависимости перенесены в `utils`, размер должен стать меньше
+- Нужные зависимости перенесены в `utils`, размер должен стать меньше
 
 ## [3.3.4] - 2019-09-05
 
 ### Fixed
 
-* Исправлена ошибка типизации `Popper`
+- Исправлена ошибка типизации `Popper`
 
 ## [3.3.3] - 2019-07-05
 
 ### Fixed
 
-* Исправлена ошибка при отсутствии `onOutsideClick`
+- Исправлена ошибка при отсутствии `onOutsideClick`
 
 ## [3.3.1] - 2019-07-05
 
 ### Fixed
 
-* Убрал лишний рендер, улучшена производительность
+- Убрал лишний рендер, улучшена производительность
 
 ## [3.3.0] - 2019-06-25
 
 ### Added
 
-* Добавлен доступ к пропу `ecludedRefs` вложенного `@semcore/outside-click`
+- Добавлен доступ к пропу `ecludedRefs` вложенного `@semcore/outside-click`
 
 ## [3.2.3] - 2019-06-13
 
 ### Fixed
 
-* Исправлена проблема открытия `Popper` при начале клика на `Trigger`-е, а заканчивание на `Popper`-е
+- Исправлена проблема открытия `Popper` при начале клика на `Trigger`-е, а заканчивание на `Popper`-е
 
 ## [3.2.2] - 2019-06-06
 
 ### Fixed
 
-* Отключение перерендера `Trigger` при закрытом `Popper`
+- Отключение перерендера `Trigger` при закрытом `Popper`
 
 ## [3.2.1] - 2019-06-04
 
 ### Changed
 
-* Расчет положения `Popper` для крайних положений ("start", "end").
+- Расчет положения `Popper` для крайних положений ("start", "end").
 
 ## [3.2.0] - 2019-04-17
 
 ### Added
 
-* Добавлен Box в `Popper` и `Trigger`
+- Добавлен Box в `Popper` и `Trigger`
 
 ### Changed
 
-* Увеличен `z-index` до 110
-* Расширен контекст в `Popper` и `Trigger`
+- Увеличен `z-index` до 110
+- Расширен контекст в `Popper` и `Trigger`
 
 ## [3.1.5] - 2019-03-21
 
 ### Fixed
 
-* Добавлено предсказуемое поведение на закрытие при размещении одного `Popper` в другом `Popper`
+- Добавлено предсказуемое поведение на закрытие при размещении одного `Popper` в другом `Popper`
 
 ## [3.1.4] - 2019-03-13
 
 ### Added
 
-* Добавлено св-во `popperZIndex`, отвечает за `z-index` выпадающего окна
+- Добавлено св-во `popperZIndex`, отвечает за `z-index` выпадающего окна
 
 ## [3.1.3] - 2019-02-20
 
 ### Fixed
 
-* Баг с отсутствием ререндера `Popper.Popper` при именении стилей popper.js
+- Баг с отсутствием ререндера `Popper.Popper` при именении стилей popper.js
 
 ## [3.1.2] - 2019-01-22
 
 ### Added
 
-* Экспорт `PortalProvider`
+- Экспорт `PortalProvider`
 
 ### Changed
 
-* Переименован props `disablePortalRender` -> `disablePortal`
+- Переименован props `disablePortalRender` -> `disablePortal`
 
 ## [3.1.1] - 2019-01-21
 
 ### Changed
 
-* Поднята версия зависимости @semcore/utils до 2.0.0
+- Поднята версия зависимости @semcore/utils до 2.0.0
 
 ## [3.1.0] - 2018-11-23
 
 ### Added
 
-* Добавлен autocomplete для IDE
+- Добавлен autocomplete для IDE
 
 ## [3.0.0] - 2018-11-01
 
 ### BREAK
 
-* переименован export компоненетов с `{ Manage, Reference, Popper }` на статичные default компонента
-* переименован компонент `Reference` в `Trigger`
-* удалено свойство `popperDisplayEvents` и его функционал
-* переименовано свойство `referenceDisplayEvents` в `displayEvents`
-* переименовано свойство `showTimeout` и `hideTimeout` в `displayTimeout.show` и `displayTimeout.hide`
+- переименован export компоненетов с `{ Manage, Reference, Popper }` на статичные default компонента
+- переименован компонент `Reference` в `Trigger`
+- удалено свойство `popperDisplayEvents` и его функционал
+- переименовано свойство `referenceDisplayEvents` в `displayEvents`
+- переименовано свойство `showTimeout` и `hideTimeout` в `displayTimeout.show` и `displayTimeout.hide`
 
 ## [2.0.0] - 2018-10-11
 
 ### BREAK
 
-* изменено возвращаемое значение с `ref, handlers, ...` на `getPopperProps`, `getArrowProps` и `getTriggerProps` для `Reference` и `Popper` компонентов
-* возможность изменить `default` значения свойств для `Manager`
-* возможность подменить контекст у всех компонентов
-* добавлен обязательное свойство `tag` компонент для `Reference`
-* переименован функциональный аргумент передаваемый в функцию рендера с `onVisibleChane` на `changeVisible`
+- изменено возвращаемое значение с `ref, handlers, ...` на `getPopperProps`, `getArrowProps` и `getTriggerProps` для `Reference` и `Popper` компонентов
+- возможность изменить `default` значения свойств для `Manager`
+- возможность подменить контекст у всех компонентов
+- добавлен обязательное свойство `tag` компонент для `Reference`
+- переименован функциональный аргумент передаваемый в функцию рендера с `onVisibleChane` на `changeVisible`
 
 ## [1.0.2] - 2018-09-27
 
 ### Changed
 
-* версию пакета `@semcore/utils`
+- версию пакета `@semcore/utils`
 
 ## [1.0.1] - 2018-09-27
 
 ### Added
 
-* зависимость в `package.json` от `@semcore/portal`
+- зависимость в `package.json` от `@semcore/portal`
 
 ## [1.0.0] - 2018-09-27
 
 ### Added
 
-* Initial release
+- Initial release

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -402,6 +402,7 @@ class Popper extends Component {
       popper: this.popper,
       focusableTriggerReturnFocusToRef: this.focusableTriggerReturnFocusToRef,
       disableEnforceFocus,
+      tabIndex: interaction === 'hover' ? -1 : 1,
     };
   }
 

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -17,7 +17,9 @@ import { Scale, animationContext } from '@semcore/animation';
 import { cssVariableEnhance } from '@semcore/utils/lib/useCssVariable';
 import { useContextTheme } from '@semcore/utils/lib/ThemeProvider';
 import { ScreenReaderOnly } from '@semcore/utils/lib/ScreenReaderOnly';
-import { useFocusSource } from '@semcore/utils/lib/enhances/keyboardFocusEnhance';
+import keyboardFocusEnhance, {
+  useFocusSource,
+} from '@semcore/utils/lib/enhances/keyboardFocusEnhance';
 
 import createPopper from './createPopper';
 
@@ -665,6 +667,8 @@ function PopperPopper(props) {
     </Portal>,
   );
 }
+
+PopperPopper.enhance = [keyboardFocusEnhance()];
 
 export default createComponent(Popper, {
   Trigger,

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -93,7 +93,7 @@ class Popper extends Component {
         ['onMouseEnter', 'onKeyboardFocus'],
         ['onMouseLeave', 'onBlur'],
       ],
-      popper: [['onMouseEnter'], ['onMouseLeave']],
+      popper: [['onMouseEnter', 'onFocusCapture'], ['onMouseLeave']],
     },
     focus: {
       trigger: [['onFocus'], ['onBlur']],
@@ -402,7 +402,6 @@ class Popper extends Component {
       popper: this.popper,
       focusableTriggerReturnFocusToRef: this.focusableTriggerReturnFocusToRef,
       disableEnforceFocus,
-      tabIndex: interaction === 'hover' ? -1 : 1,
     };
   }
 

--- a/semcore/popper/src/style/popper.shadow.css
+++ b/semcore/popper/src/style/popper.shadow.css
@@ -4,6 +4,14 @@ SPopper {
   color: var(--intergalactic-text-primary, #191b23);
 }
 
+SPopper[keyboardFocused]:focus:after {
+  position: absolute;
+  display: block;
+  content: '';
+  inset: 0;
+  box-shadow: var(--intergalactic-keyboard-focus, 0px 0px 0px 3px rgba(0, 143, 248, 0.3));
+}
+
 SFocusHint {
   display: none;
 }

--- a/semcore/utils/src/use/useFocusLock.ts
+++ b/semcore/utils/src/use/useFocusLock.ts
@@ -116,7 +116,8 @@ export const useFocusLock = (
     if (disabled) return;
     if (!canUseDOM()) return;
     if (!trapRef.current) return;
-    if (getFocusableIn(trapRef.current).length === 0) return;
+    const focusableChildren = [...trapRef.current.children].map(getFocusableIn).flat();
+    if (focusableChildren.length === 0) return;
 
     document.body.addEventListener('focusin', handleFocusIn);
     document.body.addEventListener('mousedown', handleMouseEvent);

--- a/website/docs/style/design-tokens/components/design-tokens.json
+++ b/website/docs/style/design-tokens/components/design-tokens.json
@@ -2084,6 +2084,7 @@
       "link",
       "modal",
       "pills",
+      "popper",
       "radio",
       "scroll-area",
       "side-panel",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Our poppers are focusable but default focus outline is hidden. It's ok for mouse users but not so well for keyboards users. I have added keyboard focus highlight to improve their UX.

## How has this been tested?

Only manually.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/31261408/234927046-a284d4d0-aa1f-4705-b4c0-f0ef2dec9fee.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
