### PR TITLE
[d3-chart] added `verticalWritingMode` for axis titles

### DIFF
--- a/semcore/core/CHANGELOG.md
+++ b/semcore/core/CHANGELOG.md
@@ -6,6 +6,12 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
+- Prop `locale` default value is provided for all Intergalactic components under this `I18nProvider`.
+
+## [1.14.11] - 2023-05-11
+
+### Changed
+
 - Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7]).
 
 ## [1.14.10] - 2023-05-04

--- a/semcore/core/src/index.tsx
+++ b/semcore/core/src/index.tsx
@@ -6,6 +6,8 @@ import { useForkRef } from '@semcore/utils/lib/ref';
 import useEnhancedEffect from '@semcore/utils/lib/use/useEnhancedEffect';
 // @ts-ignore
 import _assignProps from '@semcore/utils/lib/assignProps';
+// @ts-ignore
+import { i18nAppLocaleEnhance } from '@semcore/utils/lib/enhances/WithI18n';
 
 import { Component, PropsWithRenderFnChildren } from './Component';
 import register from './register';
@@ -335,6 +337,7 @@ function createComponent<ComponentProps, ChildComponentProps = {}, ContextType =
   }
   const Component = createComposeComponent(OriginComponent, context, [
     // @ts-ignore
+    i18nAppLocaleEnhance(),
     ...enhancements.map((f) => f(context, parents, createComponent, childComponents)),
     bindHandlerEnhancement(),
     childrenEnhancement(context, parents),

--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.14.9] - 2023-05-18
+
+### Changed
+
+- Improved support of `zh` and `ja` locales in vertical titles.
+
 ## [2.14.8] - 2023-05-12
 
 ### Fixed

--- a/semcore/d3-chart/src/Axis.jsx
+++ b/semcore/d3-chart/src/Axis.jsx
@@ -198,9 +198,10 @@ class AxisRoot extends Component {
   }
 
   getTitleProps() {
-    const { position } = this.asProps;
+    const { position, locale } = this.asProps;
     return {
       position: MAP_POSITION_REVERT[position],
+      verticalWritingMode: ['zh', 'ja'].includes(locale),
     };
   }
 
@@ -301,7 +302,7 @@ function Grid(props) {
 }
 
 function Title(props) {
-  const { Element: STitle, styles, scale, position, size, children } = props;
+  const { Element: STitle, styles, scale, position, size, children, verticalWritingMode } = props;
 
   const { x, y } = MAP_POSITION_TITlE[position](scale, size);
 
@@ -324,6 +325,7 @@ function Title(props) {
       position={position}
       className={sTitleStyles.className}
       style={sTitleStyles.style}
+      verticalWritingMode={verticalWritingMode}
       x={x}
       y={y}
     />,

--- a/semcore/d3-chart/src/Plot.jsx
+++ b/semcore/d3-chart/src/Plot.jsx
@@ -56,7 +56,7 @@ class PlotRoot extends Component {
   };
 
   setContext() {
-    const { scale, data, width, height } = this.asProps;
+    const { scale, data, width, height, locale } = this.asProps;
 
     const yScaleDomain = scale?.[1]?.domain?.();
     if (yScaleDomain?.length && data?.length) {
@@ -70,6 +70,7 @@ class PlotRoot extends Component {
       $rootProps: {
         size: [width, height],
         data: data,
+        locale,
         scale: scale,
         eventEmitter: this.eventEmitter,
         rootRef: this.rootRef,

--- a/semcore/d3-chart/src/style/axis.shadow.css
+++ b/semcore/d3-chart/src/style/axis.shadow.css
@@ -46,6 +46,11 @@ STitle[position='left'] {
   text-anchor: middle;
   alignment-baseline: middle;
 }
+STitle[position='right'][verticalWritingMode],
+STitle[position='left'][verticalWritingMode] {
+  writing-mode: vertical-rl;
+  transform: none;
+}
 
 STick[position='top'] {
   transform: translateY(-12px);

--- a/semcore/d3-chart/src/types/Axis.d.ts
+++ b/semcore/d3-chart/src/types/Axis.d.ts
@@ -41,6 +41,12 @@ export interface IAxisGridProps extends IContext {
 export interface IAxisTitleProps extends IContext {
   /** The position of the axis relative chart */
   position?: 'top' | 'right' | 'bottom' | 'left';
+
+  /** For vertical titles disables characters rotation while puts
+   * characters into the vertical column for better reading in some languages.
+   * @default true for `zh` and `ja` locales and false for all others.
+   */
+  verticalWritingMode?: boolean;
 }
 
 export interface IAxisTicksContext {

--- a/semcore/utils/src/enhances/WithI18n.tsx
+++ b/semcore/utils/src/enhances/WithI18n.tsx
@@ -67,5 +67,18 @@ const useI18n = (
   );
 };
 
+export const i18nAppLocaleEnhance = () => {
+  return {
+    wrapperProps: (props) => {
+      const { locale, ...other } = props;
+      const contextLocale = React.useContext(Context);
+      return {
+        ...other,
+        locale: locale ?? contextLocale,
+      };
+    },
+  };
+};
+
 export default createHoc(WithI18n);
 export { useI18n, I18nProvider, I18nConsumer };


### PR DESCRIPTION
## Motivation and Context

In d3 chart component I have added `verticalWritingMode` for vertical titles disables characters rotation while puts characters into the vertical column for better reading in some languages. It is enabled by default for `zh` and `ja` locales.

I have also improved our core – ensured that I18nProvideer provides locale prop for all Intergalactic components.

## How has this been tested?
Only manually, change is very simple.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
