### PR TITLE
[utils] all focusable components get `autoFocus` prop via `keyboardFocusEnhance`

### DIFF
--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.53.0] - 2023-05-25
+
+### Added
+
+- All focusable components get `autoFocus` prop via `keyboardFocusEnhance`.
+
 ## [3.52.0] - 2023-05-25
 
 ### Added

--- a/semcore/utils/src/enhances/keyboardFocusEnhance.tsx
+++ b/semcore/utils/src/enhances/keyboardFocusEnhance.tsx
@@ -4,6 +4,11 @@ import assignProps from '../assignProps';
 export interface IKeyboardFocusProps {
   /* Property responsible for displaying "keyboard" focus */
   keyboardFocused?: boolean;
+  /**
+   * Makes component to catch browser focus on component mount
+   * @default false
+   */
+  autoFocus?: boolean;
 }
 
 const focusSourceListeners = [];
@@ -49,21 +54,31 @@ export const useFocusSource = () => {
 
 const keyboardFocusEnhance = () => {
   return (props) => {
-    const { tabIndex = 0, disabled } = props;
+    const { tabIndex = 0, disabled, autoFocus } = props;
     const [keyboardFocused, setKeyboardFocused] = React.useState(false);
     const focusSourceRef = useFocusSource();
+    const ref = React.useRef(null);
 
-    const handlerFocus = React.useCallback(() => {
-      if (focusSourceRef.current !== 'keyboard') return;
+    const handlerFocus = React.useCallback((event: React.FocusEvent) => {
+      if (event.isTrusted === true) {
+        if (focusSourceRef.current !== 'keyboard') return;
+      }
       setKeyboardFocused(true);
     }, []);
     const handlerBlur = React.useCallback(() => setKeyboardFocused(false), []);
+    React.useEffect(() => {
+      if (autoFocus) {
+        ref.current?.focus();
+        setKeyboardFocused(true);
+      }
+    }, [autoFocus]);
 
     return assignProps(props, {
       tabIndex: disabled ? -1 : tabIndex,
       keyboardFocused,
       onFocus: handlerFocus,
       onBlur: handlerBlur,
+      ref,
     });
   };
 };


### PR DESCRIPTION
## Motivation and Context

Currently it's impossible to make autofocus that highlights element with the focus ring. If it's made via `useEffect`, no ring is visible because keyboardFocusEnhance in 99% cases consider it as non keyboard triggered.

## How has this been tested?

Manual testing.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
