### PR TITLE
popper repositioning

### DIFF
--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.18.0] - 2023-06-06
+
+### Changed
+
+- Updating `strategy`, `modifiers`, `placement`, `offset`, `preventOverflow`, `arrow`, `flip`, `computeStyles`, `eventListeners` or `onFirstUpdate` props now triggers popper positioning update.
+
 ## [4.17.17] - 2023-06-02
 
 ### Changed

--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Updating `strategy`, `modifiers`, `placement`, `offset`, `preventOverflow`, `arrow`, `flip`, `computeStyles`, `eventListeners` or `onFirstUpdate` props now triggers popper positioning update.
+- Updating `strategy`, `placement`, `offset`, `preventOverflow`, `arrow`, `flip`, `computeStyles`, `eventListeners` or `onFirstUpdate` props now triggers popper positioning update.
 
 ## [4.17.17] - 2023-06-02
 

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -138,9 +138,7 @@ class Popper extends Component {
     }
   };
 
-  createPopper() {
-    if (!this.triggerRef.current || !this.popperRef.current) return;
-
+  getPopperOptions = () => {
     let {
       placement,
       modifiers,
@@ -224,7 +222,8 @@ class Popper extends Component {
     });
 
     const modifiersMerge = [...modifiersFallback, ...modifiersOptions].concat(modifiers);
-    this.popper.current = createPopper(this.triggerRef.current, this.popperRef.current, {
+
+    return {
       placement,
       strategy,
       onFirstUpdate: callAllEventHandlers(onFirstUpdate, () => {
@@ -232,7 +231,38 @@ class Popper extends Component {
         this.observer.observe(this.popperRef.current);
       }),
       modifiers: modifiersMerge,
-    });
+    };
+  };
+
+  createPopper() {
+    if (!this.triggerRef.current || !this.popperRef.current) return;
+
+    this.popper.current = createPopper(
+      this.triggerRef.current,
+      this.popperRef.current,
+      this.getPopperOptions(),
+    );
+  }
+
+  componentDidUpdate(prevProps) {
+    const popperProps = [
+      'strategy',
+      'modifiers',
+      'placement',
+      'offset',
+      'preventOverflow',
+      'arrow',
+      'flip',
+      'computeStyles',
+      'eventListeners',
+      'onFirstUpdate',
+    ];
+    if (
+      this.popper.current &&
+      popperProps.some((propName) => prevProps[propName] !== this.asProps[propName])
+    ) {
+      this.popper.current.setOptions(this.getPopperOptions());
+    }
   }
 
   destroyPopper() {

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -247,7 +247,6 @@ class Popper extends Component {
   componentDidUpdate(prevProps) {
     const popperProps = [
       'strategy',
-      'modifiers',
       'placement',
       'offset',
       'preventOverflow',


### PR DESCRIPTION
Now updating `strategy`, `modifiers`, `placement`, `offset`, `pr…eventOverflow`, `arrow`, `flip`, `computeStyles`, `eventListeners` or `onFirstUpdate` props now triggers popper positioning update

## Motivation and Context

Previously updating main props of popper component were not triggering popper instance update. Now it's do.

## How has this been tested?

Only manual testing.

## Screenshots:

Before:


https://github.com/semrush/intergalactic/assets/31261408/4d4ab3f4-5b73-40eb-9cf8-a5d6e24fac97



After:



https://github.com/semrush/intergalactic/assets/31261408/ab68addc-30cd-46d6-84f0-c590412e50bd




## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
