### PR TITLE
[utils] fixed defaults event handlers calling when same, non-function handler provided

### DIFF
--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -6,6 +6,12 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Fixed
 
+- Fixed defaults event handlers calling when same, non-function handler provided.
+
+## [3.53.1] - 2023-06-07
+
+### Fixed
+
 - Fixed color SSR hydration.
 
 ## [3.53.0] - 2023-05-25

--- a/semcore/utils/src/assignProps.ts
+++ b/semcore/utils/src/assignProps.ts
@@ -25,13 +25,14 @@ export function assignHandlers(props, source) {
 
 function assignHandlersInner(props, source) {
   return Object.keys(source).reduce((proxySource, propName) => {
-    if (
-      propName !== 'ref' &&
-      typeof source[propName] === 'function' &&
-      typeof props[propName] === 'function' &&
-      propName.startsWith('on')
-    ) {
-      proxySource[propName] = callAllEventHandlers(props[propName], source[propName]);
+    if (propName !== 'ref' && propName.startsWith('on')) {
+      if (typeof source[propName] === 'function' && typeof props[propName] === 'function') {
+        proxySource[propName] = callAllEventHandlers(props[propName], source[propName]);
+      } else if (typeof source[propName] === 'function') {
+        proxySource[propName] = source[propName];
+      } else if (typeof props[propName] === 'function') {
+        proxySource[propName] = props[propName];
+      }
     }
     return proxySource;
   }, {});


### PR DESCRIPTION
## Motivation and Context

All props that is set on root component of any component may be redefined by user. That is made by `assignProps` function that is being added to every component by our babel plugins.

When assigning `onX` props, it is being merged in a special way: assigner wraps all handlers, both set in component and provided by users into a new function that calls every handler (from user to component internal) until some of them returns `false` value.

The bug was found in the wrapping process – if user provided handler is not a function, not handlers are going to be wrapped so user might accidentally break a component without knowing it. 

I've changed the process – if some of the handler is not a function but another one is – the one that is function is used without any wrapping.

## How has this been tested?

The change is very clear and doesn't require any special testing. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
