### PR TITLE
[select] `InputSearch` default `size`

### DIFF
--- a/semcore/select/CHANGELOG.md
+++ b/semcore/select/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.10.1] - 2023-06-26
+
+### Fixed
+
+- Providing explicit `size={undefined}` to `Select` with `InputSearch` was causing breaking of page rendering. 
+
 ## [3.10.0] - 2023-06-23
 
 ### Changed

--- a/semcore/select/src/InputSearch.jsx
+++ b/semcore/select/src/InputSearch.jsx
@@ -9,7 +9,7 @@ import { localizedMessages } from './translations/__intergalactic-dynamic-locale
 
 import style from './style/input-search.shadow.css';
 
-const MAP_SIZE_TO_ICON = {
+const sizeToIcon = {
   m: [SearchM, CloseM],
   l: [SearchM, CloseM],
 };
@@ -42,10 +42,10 @@ class InputSearch extends Component {
     const SInputSearch = Input;
     const SClose = Input.Addon;
     const { size, value, styles, getI18nText } = this.asProps;
-    const finalSize = size || this.context.size;
+    const finalSize = size || this.context.size || 'm';
     const hideClose = !value;
-    const IconClose = MAP_SIZE_TO_ICON[finalSize][1];
-    const IconSearch = MAP_SIZE_TO_ICON[finalSize][0];
+    const IconClose = sizeToIcon[finalSize][1];
+    const IconSearch = sizeToIcon[finalSize][0];
 
     return sstyled(styles)(
       <SInputSearch size={finalSize} styles={styles}>


### PR DESCRIPTION
## Motivation and Context

If `Select` gets explicit `undefined` it overrides default `m` value. In combination with `InputSearch` it breaks rendering.

As far `| undefined` is union of all optional types in Typescript, out component should at least do not break rendering  

## How has this been tested?

Manual testing.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [x] I have added new unit tests on added of fixed functionality.
