### PR TITLE
[textarea] `minRows` now works without `maxRows`

### DIFF
--- a/semcore/textarea/CHANGELOG.md
+++ b/semcore/textarea/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
-## [4.3.33] - 2023-06-30
+## [4.4.0] - 2023-07-04
+
+### Changed
+
+- Textarea `minRows` now works without `maxRows`. 
 
 ## [4.3.32] - 2023-06-27
 

--- a/semcore/textarea/src/Textarea.jsx
+++ b/semcore/textarea/src/Textarea.jsx
@@ -53,7 +53,7 @@ class Textarea extends Component {
   calculateRows = rafTrottle((disabledScrolling = false) => {
     const { node } = this;
     const { rows, minRows, maxRows } = this.asProps;
-    if (!node || !canUseDOM() || rows || !maxRows) return;
+    if (!node || !canUseDOM() || rows || !(minRows || maxRows)) return;
 
     const lh = cssToIntDefault(getComputedStyle(node).getPropertyValue('line-height'));
     const previousRows = node.rows;
@@ -72,7 +72,11 @@ class Textarea extends Component {
     if (computed >= maxRows) {
       node.rows = maxRows;
     }
-    if (computed >= minRows && computed <= maxRows) {
+    if (
+      (minRows !== undefined || maxRows !== undefined) &&
+      (minRows === undefined || computed >= minRows) &&
+      (maxRows === undefined || computed <= maxRows)
+    ) {
       node.rows = computed;
     }
 

--- a/semcore/ui/CHANGELOG.md
+++ b/semcore/ui/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [14.10.0] - 2023-07-04
+
+### @semcore/textarea
+
+- **Changed** Textarea `minRows` now works without `maxRows`. 
+
 ## [14.9.0] - 2023-06-29
 
 ### @semcore/data-table

--- a/semcore/ui/package.json
+++ b/semcore/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semcore/ui",
-  "version": "14.9.0",
+  "version": "14.10.0",
   "license": "MIT",
   "module": "./index.mjs",
   "sideEffects": false,

--- a/tools/continuous-delivery/src/fetchFromNpm.ts
+++ b/tools/continuous-delivery/src/fetchFromNpm.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import pLimit from 'p-limit';
+import semver from 'semver';
 
 type PackageNpmRegistry = {
   dependencies: {
@@ -54,10 +55,14 @@ export const fetchFromNpm = async (filter?: string[]) => {
           const npmResponse = await axios.get<ResponseNpmRegistry>(
             `https://registry.npmjs.org/${name}`,
           );
-          const lastVersions = npmResponse.data['dist-tags'].latest;
+          const versions = Object.keys(npmResponse.data.versions);
+          const sortedVersions = versions
+            .filter((version) => !version.includes('-'))
+            .sort(semver.compare);
+          const lastVersion = sortedVersions[sortedVersions.length - 1];
           currentVersions[name] = {
-            version: lastVersions,
-            dependencies: npmResponse.data.versions[lastVersions].dependencies,
+            version: lastVersion,
+            dependencies: npmResponse.data.versions[lastVersion].dependencies,
           };
         }),
     ),


### PR DESCRIPTION
## Motivation and Context

We had edge case that textarea component wasn't resizing if `minRows` prop provided without `maxRows`.

I have added much more complex condition that now handles resizing well even in the case above..

## How has this been tested?

Only manual testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
