### PR TITLE
Support OL's attributes `start`, `reversed`

### DIFF
--- a/semcore/format-text/src/style/format-text.shadow.css
+++ b/semcore/format-text/src/style/format-text.shadow.css
@@ -88,11 +88,8 @@ SFormatText {
   }
 
   & ol {
-    counter-reset: item 0;
-
     & li:before {
-      counter-increment: item;
-      content: counters(item, '.');
+      content: counters(list-item, '.');
     }
   }
 


### PR DESCRIPTION
Use built-in counter in OLs

## Motivation and Context

Attributes `start`, `reversed` set up a built-in counter named `list-item`. Using this counter allows such customization.

## How has this been tested?

    ```
    <FormatText>
        <ol start="3">
            <li> this item should have a "marker" 3 </li>
        </ol>
    </FormatText/>
    ```

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
