### PR TITLE
[global] supported `tag={React.Fragment}`

### DIFF
--- a/semcore/button/src/Button.jsx
+++ b/semcore/button/src/Button.jsx
@@ -43,7 +43,7 @@ class RootButton extends Component {
   componentDidMount() {
     if (process.env.NODE_ENV !== 'production') {
       logger.warn(
-        !hasLabels(this.containerRef.current),
+        this.containerRef.current && !hasLabels(this.containerRef.current),
         `'aria-label' or 'aria-labelledby' are required props for buttons without text content`,
         this.asProps['data-ui-name'] || Button.displayName,
       );

--- a/semcore/core/CHANGELOG.md
+++ b/semcore/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.1.0] - 2023-08-01
+
+### Change
+
+- Supported `tag={React.Fragment}` for all root components.
+
 ## [2.0.0] - 2023-06-20
 
 ### Break

--- a/semcore/core/src/enhancement/Root.tsx
+++ b/semcore/core/src/enhancement/Root.tsx
@@ -46,6 +46,8 @@ function createRootRender() {
     if (!Tag) {
       throw new Error('`render` prop of Root is not provided');
     }
+    if (Tag === React.Fragment) return <React.Fragment>{other.children}</React.Fragment>;
+
     return <Tag {...other} />;
   });
   // @ts-ignore

--- a/semcore/flex-box/CHANGELOG.md
+++ b/semcore/flex-box/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.1.0] - 2023-08-01
+
+### Change
+
+- Supported `tag={React.Fragment}` for all components based on `Flex` or `Box`.
+
 ## [5.0.0] - 2023-07-17
 
 ### Break

--- a/semcore/flex-box/src/Box/useBox.tsx
+++ b/semcore/flex-box/src/Box/useBox.tsx
@@ -288,6 +288,8 @@ export default function useBox<T extends BoxProps>(
 
   const styles = sstyled(style);
 
+  if (Tag === React.Fragment) return [React.Fragment, { children: props.children }];
+
   return [
     Tag,
     {

--- a/semcore/flex-box/src/Flex/useFlex.tsx
+++ b/semcore/flex-box/src/Flex/useFlex.tsx
@@ -121,6 +121,8 @@ export default function useFlex<T extends FlexProps>(
 
   const styles = sstyled(style);
 
+  if (Tag === React.Fragment) return [React.Fragment, { children: props.children }];
+
   return [
     Tag,
     {

--- a/semcore/icon/src/Icon.jsx
+++ b/semcore/icon/src/Icon.jsx
@@ -54,7 +54,7 @@ function Icon(props, ref) {
     if (!interactive) return;
     if (process.env.NODE_ENV !== 'production') {
       logger.warn(
-        !hasLabels(labelCheckRef.current),
+        labelCheckRef.current && !hasLabels(labelCheckRef.current),
         `'aria-label' or 'aria-labelledby' are required props for interactive icons`,
         props['data-ui-name'] || Icon.displayName,
       );

--- a/semcore/link/src/Link.jsx
+++ b/semcore/link/src/Link.jsx
@@ -22,7 +22,7 @@ class RootLink extends Component {
   componentDidMount() {
     if (process.env.NODE_ENV !== 'production') {
       logger.warn(
-        !hasLabels(this.containerRef.current),
+        this.containerRef.current && !hasLabels(this.containerRef.current),
         `'aria-label' or 'aria-labelledby' are required props for links without text content`,
         this.asProps['data-ui-name'] || RootLink.displayName,
       );


### PR DESCRIPTION

## Motivation and Context

Sometimes it might very helpful to pass React.Fragment as a component tag. Sure, it will disable most of components functionality but it seems to a an important escape hatch. Currently it works but with React warnings (e.g. "Invalid prop `className` supplied to `React.Fragment`").

## How has this been tested?

All existing tests should pass well.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
