### PR TITLE
Feature/add monospace style for Text and FormatText

### DIFF
--- a/semcore/format-text/CHANGELOG.md
+++ b/semcore/format-text/CHANGELOG.md
@@ -4,87 +4,87 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ## [4.7.0] - 2023-09-06
 
-### Added
+### Changed
 
-* `code` tag with the default styles to `FormatText` component.
+- Specified font for `code` and `pre` tags inside of `FormatText` component.
 
 ## [4.6.3] - 2023-09-12
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
+- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
 
 ## [4.6.2] - 2023-09-08
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
 
 ## [4.6.1] - 2023-09-05
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
+- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
 
 ## [4.6.0] - 2023-09-04
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
+- Version preminor update due to children dependencies update (`@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
 
 ## [4.5.0] - 2023-08-28
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
 
 ## [4.4.1] - 2023-08-24
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
 
 ## [4.4.0] - 2023-08-23
 
 ### Changed
 
-* Disable forced lists counter reset if `start`, `reversed` or `type` attributes are set on corresponding `ol` or `ul` tags.
+- Disable forced lists counter reset if `start`, `reversed` or `type` attributes are set on corresponding `ol` or `ul` tags.
 
 ## [4.3.1] - 2023-08-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
+- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
 
 ## [4.3.0] - 2023-08-18
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
 
 ## [4.2.1] - 2023-08-16
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/core` [2.2.0 ~> 2.2.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/core` [2.2.0 ~> 2.2.1]).
 
 ## [4.2.0] - 2023-08-07
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.0.0 ~> 4.1.0], `@semcore/flex-box` [5.1.0 ~> 5.2.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.0.0 ~> 4.1.0], `@semcore/flex-box` [5.1.0 ~> 5.2.0]).
 
 ## [4.1.0] - 2023-08-01
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/flex-box` [5.0.0 ~> 5.1.0]).
+- Version minor update due to children dependencies update (`@semcore/flex-box` [5.0.0 ~> 5.1.0]).
 
 ## [4.0.0] - 2023-07-17
 
 ### Break
 
-* Strict, backward incompatible typings.
+- Strict, backward incompatible typings.
 
 ## [3.2.35] - 2023-06-30
 
@@ -92,67 +92,67 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.4 ~> 3.54.0], `@semcore/flex-box` [4.7.31 ~> 4.7.32]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.4 ~> 3.54.0], `@semcore/flex-box` [4.7.31 ~> 4.7.32]).
 
 ## [3.2.33] - 2023-06-14
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.3 ~> 3.53.4], `@semcore/flex-box` [4.7.30 ~> 4.7.31]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.3 ~> 3.53.4], `@semcore/flex-box` [4.7.30 ~> 4.7.31]).
 
 ## [3.2.32] - 2023-06-12
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.2 ~> 3.53.3], `@semcore/flex-box` [4.7.29 ~> 4.7.30]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.2 ~> 3.53.3], `@semcore/flex-box` [4.7.29 ~> 4.7.30]).
 
 ## [3.2.31] - 2023-06-09
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.1 ~> 3.53.2], `@semcore/flex-box` [4.7.28 ~> 4.7.29]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.1 ~> 3.53.2], `@semcore/flex-box` [4.7.28 ~> 4.7.29]).
 
 ## [3.2.30] - 2023-06-07
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.0 ~> 3.53.1], `@semcore/flex-box` [4.7.27 ~> 4.7.28]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.0 ~> 3.53.1], `@semcore/flex-box` [4.7.27 ~> 4.7.28]).
 
 ## [3.2.29] - 2023-05-31
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.52.0 ~> 3.53.0], `@semcore/flex-box` [4.7.26 ~> 4.7.27]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.52.0 ~> 3.53.0], `@semcore/flex-box` [4.7.26 ~> 4.7.27]).
 
 ## [3.2.28] - 2023-05-25
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.51.1 ~> 3.52.0], `@semcore/flex-box` [4.7.25 ~> 4.7.26]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.51.1 ~> 3.52.0], `@semcore/flex-box` [4.7.25 ~> 4.7.26]).
 
 ## [3.2.27] - 2023-05-24
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.51.0 ~> 3.51.1], `@semcore/flex-box` [4.7.24 ~> 4.7.25]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.51.0 ~> 3.51.1], `@semcore/flex-box` [4.7.24 ~> 4.7.25]).
 
 ## [3.2.26] - 2023-05-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.7 ~> 3.51.0], `@semcore/flex-box` [4.7.23 ~> 4.7.24]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.7 ~> 3.51.0], `@semcore/flex-box` [4.7.23 ~> 4.7.24]).
 
 ## [3.2.25] - 2023-05-11
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7], `@semcore/flex-box` [4.7.22 ~> 4.7.23]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7], `@semcore/flex-box` [4.7.22 ~> 4.7.23]).
 
 ## [3.2.24] - 2023-05-04
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.5 ~> 3.50.6], `@semcore/flex-box` [4.7.21 ~> 4.7.22]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.5 ~> 3.50.6], `@semcore/flex-box` [4.7.21 ~> 4.7.22]).
 
 ## [3.2.22] - 2023-04-24
 
@@ -160,7 +160,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.0 ~> 3.50.3], `@semcore/flex-box` [4.7.18 ~> 4.7.19]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.0 ~> 3.50.3], `@semcore/flex-box` [4.7.18 ~> 4.7.19]).
 
 ## [3.2.10] - 2023-02-09
 
@@ -168,7 +168,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.45.0 ~> 3.46.0], `@semcore/flex-box` [4.7.6 ~> 4.7.7]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.45.0 ~> 3.46.0], `@semcore/flex-box` [4.7.6 ~> 4.7.7]).
 
 ## [3.2.7] - 2023-01-10
 
@@ -176,202 +176,202 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.44.1 ~> 3.44.2], `@semcore/flex-box` [4.7.3 ~> 4.7.4]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.44.1 ~> 3.44.2], `@semcore/flex-box` [4.7.3 ~> 4.7.4]).
 
 ## [3.2.5] - 2023-01-03
 
 ### Fixed
 
-* Fixed css variable design tokens.
+- Fixed css variable design tokens.
 
 ## [3.2.4] - 2022-12-21
 
 ### Fixed
 
-* Fixed underline for links from the design system.
+- Fixed underline for links from the design system.
 
 ## [3.2.3] - 2022-12-19
 
 ### Fixed
 
-* Fixed syntax css.
+- Fixed syntax css.
 
 ## [3.2.2] - 2022-12-16
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.43.0 ~> 3.44.0], `@semcore/flex-box` [4.7.1 ~> 4.7.2]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.43.0 ~> 3.44.0], `@semcore/flex-box` [4.7.1 ~> 4.7.2]).
 
 ## [3.2.1] - 2022-12-13
 
 ### Changed
 
-* Added `react-dom` to peer dependencies.
+- Added `react-dom` to peer dependencies.
 
 ## [3.2.0] - 2022-12-12
 
 ### Added
 
-* Design tokens based theming.
+- Design tokens based theming.
 
 ## [3.1.5] - 2022-11-30
 
 ### Fixed
 
-* Fixed showing types in autocomplete IDE.
+- Fixed showing types in autocomplete IDE.
 
 ## [3.1.4] - 2022-11-30
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.40.0 ~> 3.41.0], `@semcore/flex-box` [4.6.3 ~> 4.6.4]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.40.0 ~> 3.41.0], `@semcore/flex-box` [4.6.3 ~> 4.6.4]).
 
 ## [3.1.0] - 2022-10-10
 
 ### Changed
 
-* Added support for React 18 🔥
+- Added support for React 18 🔥
 
 ## [3.0.10] - 2022-10-04
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.37.1 ~> 3.37.2], `@semcore/flex-box` [4.5.11 ~> 4.5.12]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.37.1 ~> 3.37.2], `@semcore/flex-box` [4.5.11 ~> 4.5.12]).
 
 ## [3.0.0] - 2022-05-17
 
 ### BREAK
 
-* Updated styles according to the library redesign policy.
-* Changed sizes from m/l/xl to s/m/l
+- Updated styles according to the library redesign policy.
+- Changed sizes from m/l/xl to s/m/l
 
 ## [2.3.1] - 2022-03-14
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.31.2 ~> 3.31.2], `@semcore/flex-box` [4.5.0 ~> 4.5.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.31.2 ~> 3.31.2], `@semcore/flex-box` [4.5.0 ~> 4.5.1]).
 
 ## [2.3.0] - 2021-03-04
 
 ### Added
 
-* Disabled animation if reduce motion is preferred.
+- Disabled animation if reduce motion is preferred.
 
 ## [2.2.2] - 2022-02-24
 
 ### Added
 
-* Added repository field to package.json file.
+- Added repository field to package.json file.
 
 ## [2.2.1] - 2021-8-26
 
 ### Changed
 
-* Add 'sideEffect=false' for more optimal build via webpack
+- Add 'sideEffect=false' for more optimal build via webpack
 
 ## [2.2.0] - 2021-04-26
 
 ### Changed
 
-* Version of dependence `@semcore/core` has been changed to `1.11`.
-* Improved performance. Removed one component wrapper.
-* The style processing system has been changed.
-* Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
+- Version of dependence `@semcore/core` has been changed to `1.11`.
+- Improved performance. Removed one component wrapper.
+- The style processing system has been changed.
+- Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
 
 ## [2.1.1] - 2021-04-16
 
 ### Changed
 
-* Resized bullet points in `li`
+- Resized bullet points in `li`
 
 ## [2.1.0] - 2020-12-17
 
 ### Added
 
-* Added supported react@17.
+- Added supported react@17.
 
 ## [2.0.3] - 2020-10-29
 
 ### Fixed
 
-* Added the placeholder for ID style tag to improve collision protection.
+- Added the placeholder for ID style tag to improve collision protection.
 
 ## [2.0.2] - 2020-09-08
 
 ### Fixed
 
-* Fixed possible styles collisions between components with different versions, but same styles
+- Fixed possible styles collisions between components with different versions, but same styles
 
 ## [2.0.1] - 2020-06-22
 
 ### Fixed
 
-* Убрано подчеркивание у abbr при наведении.
+- Убрано подчеркивание у abbr при наведении.
 
 ## [2.0.0] - 2020-04-20
 
 ### BREAK
 
-* Изменения описаны в [migration guide](/internal/migration-guide)
+- Изменения описаны в [migration guide](/internal/migration-guide)
 
 ### Changed
 
-* Увеличен отступ параграфов для размера `m` c `8px` до `18px`
-* Увеличен отступ параграфов для размера `l` c `12px` до `20px`
-* Увеличен отступ параграфов для размера `xl` c `16px` до `24px`
-* Изменился цвет по ховеру ссылки, c 16% на 12%
-* Отсутпы для параграфов при размере `m` увеличены до `18px`
-* Отсутпы для параграфов при размере `l` увеличены до `20px`
-* Отсутпы для параграфов при размере `xl` увеличены до `24px`
+- Увеличен отступ параграфов для размера `m` c `8px` до `18px`
+- Увеличен отступ параграфов для размера `l` c `12px` до `20px`
+- Увеличен отступ параграфов для размера `xl` c `16px` до `24px`
+- Изменился цвет по ховеру ссылки, c 16% на 12%
+- Отсутпы для параграфов при размере `m` увеличены до `18px`
+- Отсутпы для параграфов при размере `l` увеличены до `20px`
+- Отсутпы для параграфов при размере `xl` увеличены до `24px`
 
 ## [1.2.1] - 2019-12-17
 
 ### Fixed
 
-* Исправлен транспайл цветовых переменных для стилей без префиксов (build.css)
+- Исправлен транспайл цветовых переменных для стилей без префиксов (build.css)
 
 ## [1.2.0] - 2019-12-12
 
 ### Added
 
-* Появилась возможность добавления различных стилистических тем через css переменные
-* Появилась возможность оптицонально подключать адаптивноссть
-* Появилась возможность изолировать стили даже в пределах одной страницы
+- Появилась возможность добавления различных стилистических тем через css переменные
+- Появилась возможность оптицонально подключать адаптивноссть
+- Появилась возможность изолировать стили даже в пределах одной страницы
 
 ### Changed
 
-* Изменен алгоритм вставки стилей в head
+- Изменен алгоритм вставки стилей в head
 
 ### Removed
 
-* Убраны относительные единицы измерения(rem), которые использовались для адаптивности
+- Убраны относительные единицы измерения(rem), которые использовались для адаптивности
 
 ## [1.1.0] - 2019-11-14
 
 ### Added
 
-* Добавлена адаптивность на маленьких экранах(<768px)
+- Добавлена адаптивность на маленьких экранах(<768px)
 
 ## [1.0.3] - 2019-09-30
 
 ### Changed
 
-* Нужные зависимости перенесены в `utils`, размер должен стать меньше
+- Нужные зависимости перенесены в `utils`, размер должен стать меньше
 
 ## [1.0.2] - 2019-07-31
 
 ### Fixed
 
-* Исправлена сборка для рендера css на сервере
+- Исправлена сборка для рендера css на сервере
 
 ## [1.0.1] - 2019-05-07
 
 ### Fixed
 
-* Свойство `size` помечано как не обязательное
+- Свойство `size` помечано как не обязательное
 
 ## [1.0.0] - 2019-05-07
 
 ### Added
 
-* Initial release
+- Initial release

--- a/semcore/format-text/CHANGELOG.md
+++ b/semcore/format-text/CHANGELOG.md
@@ -2,83 +2,89 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.7.0] - 2023-09-06
+
+### Added
+
+* `code` tag with the default styles to `FormatText` component.
+
 ## [4.6.3] - 2023-09-12
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
+* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
 
 ## [4.6.2] - 2023-09-08
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
+* Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
 
 ## [4.6.1] - 2023-09-05
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
+* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
 
 ## [4.6.0] - 2023-09-04
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
+* Version preminor update due to children dependencies update (`@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
 
 ## [4.5.0] - 2023-08-28
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
+* Version preminor update due to children dependencies update (`@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
 
 ## [4.4.1] - 2023-08-24
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
+* Version prepatch update due to children dependencies update (`@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
 
 ## [4.4.0] - 2023-08-23
 
 ### Changed
 
-- Disable forced lists counter reset if `start`, `reversed` or `type` attributes are set on corresponding `ol` or `ul` tags.
+* Disable forced lists counter reset if `start`, `reversed` or `type` attributes are set on corresponding `ol` or `ul` tags.
 
 ## [4.3.1] - 2023-08-21
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
+* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
 
 ## [4.3.0] - 2023-08-18
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
+* Version preminor update due to children dependencies update (`@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
 
 ## [4.2.1] - 2023-08-16
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/core` [2.2.0 ~> 2.2.1]).
+* Version prepatch update due to children dependencies update (`@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/core` [2.2.0 ~> 2.2.1]).
 
 ## [4.2.0] - 2023-08-07
 
 ### Changed
 
-- Version minor update due to children dependencies update (`@semcore/utils` [4.0.0 ~> 4.1.0], `@semcore/flex-box` [5.1.0 ~> 5.2.0]).
+* Version minor update due to children dependencies update (`@semcore/utils` [4.0.0 ~> 4.1.0], `@semcore/flex-box` [5.1.0 ~> 5.2.0]).
 
 ## [4.1.0] - 2023-08-01
 
 ### Changed
 
-- Version minor update due to children dependencies update (`@semcore/flex-box` [5.0.0 ~> 5.1.0]).
+* Version minor update due to children dependencies update (`@semcore/flex-box` [5.0.0 ~> 5.1.0]).
 
 ## [4.0.0] - 2023-07-17
 
 ### Break
 
-- Strict, backward incompatible typings.
+* Strict, backward incompatible typings.
 
 ## [3.2.35] - 2023-06-30
 
@@ -86,67 +92,67 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.53.4 ~> 3.54.0], `@semcore/flex-box` [4.7.31 ~> 4.7.32]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.53.4 ~> 3.54.0], `@semcore/flex-box` [4.7.31 ~> 4.7.32]).
 
 ## [3.2.33] - 2023-06-14
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.53.3 ~> 3.53.4], `@semcore/flex-box` [4.7.30 ~> 4.7.31]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.53.3 ~> 3.53.4], `@semcore/flex-box` [4.7.30 ~> 4.7.31]).
 
 ## [3.2.32] - 2023-06-12
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.53.2 ~> 3.53.3], `@semcore/flex-box` [4.7.29 ~> 4.7.30]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.53.2 ~> 3.53.3], `@semcore/flex-box` [4.7.29 ~> 4.7.30]).
 
 ## [3.2.31] - 2023-06-09
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.53.1 ~> 3.53.2], `@semcore/flex-box` [4.7.28 ~> 4.7.29]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.53.1 ~> 3.53.2], `@semcore/flex-box` [4.7.28 ~> 4.7.29]).
 
 ## [3.2.30] - 2023-06-07
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.53.0 ~> 3.53.1], `@semcore/flex-box` [4.7.27 ~> 4.7.28]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.53.0 ~> 3.53.1], `@semcore/flex-box` [4.7.27 ~> 4.7.28]).
 
 ## [3.2.29] - 2023-05-31
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.52.0 ~> 3.53.0], `@semcore/flex-box` [4.7.26 ~> 4.7.27]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.52.0 ~> 3.53.0], `@semcore/flex-box` [4.7.26 ~> 4.7.27]).
 
 ## [3.2.28] - 2023-05-25
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.51.1 ~> 3.52.0], `@semcore/flex-box` [4.7.25 ~> 4.7.26]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.51.1 ~> 3.52.0], `@semcore/flex-box` [4.7.25 ~> 4.7.26]).
 
 ## [3.2.27] - 2023-05-24
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.51.0 ~> 3.51.1], `@semcore/flex-box` [4.7.24 ~> 4.7.25]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.51.0 ~> 3.51.1], `@semcore/flex-box` [4.7.24 ~> 4.7.25]).
 
 ## [3.2.26] - 2023-05-22
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.50.7 ~> 3.51.0], `@semcore/flex-box` [4.7.23 ~> 4.7.24]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.50.7 ~> 3.51.0], `@semcore/flex-box` [4.7.23 ~> 4.7.24]).
 
 ## [3.2.25] - 2023-05-11
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7], `@semcore/flex-box` [4.7.22 ~> 4.7.23]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7], `@semcore/flex-box` [4.7.22 ~> 4.7.23]).
 
 ## [3.2.24] - 2023-05-04
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.50.5 ~> 3.50.6], `@semcore/flex-box` [4.7.21 ~> 4.7.22]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.50.5 ~> 3.50.6], `@semcore/flex-box` [4.7.21 ~> 4.7.22]).
 
 ## [3.2.22] - 2023-04-24
 
@@ -154,7 +160,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.50.0 ~> 3.50.3], `@semcore/flex-box` [4.7.18 ~> 4.7.19]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.50.0 ~> 3.50.3], `@semcore/flex-box` [4.7.18 ~> 4.7.19]).
 
 ## [3.2.10] - 2023-02-09
 
@@ -162,7 +168,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.45.0 ~> 3.46.0], `@semcore/flex-box` [4.7.6 ~> 4.7.7]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.45.0 ~> 3.46.0], `@semcore/flex-box` [4.7.6 ~> 4.7.7]).
 
 ## [3.2.7] - 2023-01-10
 
@@ -170,202 +176,202 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.44.1 ~> 3.44.2], `@semcore/flex-box` [4.7.3 ~> 4.7.4]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.44.1 ~> 3.44.2], `@semcore/flex-box` [4.7.3 ~> 4.7.4]).
 
 ## [3.2.5] - 2023-01-03
 
 ### Fixed
 
-- Fixed css variable design tokens.
+* Fixed css variable design tokens.
 
 ## [3.2.4] - 2022-12-21
 
 ### Fixed
 
-- Fixed underline for links from the design system.
+* Fixed underline for links from the design system.
 
 ## [3.2.3] - 2022-12-19
 
 ### Fixed
 
-- Fixed syntax css.
+* Fixed syntax css.
 
 ## [3.2.2] - 2022-12-16
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.43.0 ~> 3.44.0], `@semcore/flex-box` [4.7.1 ~> 4.7.2]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.43.0 ~> 3.44.0], `@semcore/flex-box` [4.7.1 ~> 4.7.2]).
 
 ## [3.2.1] - 2022-12-13
 
 ### Changed
 
-- Added `react-dom` to peer dependencies.
+* Added `react-dom` to peer dependencies.
 
 ## [3.2.0] - 2022-12-12
 
 ### Added
 
-- Design tokens based theming.
+* Design tokens based theming.
 
 ## [3.1.5] - 2022-11-30
 
 ### Fixed
 
-- Fixed showing types in autocomplete IDE.
+* Fixed showing types in autocomplete IDE.
 
 ## [3.1.4] - 2022-11-30
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.40.0 ~> 3.41.0], `@semcore/flex-box` [4.6.3 ~> 4.6.4]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.40.0 ~> 3.41.0], `@semcore/flex-box` [4.6.3 ~> 4.6.4]).
 
 ## [3.1.0] - 2022-10-10
 
 ### Changed
 
-- Added support for React 18 🔥
+* Added support for React 18 🔥
 
 ## [3.0.10] - 2022-10-04
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.37.1 ~> 3.37.2], `@semcore/flex-box` [4.5.11 ~> 4.5.12]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.37.1 ~> 3.37.2], `@semcore/flex-box` [4.5.11 ~> 4.5.12]).
 
 ## [3.0.0] - 2022-05-17
 
 ### BREAK
 
-- Updated styles according to the library redesign policy.
-- Changed sizes from m/l/xl to s/m/l
+* Updated styles according to the library redesign policy.
+* Changed sizes from m/l/xl to s/m/l
 
 ## [2.3.1] - 2022-03-14
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.31.2 ~> 3.31.2], `@semcore/flex-box` [4.5.0 ~> 4.5.1]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.31.2 ~> 3.31.2], `@semcore/flex-box` [4.5.0 ~> 4.5.1]).
 
 ## [2.3.0] - 2021-03-04
 
 ### Added
 
-- Disabled animation if reduce motion is preferred.
+* Disabled animation if reduce motion is preferred.
 
 ## [2.2.2] - 2022-02-24
 
 ### Added
 
-- Added repository field to package.json file.
+* Added repository field to package.json file.
 
 ## [2.2.1] - 2021-8-26
 
 ### Changed
 
-- Add 'sideEffect=false' for more optimal build via webpack
+* Add 'sideEffect=false' for more optimal build via webpack
 
 ## [2.2.0] - 2021-04-26
 
 ### Changed
 
-- Version of dependence `@semcore/core` has been changed to `1.11`.
-- Improved performance. Removed one component wrapper.
-- The style processing system has been changed.
-- Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
+* Version of dependence `@semcore/core` has been changed to `1.11`.
+* Improved performance. Removed one component wrapper.
+* The style processing system has been changed.
+* Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
 
 ## [2.1.1] - 2021-04-16
 
 ### Changed
 
-- Resized bullet points in `li`
+* Resized bullet points in `li`
 
 ## [2.1.0] - 2020-12-17
 
 ### Added
 
-- Added supported react@17.
+* Added supported react@17.
 
 ## [2.0.3] - 2020-10-29
 
 ### Fixed
 
-- Added the placeholder for ID style tag to improve collision protection.
+* Added the placeholder for ID style tag to improve collision protection.
 
 ## [2.0.2] - 2020-09-08
 
 ### Fixed
 
-- Fixed possible styles collisions between components with different versions, but same styles
+* Fixed possible styles collisions between components with different versions, but same styles
 
 ## [2.0.1] - 2020-06-22
 
 ### Fixed
 
-- Убрано подчеркивание у abbr при наведении.
+* Убрано подчеркивание у abbr при наведении.
 
 ## [2.0.0] - 2020-04-20
 
 ### BREAK
 
-- Изменения описаны в [migration guide](/internal/migration-guide)
+* Изменения описаны в [migration guide](/internal/migration-guide)
 
 ### Changed
 
-- Увеличен отступ параграфов для размера `m` c `8px` до `18px`
-- Увеличен отступ параграфов для размера `l` c `12px` до `20px`
-- Увеличен отступ параграфов для размера `xl` c `16px` до `24px`
-- Изменился цвет по ховеру ссылки, c 16% на 12%
-- Отсутпы для параграфов при размере `m` увеличены до `18px`
-- Отсутпы для параграфов при размере `l` увеличены до `20px`
-- Отсутпы для параграфов при размере `xl` увеличены до `24px`
+* Увеличен отступ параграфов для размера `m` c `8px` до `18px`
+* Увеличен отступ параграфов для размера `l` c `12px` до `20px`
+* Увеличен отступ параграфов для размера `xl` c `16px` до `24px`
+* Изменился цвет по ховеру ссылки, c 16% на 12%
+* Отсутпы для параграфов при размере `m` увеличены до `18px`
+* Отсутпы для параграфов при размере `l` увеличены до `20px`
+* Отсутпы для параграфов при размере `xl` увеличены до `24px`
 
 ## [1.2.1] - 2019-12-17
 
 ### Fixed
 
-- Исправлен транспайл цветовых переменных для стилей без префиксов (build.css)
+* Исправлен транспайл цветовых переменных для стилей без префиксов (build.css)
 
 ## [1.2.0] - 2019-12-12
 
 ### Added
 
-- Появилась возможность добавления различных стилистических тем через css переменные
-- Появилась возможность оптицонально подключать адаптивноссть
-- Появилась возможность изолировать стили даже в пределах одной страницы
+* Появилась возможность добавления различных стилистических тем через css переменные
+* Появилась возможность оптицонально подключать адаптивноссть
+* Появилась возможность изолировать стили даже в пределах одной страницы
 
 ### Changed
 
-- Изменен алгоритм вставки стилей в head
+* Изменен алгоритм вставки стилей в head
 
 ### Removed
 
-- Убраны относительные единицы измерения(rem), которые использовались для адаптивности
+* Убраны относительные единицы измерения(rem), которые использовались для адаптивности
 
 ## [1.1.0] - 2019-11-14
 
 ### Added
 
-- Добавлена адаптивность на маленьких экранах(<768px)
+* Добавлена адаптивность на маленьких экранах(<768px)
 
 ## [1.0.3] - 2019-09-30
 
 ### Changed
 
-- Нужные зависимости перенесены в `utils`, размер должен стать меньше
+* Нужные зависимости перенесены в `utils`, размер должен стать меньше
 
 ## [1.0.2] - 2019-07-31
 
 ### Fixed
 
-- Исправлена сборка для рендера css на сервере
+* Исправлена сборка для рендера css на сервере
 
 ## [1.0.1] - 2019-05-07
 
 ### Fixed
 
-- Свойство `size` помечано как не обязательное
+* Свойство `size` помечано как не обязательное
 
 ## [1.0.0] - 2019-05-07
 
 ### Added
 
-- Initial release
+* Initial release

--- a/semcore/format-text/src/style/format-text.shadow.css
+++ b/semcore/format-text/src/style/format-text.shadow.css
@@ -41,7 +41,8 @@ SFormatText {
     }
   }
 
-  & code {
+  & code,
+  & pre {
     font-family: Consolas, 'Roboto Mono', Menlo, Courier, monospace;
   }
 

--- a/semcore/format-text/src/style/format-text.shadow.css
+++ b/semcore/format-text/src/style/format-text.shadow.css
@@ -41,6 +41,10 @@ SFormatText {
     }
   }
 
+  & code {
+    font-family: Consolas, 'Roboto Mono', Menlo, Courier, monospace;
+  }
+
   & blockquote {
     position: relative;
     /* disable-tokens-validator */

--- a/semcore/icon/CHANGELOG.md
+++ b/semcore/icon/CHANGELOG.md
@@ -2,189 +2,186 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
-
 ## [4.8.3] - 2023-09-13
 
 ### Fixed
 
-* Fixed strange svg issue that was cutting the edge of the `Favorite` and `FavoriteFilled` icons.
+- Fixed strange svg issue that was cutting the edge of the `Favorite` and `FavoriteFilled` icons.
 
 ## [4.8.2] - 2023-09-12
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
+- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
 
 ## [4.8.1] - 2023-09-08
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
+- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
 
 ## [4.8.0] - 2023-09-05
 
 ### Added
 
-* Added new `Phone` icon.
+- Added new `Phone` icon.
 
 ## [4.7.1] - 2023-09-05
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
+- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
 
 ## [4.7.0] - 2023-09-04
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
+- Version preminor update due to children dependencies update (`@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
 
 ## [4.6.0] - 2023-08-28
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
-
+- Version preminor update due to children dependencies update (`@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
 
 ## [4.5.1] - 2023-08-24
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
-
+- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
 
 ## [4.5.0] - 2023-08-23
 
 ### Changed
 
-* Updated `Twitter` and `TwitterCarousel` icons, bye-bye birdie 😢
+- Updated `Twitter` and `TwitterCarousel` icons, bye-bye birdie 😢
 
 ## [4.4.1] - 2023-08-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
+- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
 
 ## [4.4.0] - 2023-08-18
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
+- Version preminor update due to children dependencies update (`@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
 
 ## [4.3.1] - 2023-08-16
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/core` [2.2.0 ~> 2.2.1]).
+- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/core` [2.2.0 ~> 2.2.1]).
 
 ## [4.3.0] - 2023-08-07
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/flex-box` [5.1.0 ~> 5.2.0], `@semcore/utils` [4.0.0 ~> 4.1.0]).
+- Version minor update due to children dependencies update (`@semcore/flex-box` [5.1.0 ~> 5.2.0], `@semcore/utils` [4.0.0 ~> 4.1.0]).
 
 ## [4.2.0] - 2023-08-01
 
 ### Added
 
-* Added new `GoogleGenerativeAI` icon.
+- Added new `GoogleGenerativeAI` icon.
 
 ## [4.1.0] - 2023-07-27
 
 ### Changed
 
-* Use `event.key` instead of `event.code` for better support of non QWERTY keyboard layouts.
+- Use `event.key` instead of `event.code` for better support of non QWERTY keyboard layouts.
 
 ## [4.0.0] - 2023-07-17
 
 ### BREAK
 
-* Removed all icons from `@semcore/icon/lib/*` path.
-* Removed `Stoller` icon.
-* Removed `YoutubeAlt` icon.
-* Removed `YoutubeRed` icon.
-* Removed `FeauturedImage` icon.
-* Removed `FeauturedVideo` icon.
+- Removed all icons from `@semcore/icon/lib/*` path.
+- Removed `Stoller` icon.
+- Removed `YoutubeAlt` icon.
+- Removed `YoutubeRed` icon.
+- Removed `FeauturedImage` icon.
+- Removed `FeauturedVideo` icon.
 
 ### Added
 
-* Added `Diners` pay icon.
+- Added `Diners` pay icon.
 
 ## [3.16.1] - 2023-06-30
 
 ### Added
 
-* Added new `GoogleSheets` and `GoogleSlides` icons.
+- Added new `GoogleSheets` and `GoogleSlides` icons.
 
 ### Fixed
 
-* Removed duplication custom css class.
+- Removed duplication custom css class.
 
 ## [3.15.3] - 2023-06-27
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.31 ~> 4.7.32], `@semcore/utils` [3.53.4 ~> 3.54.0]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.31 ~> 4.7.32], `@semcore/utils` [3.53.4 ~> 3.54.0]).
 
 ## [3.15.2] - 2023-06-14
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.30 ~> 4.7.31], `@semcore/utils` [3.53.3 ~> 3.53.4]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.30 ~> 4.7.31], `@semcore/utils` [3.53.3 ~> 3.53.4]).
 
 ## [3.15.1] - 2023-06-12
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.29 ~> 4.7.30], `@semcore/utils` [3.53.2 ~> 3.53.3]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.29 ~> 4.7.30], `@semcore/utils` [3.53.2 ~> 3.53.3]).
 
 ## [3.15.0] - 2023-06-08
 
 ### Added
 
-* Added new `SecurityNo` icon.
+- Added new `SecurityNo` icon.
 
 ## [3.14.16] - 2023-06-07
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.27 ~> 4.7.28], `@semcore/utils` [3.53.0 ~> 3.53.1]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.27 ~> 4.7.28], `@semcore/utils` [3.53.0 ~> 3.53.1]).
 
 ## [3.14.15] - 2023-05-31
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.26 ~> 4.7.27], `@semcore/utils` [3.52.0 ~> 3.53.0]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.26 ~> 4.7.27], `@semcore/utils` [3.52.0 ~> 3.53.0]).
 
 ## [3.14.14] - 2023-05-25
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.25 ~> 4.7.26], `@semcore/utils` [3.51.1 ~> 3.52.0]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.25 ~> 4.7.26], `@semcore/utils` [3.51.1 ~> 3.52.0]).
 
 ## [3.14.13] - 2023-05-24
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.24 ~> 4.7.25], `@semcore/utils` [3.51.0 ~> 3.51.1]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.24 ~> 4.7.25], `@semcore/utils` [3.51.0 ~> 3.51.1]).
 
 ## [3.14.12] - 2023-05-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.23 ~> 4.7.24], `@semcore/utils` [3.50.7 ~> 3.51.0]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.23 ~> 4.7.24], `@semcore/utils` [3.50.7 ~> 3.51.0]).
 
 ## [3.14.11] - 2023-05-11
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.22 ~> 4.7.23], `@semcore/utils` [3.50.6 ~> 3.50.7]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.22 ~> 4.7.23], `@semcore/utils` [3.50.6 ~> 3.50.7]).
 
 ## [3.14.10] - 2023-05-04
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.21 ~> 4.7.22], `@semcore/utils` [3.50.5 ~> 3.50.6]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.21 ~> 4.7.22], `@semcore/utils` [3.50.5 ~> 3.50.6]).
 
 ## [3.14.8] - 2023-04-24
 
@@ -192,748 +189,748 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.18 ~> 4.7.19], `@semcore/utils` [3.50.0 ~> 3.50.3]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.18 ~> 4.7.19], `@semcore/utils` [3.50.0 ~> 3.50.3]).
 
 ## [3.14.0] - 2023-03-17
 
 ### Added
 
-* Added `GitHubInvert` icon.
+- Added `GitHubInvert` icon.
 
 ## [3.13.4] - 2023-03-16
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.11 ~> 4.7.12], `@semcore/utils` [3.47.2 ~> 3.47.3]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.11 ~> 4.7.12], `@semcore/utils` [3.47.2 ~> 3.47.3]).
 
 ## [3.13.2] - 2023-03-02
 
 ### Removed
 
-* Removed automatic setting of `aria-hidden` to `true`.
+- Removed automatic setting of `aria-hidden` to `true`.
 
 ## [3.13.1] - 2023-02-28
 
 ### Fixed
 
-* Fixed DOM attributes `aria-hidden` and `role` were not overridable.
+- Fixed DOM attributes `aria-hidden` and `role` were not overridable.
 
 ## [3.13.0] - 2023-02-24
 
 ### Fixed
 
-* Fixed path for `Confluence`, `GoogleCloud`, `Hubspot`, `JavaScript`, `LookerStudio` icons.
+- Fixed path for `Confluence`, `GoogleCloud`, `Hubspot`, `JavaScript`, `LookerStudio` icons.
 
 ## [3.12.0] - 2023-02-22
 
 ### Added
 
-* Added `Confluence` icon.
+- Added `Confluence` icon.
 
 ## [3.11.0] - 2023-02-22
 
 ### Fixed
 
-* Renamed `FeauturedImage` icon to `FeaturedImage`.
+- Renamed `FeauturedImage` icon to `FeaturedImage`.
 
 ## [3.10.2] - 2023-02-21
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.9 ~> 4.7.10], `@semcore/utils` [3.47.0 ~> 3.47.1]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.9 ~> 4.7.10], `@semcore/utils` [3.47.0 ~> 3.47.1]).
 
 ## [3.10.0] - 2023-02-13
 
 ### Added
 
-* Added `JavaScript` icon.
+- Added `JavaScript` icon.
 
 ## [3.9.0] - 2023-02-09
 
 ### Changed
 
-* Renamed `YoutubeAlt` icon to `YoutubeColored`.
-* Renamed `YoutubeRed` icon to `YoutubeInvert`.
+- Renamed `YoutubeAlt` icon to `YoutubeColored`.
+- Renamed `YoutubeRed` icon to `YoutubeInvert`.
 
 ## [3.8.0] - 2023-01-20
 
 ### Added
 
-* Added `TwitterCarousel`, `TopStories`, `WebStories`, `FindResultsOn`, `InterestingFinds`, `Event`, `SeeResultsAbout`, `PopularProducts`, `RelatedProducts`, `AddressPack`, `RelatedSearches`, `ShortVideos` icons.
+- Added `TwitterCarousel`, `TopStories`, `WebStories`, `FindResultsOn`, `InterestingFinds`, `Event`, `SeeResultsAbout`, `PopularProducts`, `RelatedProducts`, `AddressPack`, `RelatedSearches`, `ShortVideos` icons.
 
 ## [3.7.0] - 2023-01-19
 
 ### Added
 
-* Added `NotificationNo` icon.
+- Added `NotificationNo` icon.
 
 ## [3.6.1] - 2023-01-19
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.5 ~> 4.7.6], `@semcore/utils` [3.44.3 ~> 3.45.0]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.5 ~> 4.7.6], `@semcore/utils` [3.44.3 ~> 3.45.0]).
 
 ## [3.6.0] - 2023-01-10
 
 ### Fixed
 
-* Renamed `Stoller` icon to `Stroller`.
+- Renamed `Stoller` icon to `Stroller`.
 
 ## [3.5.1] - 2023-01-09
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.3 ~> 4.7.4], `@semcore/utils` [3.44.1 ~> 3.44.2]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.3 ~> 4.7.4], `@semcore/utils` [3.44.1 ~> 3.44.2]).
 
 ## [3.5.0] - 2022-12-27
 
 ### Added
 
-* Added `Jewelry`, `Photo`, `Military`, `Restaurant`, `Music`, `Recreation`, `Events'`, `Cosmetics`, `Fashion`, `Printing`, `Science`, `Comics`, `Gambling`, `Architecture`, `Veterinary`, `Furniture`, `Adult`, `Religion`, `PublicSafety`, `Security`, `Fish`, `Law`, `Oil`, `Packaging`, `Logistic`, `Marine`, `PublicUtility`, `Craft`, `Sport`, `Car`, `Games`, `Language`, `Smoking`, `Farm`, `Food`, `Wine` icons.
+- Added `Jewelry`, `Photo`, `Military`, `Restaurant`, `Music`, `Recreation`, `Events'`, `Cosmetics`, `Fashion`, `Printing`, `Science`, `Comics`, `Gambling`, `Architecture`, `Veterinary`, `Furniture`, `Adult`, `Religion`, `PublicSafety`, `Security`, `Fish`, `Law`, `Oil`, `Packaging`, `Logistic`, `Marine`, `PublicUtility`, `Craft`, `Sport`, `Car`, `Games`, `Language`, `Smoking`, `Farm`, `Food`, `Wine` icons.
 
 ## [3.4.3] - 2022-12-19
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.2 ~> 4.7.3], `@semcore/utils` [3.44.0 ~> 3.44.1]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.7.2 ~> 4.7.3], `@semcore/utils` [3.44.0 ~> 3.44.1]).
 
 ## [3.4.1] - 2022-12-13
 
 ### Changed
 
-* Added `react-dom` to peer dependencies.
+- Added `react-dom` to peer dependencies.
 
 ## [3.4.0] - 2022-12-12
 
 ### Added
 
-* Design tokens based theming.
+- Design tokens based theming.
 
 ## [3.3.0] - 2022-11-11
 
 ### Added
 
-* Added `Rephrase`, `SimplifyText`, `ExpandText` icons.
+- Added `Rephrase`, `SimplifyText`, `ExpandText` icons.
 
 ## [3.2.0] - 2022-11-04
 
 ### Added
 
-* Added `LookerStudio` icon.
+- Added `LookerStudio` icon.
 
 ## [3.1.2] - 2022-10-26
 
 ### Fixed
 
-* Lazy checks for necessity of `aria-label` in non production environment.
+- Lazy checks for necessity of `aria-label` in non production environment.
 
 ## [3.1.1] - 2022-10-24
 
 ### Changed
 
-* Updated `Text` icon.
+- Updated `Text` icon.
 
 ## [3.1.0] - 2022-10-20
 
 ### Added
 
-* Added icon `GoogleAds`
+- Added icon `GoogleAds`
 
 ## [3.0.2] - 2022-10-20
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.39.0 ~> 3.39.1], `@semcore/flex-box` [4.6.1 ~> 4.6.2]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.39.0 ~> 3.39.1], `@semcore/flex-box` [4.6.1 ~> 4.6.2]).
 
 ## [3.0.0] - 2022-10-10
 
 ### Fixed
 
-* Renamed `AppBlock` icon to `AppsBlock`.
+- Renamed `AppBlock` icon to `AppsBlock`.
 
 ### Changed
 
-* Added support for React 18 🔥
+- Added support for React 18 🔥
 
 ## [2.33.0] - 2022-10-06
 
 ### Added
 
-* Added icon Stoller
+- Added icon Stoller
 
 ## [2.32.2] - 2022-10-04
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.37.1 ~> 3.37.2], `@semcore/flex-box` [4.5.11 ~> 4.5.12]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.37.1 ~> 3.37.2], `@semcore/flex-box` [4.5.11 ~> 4.5.12]).
 
 ## [2.32.1] - 2022-09-30
 
 ### Added
 
-* Added `Charge`, `CardUpdate`, `ChargebackWin`, `ChargebackLoss` icons.
+- Added `Charge`, `CardUpdate`, `ChargebackWin`, `ChargebackLoss` icons.
 
 ## [2.31.0] - 2022-09-30
 
 ### Changed
 
-* When `interactive` prop is provided, `aria-label` or `aria-labelledby` props from now are required. If required props are not provided a warning is logged to developer console.
+- When `interactive` prop is provided, `aria-label` or `aria-labelledby` props from now are required. If required props are not provided a warning is logged to developer console.
 
 ## [2.30.4] - 2022-09-15
 
 ### Fixed
 
-* Fixed icon Toxic.
+- Fixed icon Toxic.
 
 ## [2.30.3] - 2022-09-14
 
 ### Changed
 
-* Changed icon `Archive`
+- Changed icon `Archive`
 
 ### Added
 
-* Added icon `Unarchive`
+- Added icon `Unarchive`
 
 ## [2.30.2] - 2022-08-30
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.37.0 ~> 3.37.1], `@semcore/flex-box` [4.5.10 ~> 4.5.11]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.37.0 ~> 3.37.1], `@semcore/flex-box` [4.5.10 ~> 4.5.11]).
 
 ## [2.30.1] - 2022-08-18
 
 ### Added
 
-* Added call `onClick` when pressing enter if the icon is `interactive`.
+- Added call `onClick` when pressing enter if the icon is `interactive`.
 
 ## [2.29.5] - 2022-08-18
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.36.0 ~> 3.37.0], `@semcore/flex-box` [4.5.9 ~> 4.5.10]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.36.0 ~> 3.37.0], `@semcore/flex-box` [4.5.9 ~> 4.5.10]).
 
 ## [2.29.2] - 2022-07-25
 
 ### Fixed
 
-* Renamed icon from `AppBlock` to `AppsBlock`. Old name is deprecated.
+- Renamed icon from `AppBlock` to `AppsBlock`. Old name is deprecated.
 
 ## [2.29.1] - 2022-07-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.34.0 ~> 3.35.0], `@semcore/flex-box` [4.5.6 ~> 4.5.7]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.34.0 ~> 3.35.0], `@semcore/flex-box` [4.5.6 ~> 4.5.7]).
 
 ## [2.29.0] - 2022-07-21
 
 ### Added
 
-* Added icon `ClusteredList`.
+- Added icon `ClusteredList`.
 
 ## [2.28.0] - 2022-07-07
 
 ### Added
 
-* Added icon `AppsBlock`.
+- Added icon `AppsBlock`.
 
 ## [2.27.0] - 2022-06-01
 
 ### Changed
 
-* Added files with the extension .mjs
+- Added files with the extension .mjs
 
 ## [2.26.1] - 2022-05-31
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.32.1 ~> 3.32.2], `@semcore/flex-box` [4.5.3 ~> 4.5.4]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.32.1 ~> 3.32.2], `@semcore/flex-box` [4.5.3 ~> 4.5.4]).
 
 ## [2.26.0] - 2022-05-23
 
 ### Added
 
-* Added icon `Kebab`.
+- Added icon `Kebab`.
 
 ## [2.25.1] - 2022-05-19
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.32.0 ~> 3.32.1], `@semcore/flex-box` [4.5.1 ~> 4.5.3]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.32.0 ~> 3.32.1], `@semcore/flex-box` [4.5.1 ~> 4.5.3]).
 
 ## [2.25.0] - 2022-05-18
 
 ### Added
 
-* Added icon `GoogleCloud`.
+- Added icon `GoogleCloud`.
 
 ## [2.24.0] - 2022-05-12
 
 ### Added
 
-* Added icon `UserShared`.
+- Added icon `UserShared`.
 
 ### Changed
 
-* Update pay icons `Visa, JCB`.
+- Update pay icons `Visa, JCB`.
 
 ## [2.21.0] - 2022-04-28
 
 ### Added
 
-* Added icons `IndentedResult, UserSharedFirst`.
+- Added icons `IndentedResult, UserSharedFirst`.
 
 ### Changed
 
-* Changed icon `UserGroup`.
+- Changed icon `UserGroup`.
 
 ### Removed
 
-* Removed icons `UserGroupNo, UserShared`.
+- Removed icons `UserGroupNo, UserShared`.
 
 ## [2.20.0] - 2022-03-21
 
 ### Added
 
-* Added icons `Formal, Casual, QuestionSerp, MathMinusAlt`.
+- Added icons `Formal, Casual, QuestionSerp, MathMinusAlt`.
 
 ## [2.19.4] - 2022-03-14
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.31.2 ~> 3.31.2], `@semcore/flex-box` [4.5.0 ~> 4.5.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.31.2 ~> 3.31.2], `@semcore/flex-box` [4.5.0 ~> 4.5.1]).
 
 ## [2.19.3] - 2022-02-24
 
 ### Added
 
-* Added repository field to package.json file.
+- Added repository field to package.json file.
 
 ## [2.19.2] - 2022-02-14
 
 ### Fixed
 
-* Fixed sizes for a few icons.
+- Fixed sizes for a few icons.
 
 ## [2.19.1] - 2022-02-14
 
 ### Fixed
 
-* Fixed color setting for `LightningFilled, MailOpenFilled`.
+- Fixed color setting for `LightningFilled, MailOpenFilled`.
 
 ## [2.19.0] - 2022-02-09
 
 ### Added
 
-* Add icon `Hubspot`.
+- Add icon `Hubspot`.
 
 ### Changed
 
-* Changed svg for `SortAsc`, `SortDesc`.
+- Changed svg for `SortAsc`, `SortDesc`.
 
 ## [2.18.0] - 2022-02-03
 
 ### Added
 
-* Add icons 'LightningFilled' in new icons.
+- Add icons 'LightningFilled' in new icons.
 
 ## [2.17.1] - 2022-01-31
 
 ### Fixed
 
-* Fixed view icon `MailOpenFilled` size `m`.
+- Fixed view icon `MailOpenFilled` size `m`.
 
 ## [2.17.0] - 2022-01-17
 
 ### Added
 
-* Add icons 'Hotel' in new icons.
+- Add icons 'Hotel' in new icons.
 
 ## [2.16.0] - 2022-01-12
 
 ### Changed
 
-* Added import new icons
-* Old icons you can get from `@semcore/icon/lib/Name/Size`
-* New icons you can get from `@semcore/icon/Name/Size`
+- Added import new icons
+- Old icons you can get from `@semcore/icon/lib/Name/Size`
+- New icons you can get from `@semcore/icon/Name/Size`
 
 ## [2.15.0] - 2022-01-11
 
 ### Added
 
-* Added import icons from root folder (exm: `@semcore/icon/ArrowDown/m`)
+- Added import icons from root folder (exm: `@semcore/icon/ArrowDown/m`)
 
 ## [2.14.0] - 2021-10-04
 
 ### Added
 
-* Add new icons 'MailOpen' and 'MailOutlineOpen'
+- Add new icons 'MailOpen' and 'MailOutlineOpen'
 
 ## [2.13.0] - 2021-9-14
 
 ### Added
 
-* Add new icon 'BriefcaseAlt'
+- Add new icon 'BriefcaseAlt'
 
 ## [2.12.2] - 2021-8-26
 
 ### Changed
 
-* Add 'sideEffect=false' for more optimal build via webpack
+- Add 'sideEffect=false' for more optimal build via webpack
 
 ## [2.12.1] - 2021-07-22
 
 ### Fixed
 
-* Fixed set style which render `useBox`.
+- Fixed set style which render `useBox`.
 
 ## [2.12.0] - 2021-07-16
 
 ### Changed
 
-* Remove from html for svg don't used attributes.
-* Added `propsForElement` for set props to svg.
+- Remove from html for svg don't used attributes.
+- Added `propsForElement` for set props to svg.
 
 ## [2.11.0] - 2021-07-05
 
 ### Changed
 
-* Version of dependence `@semcore/core` has been changed to `1.11`.
-* Improved performance. Removed one component wrapper.
-* The style processing system has been changed.
-* Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
+- Version of dependence `@semcore/core` has been changed to `1.11`.
+- Improved performance. Removed one component wrapper.
+- The style processing system has been changed.
+- Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
 
 ## [2.10.0] - 2021-04-28
 
 ### Added
 
-* Added control with keyboard for all icons including prop `interactive`.
+- Added control with keyboard for all icons including prop `interactive`.
 
 ## [2.9.0] - 2021-04-13
 
 ### Added
 
-* Added new icon `SharedToUser`.
+- Added new icon `SharedToUser`.
 
 ## [2.8.1] - 2021-02-24
 
 ### Changed
 
-* Update icons `SEMrush, TwitterSemrush, FacebookSemrush, LinkedInSemrush`.
+- Update icons `SEMrush, TwitterSemrush, FacebookSemrush, LinkedInSemrush`.
 
 ## [2.8.0] - 2021-02-11
 
 ### Added
 
-* Added new icon `VideoStop`.
+- Added new icon `VideoStop`.
 
 ## [2.7.0] - 2021-01-20
 
 ### Added
 
-* Added new color icon `Github`.
+- Added new color icon `Github`.
 
 ## [2.6.0] - 2020-12-23
 
 ### Added
 
-* Added new icon `GoogleAnalytics4` for 4 version.
+- Added new icon `GoogleAnalytics4` for 4 version.
 
 ## [2.5.0] - 2020-12-17
 
 ### Added
 
-* Added supported react@17.
+- Added supported react@17.
 
 ## [2.4.0] - 2020-10-30
 
 ### Added
 
-* Added new icon `GlobeAlt`.
+- Added new icon `GlobeAlt`.
 
 ## [2.3.2] - 2020-10-29
 
 ### Fixed
 
-* Added the placeholder for ID style tag to improve collision protection.
+- Added the placeholder for ID style tag to improve collision protection.
 
 ## [2.3.1] - 2020-10-14
 
 ### Fixed
 
-* fixed wrong path for ES6 build
+- fixed wrong path for ES6 build
 
 ## [2.3.0] - 2020-10-12
 
 ### Added
 
-* Added new icon `color/WhatsApp`.
+- Added new icon `color/WhatsApp`.
 
 ## [2.2.1] - 2020-09-08
 
 ### Fixed
 
-* Fixed possible styles collisions between components with different versions, but same styles
+- Fixed possible styles collisions between components with different versions, but same styles
 
 ## [2.2.0] - 2020-07-24
 
 ### Added
 
-* Добавили свойство `flex-shrink` для икон по умолчанию, для корректного отображения во флекс-боксах.
+- Добавили свойство `flex-shrink` для икон по умолчанию, для корректного отображения во флекс-боксах.
 
 ## [2.1.1] - 2020-06-22
 
 ### Fixed
 
-* Изменились иконки `FeaturedImage`, `FeaturedVideo`
+- Изменились иконки `FeaturedImage`, `FeaturedVideo`
 
 ## [2.1.0] - 2020-06-10
 
 ### Added
 
-* Добавили новые иконки `SERP Features`, `Figma`, `GoogleColor, GoogleGSC`
+- Добавили новые иконки `SERP Features`, `Figma`, `GoogleColor, GoogleGSC`
 
 ## [2.0.3] - 2020-06-10
 
 ### Fixed
 
-* Исправлены TS типы
+- Исправлены TS типы
 
 ## [2.0.2] - 2020-06-09
 
 ### BREAK
 
-* Изменения описаны в [migration guide](/internal/migration-guide)
+- Изменения описаны в [migration guide](/internal/migration-guide)
 
 ### Added
 
-* Добавили иконки `FacebookMessenger, GenderFemale, GenderMale, YouTubeRed`
+- Добавили иконки `FacebookMessenger, GenderFemale, GenderMale, YouTubeRed`
 
 ### Changed
 
-* Изменили цвет иконки по наведению, с 8% на 12%
-* Обновили иконки семейства `YouTube` во всех размерах
+- Изменили цвет иконки по наведению, с 8% на 12%
+- Обновили иконки семейства `YouTube` во всех размерах
 
 ## [1.5.5] - 2020-02-25
 
 ### Added
 
-* Иконка `GoogleDoc` в размерах `xs`, `s`, `m`
-* Иконка `CalendarCheck` в размерах `m`, `s`, `xs`
-* Иконка `ListBullet` в размере `xxs`
-* Иконка `Slack` в размерах `xs`, `s`, `m`
-* Иконка `WordPress` в размерах `xs`, `s`, `m`
+- Иконка `GoogleDoc` в размерах `xs`, `s`, `m`
+- Иконка `CalendarCheck` в размерах `m`, `s`, `xs`
+- Иконка `ListBullet` в размере `xxs`
+- Иконка `Slack` в размерах `xs`, `s`, `m`
+- Иконка `WordPress` в размерах `xs`, `s`, `m`
 
 ### Changed
 
-* Исправлен размер иконки `MathMinusAlt` в размере `s`
-* Исправлен размер иконки `MathPlusAlt` в размере `s`
+- Исправлен размер иконки `MathMinusAlt` в размере `s`
+- Исправлен размер иконки `MathPlusAlt` в размере `s`
 
 ## [1.5.4] - 2020-01-22
 
 ### Fixed
 
-* Добавлен `viewBox` иконкам `Filter`, `Funnel`, `SmileSimple`
+- Добавлен `viewBox` иконкам `Filter`, `Funnel`, `SmileSimple`
 
 ## [1.5.3] - 2019-12-23
 
 ### Fixed
 
-* Исправлен цвет иконок `Filter`, `Funnel`
-* Добавлен `viewBox` иконкам `GoogleDataStudio`, `Briefcase`, `Hotel`
+- Исправлен цвет иконок `Filter`, `Funnel`
+- Добавлен `viewBox` иконкам `GoogleDataStudio`, `Briefcase`, `Hotel`
 
 ## [1.5.1] - 2019-12-17
 
 ### Added
 
-* Добавлены иконки `GoogleDataStudio` в размерах `xs`, `s`, `m`
-* Добавлены иконки `Briefcase` в размерах `xs`, `s`, `m`
-* Добавлены иконки `Filter` в размерах `xs`, `s`, `m`
-* Добавлены иконки `Funnel` в размерах `xs`, `s`, `m`
-* Добавлены иконки `Hotel` в размерах `xs`, `s`, `m`
-* Добавлены иконки `SmileSimple` в размерах `xs`, `s`, `m`
+- Добавлены иконки `GoogleDataStudio` в размерах `xs`, `s`, `m`
+- Добавлены иконки `Briefcase` в размерах `xs`, `s`, `m`
+- Добавлены иконки `Filter` в размерах `xs`, `s`, `m`
+- Добавлены иконки `Funnel` в размерах `xs`, `s`, `m`
+- Добавлены иконки `Hotel` в размерах `xs`, `s`, `m`
+- Добавлены иконки `SmileSimple` в размерах `xs`, `s`, `m`
 
 ## [1.5.0] - 2019-12-12
 
 ### Added
 
-* Появилась возможность добавления различных стилистических тем через css переменные
-* Появилась возможность оптицонально подключать адаптивноссть
-* Появилась возможность изолировать стили даже в пределах одной страницы
+- Появилась возможность добавления различных стилистических тем через css переменные
+- Появилась возможность оптицонально подключать адаптивноссть
+- Появилась возможность изолировать стили даже в пределах одной страницы
 
 ### Changed
 
-* Изменен алгоритм вставки стилей в head
+- Изменен алгоритм вставки стилей в head
 
 ### Removed
 
-* Убраны относительные единицы измерения(rem), которые использовались для адаптивности
+- Убраны относительные единицы измерения(rem), которые использовались для адаптивности
 
 ## [1.4.5] - 2019-11-25
 
 ### Fixed
 
-* Перезаллили `production` сборку с хэш именами классов
+- Перезаллили `production` сборку с хэш именами классов
 
 ## [1.4.4] - 2019-11-14
 
 ### Fixed
 
-* Исправили иконку `ListCheckAlt`
+- Исправили иконку `ListCheckAlt`
 
 ## [1.4.3] - 2019-11-13
 
 ### Added
 
-* Добавлены иконки `Bacs, Maestro, V Pay, Direct Credit`
+- Добавлены иконки `Bacs, Maestro, V Pay, Direct Credit`
 
 ## [1.4.2] - 2019-10-24
 
 ### Fixed
 
-* Исправлены хэш стилей от версии компонента
+- Исправлены хэш стилей от версии компонента
 
 ## [1.4.1] - 2019-09-30
 
 ### Changed
 
-* Нужные зависимости перенесены в `utils`, размер должен стать меньше
+- Нужные зависимости перенесены в `utils`, размер должен стать меньше
 
 ## [1.4.0] - 2019-08-02
 
 ### Added
 
-* Добавлена иконка `Airplane`
+- Добавлена иконка `Airplane`
 
 ### Fixed
 
-* Исправлена сборка для SSR
+- Исправлена сборка для SSR
 
 ## [1.3.4] - 2019-07-31
 
 ### Fixed
 
-* Уменьшен размер сборки
+- Уменьшен размер сборки
 
 ## [1.3.3] - 2019-07-17
 
 ### Added
 
-* Описание типов для иконок
+- Описание типов для иконок
 
 ### Fixed
 
-* Тип иконки-родителя исправлен с `React.HTMLAttributes<SVGElement>` на `React.SVGAttributes<SVGElement>`
+- Тип иконки-родителя исправлен с `React.HTMLAttributes<SVGElement>` на `React.SVGAttributes<SVGElement>`
 
 ## [1.3.2] - 2019-05-07
 
 ### Added
 
-* Добавлена иконка `CreditCard`
-* Добавлена иконка `AdobeAnalytics` в размерах `xs`, `s`, `m`
+- Добавлена иконка `CreditCard`
+- Добавлена иконка `AdobeAnalytics` в размерах `xs`, `s`, `m`
 
 ## [1.3.1] - 2019-03-25
 
 ### Added
 
-* Добавлена иконка `TimeDay` в размерах `xs`, `s`, `m`
-* Добавлена иконка `TimeNight` в размерах `xs`, `s`, `m`
+- Добавлена иконка `TimeDay` в размерах `xs`, `s`, `m`
+- Добавлена иконка `TimeNight` в размерах `xs`, `s`, `m`
 
 ## [1.3.0] - 2019-02-18
 
 ### Added
 
-* Добавлена зависимость от `paint`(появилась возможность задавать отступы и цвета)
+- Добавлена зависимость от `paint`(появилась возможность задавать отступы и цвета)
 
 ## [1.2.4] - 2019-02-14
 
 ### Changed
 
-* Иконку `CurrencyUsd`
+- Иконку `CurrencyUsd`
 
 ## [1.2.3] - 2019-01-31
 
 ### Added
 
-* Иконки `ActionStop`, `CurrencyUsd`
+- Иконки `ActionStop`, `CurrencyUsd`
 
 ## [1.2.2] - 2019-01-18
 
 ### Changed
 
-* Добавленно свойство css `box-sizing: content-box;` для исправления проблем с паддингом в некоторых браузерах
+- Добавленно свойство css `box-sizing: content-box;` для исправления проблем с паддингом в некоторых браузерах
 
 ## [1.2.1] - 2018-11-27
 
 ### Fixed
 
-* Убран хук на postinstall
+- Убран хук на postinstall
 
 ## [1.2.0] - 2018-11-27
 
 ### Added
 
-* Иконки color `Outlook`, `Yahoo`, `GoogleMail`, `Office365`, `MicrosoftExchange`
-* Autocomplete для IDE (компонент Icon)
+- Иконки color `Outlook`, `Yahoo`, `GoogleMail`, `Office365`, `MicrosoftExchange`
+- Autocomplete для IDE (компонент Icon)
 
 ## [1.1.3] - 2018-10-05
 
 ### Fixed
 
-* добавлен viewBox для иконок `Expand` размера `m`, `s`, `xs`
+- добавлен viewBox для иконок `Expand` размера `m`, `s`, `xs`
 
 ## [1.1.2] - 2018-10-05
 
 ### Added
 
-* размер `s`,`xs` для `Expand` иконки
+- размер `s`,`xs` для `Expand` иконки
 
 ## [1.1.1] - 2018-09-14
 
 ### Fixed
 
-* переименовали иконку Lighning в Lightning
+- переименовали иконку Lighning в Lightning
 
 ### Added
 
-* data атрибуты name и group
+- data атрибуты name и group
 
 ## [1.1.0] - 2018-09-10
 
 ### Fixed
 
-* Цвет иконок MathMinusS & MathMinusXS изменен с голубого на черный
-* Развернута иконка ActionReply
-* Добавлены charts к иконке DesktopChartXS
-* Иконки SortAsc (S, XS, XXS) переименованы в SortDesc
-* Иконки SortDesc (S, XS, XXS) переименованы в SortAsc
+- Цвет иконок MathMinusS & MathMinusXS изменен с голубого на черный
+- Развернута иконка ActionReply
+- Добавлены charts к иконке DesktopChartXS
+- Иконки SortAsc (S, XS, XXS) переименованы в SortDesc
+- Иконки SortDesc (S, XS, XXS) переименованы в SortAsc
 
 ## [1.0.1] - 2018-09-06
 
 ### Added
 
-* иконки типа `pay`
-* цветные иконки `color`
-* разновидности иконок социальных сетей `external`
+- иконки типа `pay`
+- цветные иконки `color`
+- разновидности иконок социальных сетей `external`
 
 ## [1.0.0] - 2018-08-08
 
 ### Added
 
-* Добавленна поддержка зависимости от React15
+- Добавленна поддержка зависимости от React15
 
 ### Changed
 
-* Обновлена зависимость от utils
+- Обновлена зависимость от utils
 
 ## [1.0.0-2] - 2018-07-06
 
 ### Added
 
-* Инкапсуляция стилей
+- Инкапсуляция стилей
 
 ## [1.0.0-1] - 2018-06-28
 
 ### Added
 
-* Initial release
+- Initial release

--- a/semcore/typography/CHANGELOG.md
+++ b/semcore/typography/CHANGELOG.md
@@ -2,95 +2,101 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.9.0] - 2023-09-06
+
+### Added
+
+* `monospace` prop to `Text` component.
+
 ## [5.8.2] - 2023-09-12
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/icon` [4.8.1 ~> 4.8.2], `@semcore/core` [2.6.2 ~> 2.6.3]).
+* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/icon` [4.8.1 ~> 4.8.2], `@semcore/core` [2.6.2 ~> 2.6.3]).
 
 ## [5.8.1] - 2023-09-08
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/icon` [4.8.0 ~> 4.8.1], `@semcore/core` [2.6.1 ~> 2.6.2]).
+* Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/icon` [4.8.0 ~> 4.8.1], `@semcore/core` [2.6.1 ~> 2.6.2]).
 
 ## [5.8.0] - 2023-09-05
 
 ### Added
 
-- `semibold` prop to `Text` component.
+* `semibold` prop to `Text` component.
 
 ## [5.7.1] - 2023-09-05
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/icon` [4.7.0 ~> 4.7.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
+* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/icon` [4.7.0 ~> 4.7.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
 
 ## [5.7.0] - 2023-09-04
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/icon` [4.6.0 ~> 4.7.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
+* Version preminor update due to children dependencies update (`@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/icon` [4.6.0 ~> 4.7.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
 
 ## [5.6.0] - 2023-08-28
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/icon` [4.5.1 ~> 4.6.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
+* Version preminor update due to children dependencies update (`@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/icon` [4.5.1 ~> 4.6.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
 
 ## [5.5.1] - 2023-08-24
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/icon` [4.5.0 ~> 4.5.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
+* Version prepatch update due to children dependencies update (`@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/icon` [4.5.0 ~> 4.5.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
 
 ## [5.5.0] - 2023-08-23
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/flex-box` [5.3.1 ~> 5.4.0], `@semcore/icon` [4.4.1 ~> 4.5.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
+* Version preminor update due to children dependencies update (`@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/flex-box` [5.3.1 ~> 5.4.0], `@semcore/icon` [4.4.1 ~> 4.5.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
 
 ## [5.4.1] - 2023-08-21
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/icon` [4.4.0 ~> 4.4.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
+* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/icon` [4.4.0 ~> 4.4.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
 
 ## [5.4.0] - 2023-08-18
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/icon` [4.3.1 ~> 4.4.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
+* Version preminor update due to children dependencies update (`@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/icon` [4.3.1 ~> 4.4.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
 
 ## [5.3.1] - 2023-08-16
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/icon` [4.3.0 ~> 4.3.1], `@semcore/core` [2.2.0 ~> 2.2.1]).
+* Version prepatch update due to children dependencies update (`@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/icon` [4.3.0 ~> 4.3.1], `@semcore/core` [2.2.0 ~> 2.2.1]).
 
 ## [5.3.0] - 2023-08-07
 
 ### Changed
 
-- Version minor update due to children dependencies update (`@semcore/utils` [4.0.0 ~> 4.1.0], `@semcore/flex-box` [5.1.0 ~> 5.2.0], `@semcore/icon` [4.2.0 ~> 4.3.0]).
+* Version minor update due to children dependencies update (`@semcore/utils` [4.0.0 ~> 4.1.0], `@semcore/flex-box` [5.1.0 ~> 5.2.0], `@semcore/icon` [4.2.0 ~> 4.3.0]).
 
 ## [5.2.0] - 2023-08-01
 
 ### Changed
 
-- Version minor update due to children dependencies update (`@semcore/flex-box` [5.0.0 ~> 5.1.0], `@semcore/icon` [4.1.0 ~> 4.2.0]).
+* Version minor update due to children dependencies update (`@semcore/flex-box` [5.0.0 ~> 5.1.0], `@semcore/icon` [4.1.0 ~> 4.2.0]).
 
 ## [5.1.0] - 2023-07-27
 
 ### Changed
 
-- Version minor update due to children dependencies update (`@semcore/icon` [4.0.0 ~> 4.1.0]).
+* Version minor update due to children dependencies update (`@semcore/icon` [4.0.0 ~> 4.1.0]).
 
 ## [5.0.0] - 2023-07-17
 
 ### Break
 
-- Strict, backward incompatible typings.
+* Strict, backward incompatible typings.
 
 ## [4.4.14] - 2023-06-30
 
@@ -98,85 +104,85 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/icon` [3.15.3 ~> 3.16.0]).
+* Version patch update due to children dependencies update (`@semcore/icon` [3.15.3 ~> 3.16.0]).
 
 ## [4.4.12] - 2023-06-27
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.53.4 ~> 3.54.0], `@semcore/flex-box` [4.7.31 ~> 4.7.32], `@semcore/icon` [3.15.2 ~> 3.15.3]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.53.4 ~> 3.54.0], `@semcore/flex-box` [4.7.31 ~> 4.7.32], `@semcore/icon` [3.15.2 ~> 3.15.3]).
 
 ## [4.4.11] - 2023-06-14
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.53.3 ~> 3.53.4], `@semcore/flex-box` [4.7.30 ~> 4.7.31], `@semcore/icon` [3.15.1 ~> 3.15.2]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.53.3 ~> 3.53.4], `@semcore/flex-box` [4.7.30 ~> 4.7.31], `@semcore/icon` [3.15.1 ~> 3.15.2]).
 
 ## [4.4.10] - 2023-06-12
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.53.2 ~> 3.53.3], `@semcore/flex-box` [4.7.29 ~> 4.7.30], `@semcore/icon` [3.15.0 ~> 3.15.1]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.53.2 ~> 3.53.3], `@semcore/flex-box` [4.7.29 ~> 4.7.30], `@semcore/icon` [3.15.0 ~> 3.15.1]).
 
 ## [4.4.9] - 2023-06-09
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.53.1 ~> 3.53.2], `@semcore/flex-box` [4.7.28 ~> 4.7.29], `@semcore/icon` [3.14.16 ~> 3.15.0]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.53.1 ~> 3.53.2], `@semcore/flex-box` [4.7.28 ~> 4.7.29], `@semcore/icon` [3.14.16 ~> 3.15.0]).
 
 ## [4.4.8] - 2023-06-07
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.53.0 ~> 3.53.1], `@semcore/flex-box` [4.7.27 ~> 4.7.28], `@semcore/icon` [3.14.15 ~> 3.14.16]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.53.0 ~> 3.53.1], `@semcore/flex-box` [4.7.27 ~> 4.7.28], `@semcore/icon` [3.14.15 ~> 3.14.16]).
 
 ## [4.4.7] - 2023-05-31
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.52.0 ~> 3.53.0], `@semcore/flex-box` [4.7.26 ~> 4.7.27], `@semcore/icon` [3.14.14 ~> 3.14.15]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.52.0 ~> 3.53.0], `@semcore/flex-box` [4.7.26 ~> 4.7.27], `@semcore/icon` [3.14.14 ~> 3.14.15]).
 
 ## [4.4.6] - 2023-05-25
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.51.1 ~> 3.52.0], `@semcore/flex-box` [4.7.25 ~> 4.7.26], `@semcore/icon` [3.14.13 ~> 3.14.14]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.51.1 ~> 3.52.0], `@semcore/flex-box` [4.7.25 ~> 4.7.26], `@semcore/icon` [3.14.13 ~> 3.14.14]).
 
 ## [4.4.5] - 2023-05-24
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.51.0 ~> 3.51.1], `@semcore/flex-box` [4.7.24 ~> 4.7.25], `@semcore/icon` [3.14.12 ~> 3.14.13]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.51.0 ~> 3.51.1], `@semcore/flex-box` [4.7.24 ~> 4.7.25], `@semcore/icon` [3.14.12 ~> 3.14.13]).
 
 ## [4.4.4] - 2023-05-22
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.50.7 ~> 3.51.0], `@semcore/flex-box` [4.7.23 ~> 4.7.24], `@semcore/icon` [3.14.11 ~> 3.14.12]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.50.7 ~> 3.51.0], `@semcore/flex-box` [4.7.23 ~> 4.7.24], `@semcore/icon` [3.14.11 ~> 3.14.12]).
 
 ## [4.4.3] - 2023-05-11
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7], `@semcore/flex-box` [4.7.22 ~> 4.7.23], `@semcore/icon` [3.14.10 ~> 3.14.11]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7], `@semcore/flex-box` [4.7.22 ~> 4.7.23], `@semcore/icon` [3.14.10 ~> 3.14.11]).
 
 ## [4.4.2] - 2023-05-04
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.50.5 ~> 3.50.6], `@semcore/flex-box` [4.7.21 ~> 4.7.22], `@semcore/icon` [3.14.9 ~> 3.14.10]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.50.5 ~> 3.50.6], `@semcore/flex-box` [4.7.21 ~> 4.7.22], `@semcore/icon` [3.14.9 ~> 3.14.10]).
 
 ## [4.4.0] - 2023-04-25
 
 ### Added
 
-- Added `uppercase`, `lowercase`, `capitalize` text transformation props.
+* Added `uppercase`, `lowercase`, `capitalize` text transformation props.
 
 ## [4.3.29] - 2023-04-17
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.50.0 ~> 3.50.3], `@semcore/flex-box` [4.7.18 ~> 4.7.19], `@semcore/icon` [3.14.6 ~> 3.14.7]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.50.0 ~> 3.50.3], `@semcore/flex-box` [4.7.18 ~> 4.7.19], `@semcore/icon` [3.14.6 ~> 3.14.7]).
 
 ## [4.3.16] - 2023-02-22
 
@@ -184,7 +190,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.47.0 ~> 3.47.1], `@semcore/flex-box` [4.7.9 ~> 4.7.10], `@semcore/icon` [3.10.1 ~> 3.10.2]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.47.0 ~> 3.47.1], `@semcore/flex-box` [4.7.9 ~> 4.7.10], `@semcore/icon` [3.10.1 ~> 3.10.2]).
 
 ## [4.3.12] - 2023-02-13
 
@@ -194,7 +200,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.45.0 ~> 3.46.0], `@semcore/flex-box` [4.7.6 ~> 4.7.7], `@semcore/icon` [3.7.0 ~> 3.8.0]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.45.0 ~> 3.46.0], `@semcore/flex-box` [4.7.6 ~> 4.7.7], `@semcore/icon` [3.7.0 ~> 3.8.0]).
 
 ## [4.3.7] - 2023-01-11
 
@@ -204,19 +210,19 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.44.1 ~> 3.44.2], `@semcore/flex-box` [4.7.3 ~> 4.7.4], `@semcore/icon` [3.5.0 ~> 3.5.1]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.44.1 ~> 3.44.2], `@semcore/flex-box` [4.7.3 ~> 4.7.4], `@semcore/icon` [3.5.0 ~> 3.5.1]).
 
 ## [4.3.1] - 2022-12-13
 
 ### Changed
 
-- Added `react-dom` to peer dependencies.
+* Added `react-dom` to peer dependencies.
 
 ## [4.3.0] - 2022-12-12
 
 ### Added
 
-- Design tokens based theming.
+* Design tokens based theming.
 
 ## [4.2.6] - 2022-11-08
 
@@ -224,329 +230,329 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.40.0 ~> 3.40.0], `@semcore/flex-box` [4.6.2 ~> 4.6.3], `@semcore/icon` [3.1.1 ~> 3.1.2]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.40.0 ~> 3.40.0], `@semcore/flex-box` [4.6.2 ~> 4.6.3], `@semcore/icon` [3.1.1 ~> 3.1.2]).
 
 ## [4.2.0] - 2022-10-10
 
 ### Changed
 
-- Added support for React 18 🔥
-- Extended version range for dependency `@semcore/icons`.
+* Added support for React 18 🔥
+* Extended version range for dependency `@semcore/icons`.
 
 ## [4.1.11] - 2022-10-06
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/icon` [2.32.2 ~> 2.33.0]).
+* Version patch update due to children dependencies update (`@semcore/icon` [2.32.2 ~> 2.33.0]).
 
 ## [4.1.0] - 2022-08-10
 
 ### Changed
 
-- Added essential `aria-\*` attributes for Typography lists.
+* Added essential `aria-\*` attributes for Typography lists.
 
 ## [4.0.11] - 2022-08-01
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.35.0 ~> 3.35.1], `@semcore/flex-box` [4.5.7 ~> 4.5.8], `@semcore/icon` [2.29.2 ~> 2.29.3]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.35.0 ~> 3.35.1], `@semcore/flex-box` [4.5.7 ~> 4.5.8], `@semcore/icon` [2.29.2 ~> 2.29.3]).
 
 ## [4.0.3] - 2022-05-19
 
 ### Fixed
 
-- Synced dependencies versions to remove duplicates in the single export package.
+* Synced dependencies versions to remove duplicates in the single export package.
 
 ## [4.0.1] - 2022-05-18
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/icon` [2.24.0 ~> 2.25.0]).
+* Version patch update due to children dependencies update (`@semcore/icon` [2.24.0 ~> 2.25.0]).
 
 ## [4.0.0] - 2022-05-17
 
 ### BREAK
 
-- Updated styles according to the library redesign policy.
+* Updated styles according to the library redesign policy.
 
 ## [3.4.4] - 2022-05-16
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/icon` [2.21.0 ~> 2.24.0]).
+* Version patch update due to children dependencies update (`@semcore/icon` [2.21.0 ~> 2.24.0]).
 
 ## [3.4.0] - 2021-03-04
 
 ### Added
 
-- Disabled animation if reduce motion is preferred.
+* Disabled animation if reduce motion is preferred.
 
 ## [3.3.2] - 2022-02-24
 
 ### Added
 
-- Added repository field to package.json file.
+* Added repository field to package.json file.
 
 ## [3.3.1] - 2022-02-22
 
 ### Fixed
 
-- Removed css specificity of props lineHeight/fontSize in `Text` component.
+* Removed css specificity of props lineHeight/fontSize in `Text` component.
 
 ## [3.3.0] - 2022-01-18
 
 ### Changed
 
-- Up version icons and use new icon.
-- Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
+* Up version icons and use new icon.
+* Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
 
 ## [3.2.2] - 2021-8-26
 
 ### Changed
 
-- Add 'sideEffect=false' for more optimal build via webpack
+* Add 'sideEffect=false' for more optimal build via webpack
 
 ## [3.2.1] - 2021-08-02
 
 ### Fixed
 
-- [ts] correct types.
+* [ts] correct types.
 
 ## [3.2.0] - 2021-04-26
 
 ### Changed
 
-- Version of dependence `@semcore/core` has been changed to `1.11`.
-- Improved performance. Removed one component wrapper.
-- The style processing system has been changed.
-- Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
+* Version of dependence `@semcore/core` has been changed to `1.11`.
+* Improved performance. Removed one component wrapper.
+* The style processing system has been changed.
+* Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
 
 ## [3.1.0] - 2020-12-17
 
 ### Added
 
-- Added supported react@17.
+* Added supported react@17.
 
 ## [3.0.9] - 2020-10-29
 
 ### Fixed
 
-- Added the placeholder for ID style tag to improve collision protection.
+* Added the placeholder for ID style tag to improve collision protection.
 
 ## [3.0.8] - 2020-09-16
 
 ### Fixed
 
-- Set props `fontSize`, `lineHeight` for component`Text`. Now it independent from prop `size`.
-- Problem use prop `noWrap` for `List.Item`. Now text reduce in ellipsis for `<List.Item noWrap>`
+* Set props `fontSize`, `lineHeight` for component`Text`. Now it independent from prop `size`.
+* Problem use prop `noWrap` for `List.Item`. Now text reduce in ellipsis for `<List.Item noWrap>`
 
 ## [3.0.7] - 2020-09-08
 
 ### Fixed
 
-- Fixed possible styles collisions between components with different versions, but same styles
+* Fixed possible styles collisions between components with different versions, but same styles
 
 ## [3.0.6] - 2020-09-07
 
 ### Fixed
 
-- Flag `sideEffects` now contain list of files with side effects
+* Flag `sideEffects` now contain list of files with side effects
 
 ## [3.0.5] - 2020-09-03
 
 ### Fixed
 
-- Added flag `sideEffects: false` to package.json
+* Added flag `sideEffects: false` to package.json
 
 ## [3.0.4] - 2020-08-14
 
 ### Fixed
 
-- Исправлены не работающие props `fontSize` и `lineHeight` у компонента `Text`
+* Исправлены не работающие props `fontSize` и `lineHeight` у компонента `Text`
 
 ## [3.0.3] - 2020-06-22
 
 ### Fixed
 
-- Убрано подчеркивание у Hint при наведении.
+* Убрано подчеркивание у Hint при наведении.
 
 ## [3.0.2] - 2020-06-10
 
 ### Fixed
 
-- Исправлены TS типы
+* Исправлены TS типы
 
 ## [3.0.1] - 2020-06-08
 
 ### BREAK
 
-- Изменения описаны в [migration guide](/internal/migration-guide)
+* Изменения описаны в [migration guide](/internal/migration-guide)
 
 ### Added
 
-- Добавили свойство `ellipsis` для компонента `Text`
+* Добавили свойство `ellipsis` для компонента `Text`
 
 ### Changed
 
-- Изменили цвет `Hint` активного и по ховеру c 16% на 12%
+* Изменили цвет `Hint` активного и по ховеру c 16% на 12%
 
 ## [2.6.2] - 2020-03-24
 
 ### Fixed
 
-- Добавлена пропущенная зависимость `@semcore/flex-box`/`@semcore/icon`
+* Добавлена пропущенная зависимость `@semcore/flex-box`/`@semcore/icon`
 
 ## [2.6.1] - 2019-12-17
 
 ### Fixed
 
-- Исправлен транспайл цветовых переменных для стилей без префиксов (build.css)
+* Исправлен транспайл цветовых переменных для стилей без префиксов (build.css)
 
 ## [2.6.0] - 2019-12-12
 
 ### Added
 
-- Появилась возможность добавления различных стилистических тем через css переменные
-- Появилась возможность оптицонально подключать адаптивноссть
-- Появилась возможность изолировать стили даже в пределах одной страницы
+* Появилась возможность добавления различных стилистических тем через css переменные
+* Появилась возможность оптицонально подключать адаптивноссть
+* Появилась возможность изолировать стили даже в пределах одной страницы
 
 ### Changed
 
-- Изменен алгоритм вставки стилей в head
+* Изменен алгоритм вставки стилей в head
 
 ### Removed
 
-- Убраны относительные единицы измерения(rem), которые использовались для адаптивности
+* Убраны относительные единицы измерения(rem), которые использовались для адаптивности
 
 ## [2.5.1] - 2019-12-08
 
 ### Fixed
 
-- Получение DOM-ноды через `ref` для всех компоненетов
+* Получение DOM-ноды через `ref` для всех компоненетов
 
 ## [2.5.0] - 2019-11-14
 
 ### Added
 
-- Добавлена адаптивность на маленьких экранах(<768px)
+* Добавлена адаптивность на маленьких экранах(<768px)
 
 ## [2.4.5] - 2019-10-24
 
 ### Changed
 
-- Поднята зависимость `utils`
+* Поднята зависимость `utils`
 
 ## [2.4.4] - 2019-09-30
 
 ### Changed
 
-- Нужные зависимости перенесены в `utils`, размер должен стать меньше
+* Нужные зависимости перенесены в `utils`, размер должен стать меньше
 
 ## [2.4.3] - 2019-09-11
 
 ### Fixed
 
-- Изменен `span` -> `div` в `List.Item`
+* Изменен `span` -> `div` в `List.Item`
 
 ## [2.4.2] - 2019-09-05
 
 ### Fixed
 
-- Исправлена ошибка в типизации `Hint`
-- Заменены устаревшие типографические переменные в `Blockquote`
+* Исправлена ошибка в типизации `Hint`
+* Заменены устаревшие типографические переменные в `Blockquote`
 
 ### Changed
 
-- Размеры шрифта и межстрочного интервала теперь берутся из `style/var.css` утилит
+* Размеры шрифта и межстрочного интервала теперь берутся из `style/var.css` утилит
 
 ## [2.4.1] - 2019-08-12
 
 ### Changed
 
-- Обновлены `utils`
-- Улучшена функция оборачивания в `Text` у `Hint`
+* Обновлены `utils`
+* Улучшена функция оборачивания в `Text` у `Hint`
 
 ## [2.4.0] - 2019-07-31
 
 ### Added
 
-- У `Text` добавлен сброс отступов
+* У `Text` добавлен сброс отступов
 
 ### Fixed
 
-- Исправлена сборка для рендера css на сервере
+* Исправлена сборка для рендера css на сервере
 
 ## [2.3.1] - 2019-06-24
 
 ### Fixed
 
-- Исправлена ошибка в типизации компонента Hint
+* Исправлена ошибка в типизации компонента Hint
 
 ## [2.3.0] - 2019-05-15
 
 ### Added
 
-- Добавлен `Hint` компонент
+* Добавлен `Hint` компонент
 
 ## [2.2.0] - 2019-02-26
 
 ### Added
 
-- Добавлено `noWrap` свойство
+* Добавлено `noWrap` свойство
 
 ### Changed
 
-- Обновлена зависимость `paint`
+* Обновлена зависимость `paint`
 
 ## [2.1.0] - 2019-02-18
 
 ### Added
 
-- Добавлено `medium` свойство
+* Добавлено `medium` свойство
 
 ### Changed
 
-- Обновлена зависимость `paint`
+* Обновлена зависимость `paint`
 
 ## [2.0.0] - 2019-02-08
 
 ### BREAK
 
-- Удалены компоненты `P`/`H`/`Small`/`UL`/`OL`/`CheckList`
-- Удалено свойство `gutterBottom`
-- Изменены значения `size` у всех компонентов(0, 2, 3 -> 100, 200, 300)
+* Удалены компоненты `P`/`H`/`Small`/`UL`/`OL`/`CheckList`
+* Удалено свойство `gutterBottom`
+* Изменены значения `size` у всех компонентов(0, 2, 3 -> 100, 200, 300)
 
 ### Added
 
-- Унаследовано от `Box`/`Print`
-- В `List` можно передовать пользовательский маркер
+* Унаследовано от `Box`/`Print`
+* В `List` можно передовать пользовательский маркер
 
 ## [1.0.3] - 2018-14-11
 
 ### Added
 
-- Размеры `line-height` для `Text`, `CheckList`, `Ol`, `Ul`
+* Размеры `line-height` для `Text`, `CheckList`, `Ol`, `Ul`
 
 ## [1.0.2] - 2018-10-09
 
 ### Fixed
 
-- Исправлена проблема отображения `CheckList` в production-сборке
+* Исправлена проблема отображения `CheckList` в production-сборке
 
 ## [1.0.1] - 2018-10-09
 
 ### Fixed
 
-- Paragraph `m` высота строки исправлена с 1.5 на 1.42
+* Paragraph `m` высота строки исправлена с 1.5 на 1.42
 
 ## [1.0.0] - 2018-08-29
 
 ### Added
 
-- Component CheckList
+* Component CheckList
 
 ## [1.0.0-1] - 2018-08-14
 
 ### Added
 
-- Initial release
+* Initial release

--- a/semcore/typography/CHANGELOG.md
+++ b/semcore/typography/CHANGELOG.md
@@ -6,97 +6,97 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Added
 
-* `monospace` prop to `Text` component.
+- `monospace` prop to `Text` component.
 
 ## [5.8.2] - 2023-09-12
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/icon` [4.8.1 ~> 4.8.2], `@semcore/core` [2.6.2 ~> 2.6.3]).
+- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/icon` [4.8.1 ~> 4.8.2], `@semcore/core` [2.6.2 ~> 2.6.3]).
 
 ## [5.8.1] - 2023-09-08
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/icon` [4.8.0 ~> 4.8.1], `@semcore/core` [2.6.1 ~> 2.6.2]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/icon` [4.8.0 ~> 4.8.1], `@semcore/core` [2.6.1 ~> 2.6.2]).
 
 ## [5.8.0] - 2023-09-05
 
 ### Added
 
-* `semibold` prop to `Text` component.
+- `semibold` prop to `Text` component.
 
 ## [5.7.1] - 2023-09-05
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/icon` [4.7.0 ~> 4.7.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
+- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/icon` [4.7.0 ~> 4.7.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
 
 ## [5.7.0] - 2023-09-04
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/icon` [4.6.0 ~> 4.7.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
+- Version preminor update due to children dependencies update (`@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/icon` [4.6.0 ~> 4.7.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
 
 ## [5.6.0] - 2023-08-28
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/icon` [4.5.1 ~> 4.6.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/icon` [4.5.1 ~> 4.6.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
 
 ## [5.5.1] - 2023-08-24
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/icon` [4.5.0 ~> 4.5.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/icon` [4.5.0 ~> 4.5.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
 
 ## [5.5.0] - 2023-08-23
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/flex-box` [5.3.1 ~> 5.4.0], `@semcore/icon` [4.4.1 ~> 4.5.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/flex-box` [5.3.1 ~> 5.4.0], `@semcore/icon` [4.4.1 ~> 4.5.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
 
 ## [5.4.1] - 2023-08-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/icon` [4.4.0 ~> 4.4.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
+- Version prepatch update due to children dependencies update (`@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/icon` [4.4.0 ~> 4.4.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
 
 ## [5.4.0] - 2023-08-18
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/icon` [4.3.1 ~> 4.4.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/icon` [4.3.1 ~> 4.4.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
 
 ## [5.3.1] - 2023-08-16
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/icon` [4.3.0 ~> 4.3.1], `@semcore/core` [2.2.0 ~> 2.2.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/icon` [4.3.0 ~> 4.3.1], `@semcore/core` [2.2.0 ~> 2.2.1]).
 
 ## [5.3.0] - 2023-08-07
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.0.0 ~> 4.1.0], `@semcore/flex-box` [5.1.0 ~> 5.2.0], `@semcore/icon` [4.2.0 ~> 4.3.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.0.0 ~> 4.1.0], `@semcore/flex-box` [5.1.0 ~> 5.2.0], `@semcore/icon` [4.2.0 ~> 4.3.0]).
 
 ## [5.2.0] - 2023-08-01
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/flex-box` [5.0.0 ~> 5.1.0], `@semcore/icon` [4.1.0 ~> 4.2.0]).
+- Version minor update due to children dependencies update (`@semcore/flex-box` [5.0.0 ~> 5.1.0], `@semcore/icon` [4.1.0 ~> 4.2.0]).
 
 ## [5.1.0] - 2023-07-27
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/icon` [4.0.0 ~> 4.1.0]).
+- Version minor update due to children dependencies update (`@semcore/icon` [4.0.0 ~> 4.1.0]).
 
 ## [5.0.0] - 2023-07-17
 
 ### Break
 
-* Strict, backward incompatible typings.
+- Strict, backward incompatible typings.
 
 ## [4.4.14] - 2023-06-30
 
@@ -104,85 +104,85 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [3.15.3 ~> 3.16.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [3.15.3 ~> 3.16.0]).
 
 ## [4.4.12] - 2023-06-27
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.4 ~> 3.54.0], `@semcore/flex-box` [4.7.31 ~> 4.7.32], `@semcore/icon` [3.15.2 ~> 3.15.3]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.4 ~> 3.54.0], `@semcore/flex-box` [4.7.31 ~> 4.7.32], `@semcore/icon` [3.15.2 ~> 3.15.3]).
 
 ## [4.4.11] - 2023-06-14
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.3 ~> 3.53.4], `@semcore/flex-box` [4.7.30 ~> 4.7.31], `@semcore/icon` [3.15.1 ~> 3.15.2]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.3 ~> 3.53.4], `@semcore/flex-box` [4.7.30 ~> 4.7.31], `@semcore/icon` [3.15.1 ~> 3.15.2]).
 
 ## [4.4.10] - 2023-06-12
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.2 ~> 3.53.3], `@semcore/flex-box` [4.7.29 ~> 4.7.30], `@semcore/icon` [3.15.0 ~> 3.15.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.2 ~> 3.53.3], `@semcore/flex-box` [4.7.29 ~> 4.7.30], `@semcore/icon` [3.15.0 ~> 3.15.1]).
 
 ## [4.4.9] - 2023-06-09
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.1 ~> 3.53.2], `@semcore/flex-box` [4.7.28 ~> 4.7.29], `@semcore/icon` [3.14.16 ~> 3.15.0]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.1 ~> 3.53.2], `@semcore/flex-box` [4.7.28 ~> 4.7.29], `@semcore/icon` [3.14.16 ~> 3.15.0]).
 
 ## [4.4.8] - 2023-06-07
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.0 ~> 3.53.1], `@semcore/flex-box` [4.7.27 ~> 4.7.28], `@semcore/icon` [3.14.15 ~> 3.14.16]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.0 ~> 3.53.1], `@semcore/flex-box` [4.7.27 ~> 4.7.28], `@semcore/icon` [3.14.15 ~> 3.14.16]).
 
 ## [4.4.7] - 2023-05-31
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.52.0 ~> 3.53.0], `@semcore/flex-box` [4.7.26 ~> 4.7.27], `@semcore/icon` [3.14.14 ~> 3.14.15]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.52.0 ~> 3.53.0], `@semcore/flex-box` [4.7.26 ~> 4.7.27], `@semcore/icon` [3.14.14 ~> 3.14.15]).
 
 ## [4.4.6] - 2023-05-25
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.51.1 ~> 3.52.0], `@semcore/flex-box` [4.7.25 ~> 4.7.26], `@semcore/icon` [3.14.13 ~> 3.14.14]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.51.1 ~> 3.52.0], `@semcore/flex-box` [4.7.25 ~> 4.7.26], `@semcore/icon` [3.14.13 ~> 3.14.14]).
 
 ## [4.4.5] - 2023-05-24
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.51.0 ~> 3.51.1], `@semcore/flex-box` [4.7.24 ~> 4.7.25], `@semcore/icon` [3.14.12 ~> 3.14.13]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.51.0 ~> 3.51.1], `@semcore/flex-box` [4.7.24 ~> 4.7.25], `@semcore/icon` [3.14.12 ~> 3.14.13]).
 
 ## [4.4.4] - 2023-05-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.7 ~> 3.51.0], `@semcore/flex-box` [4.7.23 ~> 4.7.24], `@semcore/icon` [3.14.11 ~> 3.14.12]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.7 ~> 3.51.0], `@semcore/flex-box` [4.7.23 ~> 4.7.24], `@semcore/icon` [3.14.11 ~> 3.14.12]).
 
 ## [4.4.3] - 2023-05-11
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7], `@semcore/flex-box` [4.7.22 ~> 4.7.23], `@semcore/icon` [3.14.10 ~> 3.14.11]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7], `@semcore/flex-box` [4.7.22 ~> 4.7.23], `@semcore/icon` [3.14.10 ~> 3.14.11]).
 
 ## [4.4.2] - 2023-05-04
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.5 ~> 3.50.6], `@semcore/flex-box` [4.7.21 ~> 4.7.22], `@semcore/icon` [3.14.9 ~> 3.14.10]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.5 ~> 3.50.6], `@semcore/flex-box` [4.7.21 ~> 4.7.22], `@semcore/icon` [3.14.9 ~> 3.14.10]).
 
 ## [4.4.0] - 2023-04-25
 
 ### Added
 
-* Added `uppercase`, `lowercase`, `capitalize` text transformation props.
+- Added `uppercase`, `lowercase`, `capitalize` text transformation props.
 
 ## [4.3.29] - 2023-04-17
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.0 ~> 3.50.3], `@semcore/flex-box` [4.7.18 ~> 4.7.19], `@semcore/icon` [3.14.6 ~> 3.14.7]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.0 ~> 3.50.3], `@semcore/flex-box` [4.7.18 ~> 4.7.19], `@semcore/icon` [3.14.6 ~> 3.14.7]).
 
 ## [4.3.16] - 2023-02-22
 
@@ -190,7 +190,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.47.0 ~> 3.47.1], `@semcore/flex-box` [4.7.9 ~> 4.7.10], `@semcore/icon` [3.10.1 ~> 3.10.2]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.47.0 ~> 3.47.1], `@semcore/flex-box` [4.7.9 ~> 4.7.10], `@semcore/icon` [3.10.1 ~> 3.10.2]).
 
 ## [4.3.12] - 2023-02-13
 
@@ -200,7 +200,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.45.0 ~> 3.46.0], `@semcore/flex-box` [4.7.6 ~> 4.7.7], `@semcore/icon` [3.7.0 ~> 3.8.0]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.45.0 ~> 3.46.0], `@semcore/flex-box` [4.7.6 ~> 4.7.7], `@semcore/icon` [3.7.0 ~> 3.8.0]).
 
 ## [4.3.7] - 2023-01-11
 
@@ -210,19 +210,19 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.44.1 ~> 3.44.2], `@semcore/flex-box` [4.7.3 ~> 4.7.4], `@semcore/icon` [3.5.0 ~> 3.5.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.44.1 ~> 3.44.2], `@semcore/flex-box` [4.7.3 ~> 4.7.4], `@semcore/icon` [3.5.0 ~> 3.5.1]).
 
 ## [4.3.1] - 2022-12-13
 
 ### Changed
 
-* Added `react-dom` to peer dependencies.
+- Added `react-dom` to peer dependencies.
 
 ## [4.3.0] - 2022-12-12
 
 ### Added
 
-* Design tokens based theming.
+- Design tokens based theming.
 
 ## [4.2.6] - 2022-11-08
 
@@ -230,329 +230,329 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.40.0 ~> 3.40.0], `@semcore/flex-box` [4.6.2 ~> 4.6.3], `@semcore/icon` [3.1.1 ~> 3.1.2]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.40.0 ~> 3.40.0], `@semcore/flex-box` [4.6.2 ~> 4.6.3], `@semcore/icon` [3.1.1 ~> 3.1.2]).
 
 ## [4.2.0] - 2022-10-10
 
 ### Changed
 
-* Added support for React 18 🔥
-* Extended version range for dependency `@semcore/icons`.
+- Added support for React 18 🔥
+- Extended version range for dependency `@semcore/icons`.
 
 ## [4.1.11] - 2022-10-06
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [2.32.2 ~> 2.33.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [2.32.2 ~> 2.33.0]).
 
 ## [4.1.0] - 2022-08-10
 
 ### Changed
 
-* Added essential `aria-\*` attributes for Typography lists.
+- Added essential `aria-\*` attributes for Typography lists.
 
 ## [4.0.11] - 2022-08-01
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.35.0 ~> 3.35.1], `@semcore/flex-box` [4.5.7 ~> 4.5.8], `@semcore/icon` [2.29.2 ~> 2.29.3]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.35.0 ~> 3.35.1], `@semcore/flex-box` [4.5.7 ~> 4.5.8], `@semcore/icon` [2.29.2 ~> 2.29.3]).
 
 ## [4.0.3] - 2022-05-19
 
 ### Fixed
 
-* Synced dependencies versions to remove duplicates in the single export package.
+- Synced dependencies versions to remove duplicates in the single export package.
 
 ## [4.0.1] - 2022-05-18
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [2.24.0 ~> 2.25.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [2.24.0 ~> 2.25.0]).
 
 ## [4.0.0] - 2022-05-17
 
 ### BREAK
 
-* Updated styles according to the library redesign policy.
+- Updated styles according to the library redesign policy.
 
 ## [3.4.4] - 2022-05-16
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [2.21.0 ~> 2.24.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [2.21.0 ~> 2.24.0]).
 
 ## [3.4.0] - 2021-03-04
 
 ### Added
 
-* Disabled animation if reduce motion is preferred.
+- Disabled animation if reduce motion is preferred.
 
 ## [3.3.2] - 2022-02-24
 
 ### Added
 
-* Added repository field to package.json file.
+- Added repository field to package.json file.
 
 ## [3.3.1] - 2022-02-22
 
 ### Fixed
 
-* Removed css specificity of props lineHeight/fontSize in `Text` component.
+- Removed css specificity of props lineHeight/fontSize in `Text` component.
 
 ## [3.3.0] - 2022-01-18
 
 ### Changed
 
-* Up version icons and use new icon.
-* Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
+- Up version icons and use new icon.
+- Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
 
 ## [3.2.2] - 2021-8-26
 
 ### Changed
 
-* Add 'sideEffect=false' for more optimal build via webpack
+- Add 'sideEffect=false' for more optimal build via webpack
 
 ## [3.2.1] - 2021-08-02
 
 ### Fixed
 
-* [ts] correct types.
+- [ts] correct types.
 
 ## [3.2.0] - 2021-04-26
 
 ### Changed
 
-* Version of dependence `@semcore/core` has been changed to `1.11`.
-* Improved performance. Removed one component wrapper.
-* The style processing system has been changed.
-* Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
+- Version of dependence `@semcore/core` has been changed to `1.11`.
+- Improved performance. Removed one component wrapper.
+- The style processing system has been changed.
+- Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
 
 ## [3.1.0] - 2020-12-17
 
 ### Added
 
-* Added supported react@17.
+- Added supported react@17.
 
 ## [3.0.9] - 2020-10-29
 
 ### Fixed
 
-* Added the placeholder for ID style tag to improve collision protection.
+- Added the placeholder for ID style tag to improve collision protection.
 
 ## [3.0.8] - 2020-09-16
 
 ### Fixed
 
-* Set props `fontSize`, `lineHeight` for component`Text`. Now it independent from prop `size`.
-* Problem use prop `noWrap` for `List.Item`. Now text reduce in ellipsis for `<List.Item noWrap>`
+- Set props `fontSize`, `lineHeight` for component`Text`. Now it independent from prop `size`.
+- Problem use prop `noWrap` for `List.Item`. Now text reduce in ellipsis for `<List.Item noWrap>`
 
 ## [3.0.7] - 2020-09-08
 
 ### Fixed
 
-* Fixed possible styles collisions between components with different versions, but same styles
+- Fixed possible styles collisions between components with different versions, but same styles
 
 ## [3.0.6] - 2020-09-07
 
 ### Fixed
 
-* Flag `sideEffects` now contain list of files with side effects
+- Flag `sideEffects` now contain list of files with side effects
 
 ## [3.0.5] - 2020-09-03
 
 ### Fixed
 
-* Added flag `sideEffects: false` to package.json
+- Added flag `sideEffects: false` to package.json
 
 ## [3.0.4] - 2020-08-14
 
 ### Fixed
 
-* Исправлены не работающие props `fontSize` и `lineHeight` у компонента `Text`
+- Исправлены не работающие props `fontSize` и `lineHeight` у компонента `Text`
 
 ## [3.0.3] - 2020-06-22
 
 ### Fixed
 
-* Убрано подчеркивание у Hint при наведении.
+- Убрано подчеркивание у Hint при наведении.
 
 ## [3.0.2] - 2020-06-10
 
 ### Fixed
 
-* Исправлены TS типы
+- Исправлены TS типы
 
 ## [3.0.1] - 2020-06-08
 
 ### BREAK
 
-* Изменения описаны в [migration guide](/internal/migration-guide)
+- Изменения описаны в [migration guide](/internal/migration-guide)
 
 ### Added
 
-* Добавили свойство `ellipsis` для компонента `Text`
+- Добавили свойство `ellipsis` для компонента `Text`
 
 ### Changed
 
-* Изменили цвет `Hint` активного и по ховеру c 16% на 12%
+- Изменили цвет `Hint` активного и по ховеру c 16% на 12%
 
 ## [2.6.2] - 2020-03-24
 
 ### Fixed
 
-* Добавлена пропущенная зависимость `@semcore/flex-box`/`@semcore/icon`
+- Добавлена пропущенная зависимость `@semcore/flex-box`/`@semcore/icon`
 
 ## [2.6.1] - 2019-12-17
 
 ### Fixed
 
-* Исправлен транспайл цветовых переменных для стилей без префиксов (build.css)
+- Исправлен транспайл цветовых переменных для стилей без префиксов (build.css)
 
 ## [2.6.0] - 2019-12-12
 
 ### Added
 
-* Появилась возможность добавления различных стилистических тем через css переменные
-* Появилась возможность оптицонально подключать адаптивноссть
-* Появилась возможность изолировать стили даже в пределах одной страницы
+- Появилась возможность добавления различных стилистических тем через css переменные
+- Появилась возможность оптицонально подключать адаптивноссть
+- Появилась возможность изолировать стили даже в пределах одной страницы
 
 ### Changed
 
-* Изменен алгоритм вставки стилей в head
+- Изменен алгоритм вставки стилей в head
 
 ### Removed
 
-* Убраны относительные единицы измерения(rem), которые использовались для адаптивности
+- Убраны относительные единицы измерения(rem), которые использовались для адаптивности
 
 ## [2.5.1] - 2019-12-08
 
 ### Fixed
 
-* Получение DOM-ноды через `ref` для всех компоненетов
+- Получение DOM-ноды через `ref` для всех компоненетов
 
 ## [2.5.0] - 2019-11-14
 
 ### Added
 
-* Добавлена адаптивность на маленьких экранах(<768px)
+- Добавлена адаптивность на маленьких экранах(<768px)
 
 ## [2.4.5] - 2019-10-24
 
 ### Changed
 
-* Поднята зависимость `utils`
+- Поднята зависимость `utils`
 
 ## [2.4.4] - 2019-09-30
 
 ### Changed
 
-* Нужные зависимости перенесены в `utils`, размер должен стать меньше
+- Нужные зависимости перенесены в `utils`, размер должен стать меньше
 
 ## [2.4.3] - 2019-09-11
 
 ### Fixed
 
-* Изменен `span` -> `div` в `List.Item`
+- Изменен `span` -> `div` в `List.Item`
 
 ## [2.4.2] - 2019-09-05
 
 ### Fixed
 
-* Исправлена ошибка в типизации `Hint`
-* Заменены устаревшие типографические переменные в `Blockquote`
+- Исправлена ошибка в типизации `Hint`
+- Заменены устаревшие типографические переменные в `Blockquote`
 
 ### Changed
 
-* Размеры шрифта и межстрочного интервала теперь берутся из `style/var.css` утилит
+- Размеры шрифта и межстрочного интервала теперь берутся из `style/var.css` утилит
 
 ## [2.4.1] - 2019-08-12
 
 ### Changed
 
-* Обновлены `utils`
-* Улучшена функция оборачивания в `Text` у `Hint`
+- Обновлены `utils`
+- Улучшена функция оборачивания в `Text` у `Hint`
 
 ## [2.4.0] - 2019-07-31
 
 ### Added
 
-* У `Text` добавлен сброс отступов
+- У `Text` добавлен сброс отступов
 
 ### Fixed
 
-* Исправлена сборка для рендера css на сервере
+- Исправлена сборка для рендера css на сервере
 
 ## [2.3.1] - 2019-06-24
 
 ### Fixed
 
-* Исправлена ошибка в типизации компонента Hint
+- Исправлена ошибка в типизации компонента Hint
 
 ## [2.3.0] - 2019-05-15
 
 ### Added
 
-* Добавлен `Hint` компонент
+- Добавлен `Hint` компонент
 
 ## [2.2.0] - 2019-02-26
 
 ### Added
 
-* Добавлено `noWrap` свойство
+- Добавлено `noWrap` свойство
 
 ### Changed
 
-* Обновлена зависимость `paint`
+- Обновлена зависимость `paint`
 
 ## [2.1.0] - 2019-02-18
 
 ### Added
 
-* Добавлено `medium` свойство
+- Добавлено `medium` свойство
 
 ### Changed
 
-* Обновлена зависимость `paint`
+- Обновлена зависимость `paint`
 
 ## [2.0.0] - 2019-02-08
 
 ### BREAK
 
-* Удалены компоненты `P`/`H`/`Small`/`UL`/`OL`/`CheckList`
-* Удалено свойство `gutterBottom`
-* Изменены значения `size` у всех компонентов(0, 2, 3 -> 100, 200, 300)
+- Удалены компоненты `P`/`H`/`Small`/`UL`/`OL`/`CheckList`
+- Удалено свойство `gutterBottom`
+- Изменены значения `size` у всех компонентов(0, 2, 3 -> 100, 200, 300)
 
 ### Added
 
-* Унаследовано от `Box`/`Print`
-* В `List` можно передовать пользовательский маркер
+- Унаследовано от `Box`/`Print`
+- В `List` можно передовать пользовательский маркер
 
 ## [1.0.3] - 2018-14-11
 
 ### Added
 
-* Размеры `line-height` для `Text`, `CheckList`, `Ol`, `Ul`
+- Размеры `line-height` для `Text`, `CheckList`, `Ol`, `Ul`
 
 ## [1.0.2] - 2018-10-09
 
 ### Fixed
 
-* Исправлена проблема отображения `CheckList` в production-сборке
+- Исправлена проблема отображения `CheckList` в production-сборке
 
 ## [1.0.1] - 2018-10-09
 
 ### Fixed
 
-* Paragraph `m` высота строки исправлена с 1.5 на 1.42
+- Paragraph `m` высота строки исправлена с 1.5 на 1.42
 
 ## [1.0.0] - 2018-08-29
 
 ### Added
 
-* Component CheckList
+- Component CheckList
 
 ## [1.0.0-1] - 2018-08-14
 
 ### Added
 
-* Initial release
+- Initial release

--- a/semcore/typography/src/index.d.ts
+++ b/semcore/typography/src/index.d.ts
@@ -22,6 +22,8 @@ export type TextProps = BoxProps & {
   italic?: boolean;
   /** Underlined text */
   underline?: boolean;
+  /** CSS property `font-family: monospace;` */
+  monospace?: boolean;
   /** Strikethrough text */
   lineThrough?: boolean;
   /** Uppercase text */

--- a/semcore/typography/src/style/text.shadow.css
+++ b/semcore/typography/src/style/text.shadow.css
@@ -65,6 +65,10 @@ SText[italic] {
   font-style: italic;
 }
 
+SText[monospace] {
+  font-family: Consolas, 'Roboto Mono', Menlo, Courier, monospace;
+}
+
 SText[uppercase] {
   text-transform: uppercase;
 }

--- a/website/docs/style/typography/examples/format-text.tsx
+++ b/website/docs/style/typography/examples/format-text.tsx
@@ -36,6 +36,9 @@ export default () => (
     <h6>
       H6, <small>16px</small>
     </h6>
+    <p>
+      But I do love the taste of a <code>good burger</code>. Mm-mm-mm.
+    </p>
     <ul>
       <li>I'm gonna make him an offer he can't refuse.</li>
       <li>Carpe diem. Seize the day, boys. Make your lives extraordinary.</li>

--- a/website/docs/style/typography/examples/text-emphasis.tsx
+++ b/website/docs/style/typography/examples/text-emphasis.tsx
@@ -18,6 +18,9 @@ export default () => (
     <Text size={300} tag='p' mb={2} mt={0}>
       But I do love the taste of a <Text tag='s'>good burger</Text>. Mm-mm-mm.
     </Text>
+    <Text size={300} tag='p' mb={2} mt={0} monospace>
+      monospace text
+    </Text>
     <Text size={300} tag='p' mb={2} mt={0} uppercase>
       uppercase text
     </Text>


### PR DESCRIPTION
## Motivation and Context
We have a request for providing default styles for font with `monospace` font-family and `code` tag. So I've added `monospace` prop for Text component and styles for `code` tag for FormatText component. 
**I need you to check these updates from the frontend side.**

## How has this been tested?
I used our playground and examples on the website to test if the new property and `code` tag was added and can be used for Text and FormatText components.

## Types of changes

- [x] New feature (non-breaking change which adds functionality).

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
