### PR TITLE
[date-picker] fixed types for render props in DateRangePicker.Trigger

### DIFF
--- a/semcore/date-picker/CHANGELOG.md
+++ b/semcore/date-picker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.10.1] - 2023-09-20
+
+### Fixed
+
+- Fixed types for `value` and `onChange` in DateRangePicker.Trigger.
+
 ## [4.10.0] - 2023-09-19
 
 ### Changed

--- a/semcore/date-picker/src/index.d.ts
+++ b/semcore/date-picker/src/index.d.ts
@@ -263,16 +263,23 @@ export type DatePickerHandlers = {
 
 /** @deprecated */
 export interface IInputTriggerProps extends InputTriggerProps, UnknownProperties {}
-export type InputTriggerProps = InputProps & {
-  value?: Date;
+type BaseInputTriggerProps = InputProps & {
   /**
    * Date input placeholder characters
    * @default { year: 'Y'; month: 'M'; day: 'D' }
    */
   placeholders?: { year: string; month: string; day: string };
-  onChange?: (date: Date, event: ChangeEvent) => void;
   locale?: string;
   onDisplayedPeriodChange?: (date: Date) => void;
+};
+export type InputTriggerProps = BaseInputTriggerProps & {
+  value?: Date;
+  onChange?: (date: Date, event: ChangeEvent) => void;
+};
+
+export type RangeInputTriggerProps = BaseInputTriggerProps & {
+  value?: Date[];
+  onChange?: (date: Date[], event: ChangeEvent) => void;
 };
 
 /** @deprecated */
@@ -281,7 +288,7 @@ export type SingleDateInputProps = InputTriggerProps & {};
 
 /** @deprecated */
 export interface IDateRangeProps extends DateRangeProps, UnknownProperties {}
-export type DateRangeProps = InputTriggerProps & {};
+export type DateRangeProps = RangeInputTriggerProps & {};
 
 /** @deprecated */
 export interface IDatePickerMaskedInputProps
@@ -306,6 +313,14 @@ declare const InputTrigger: Intergalactic.Component<
     Indicator: typeof Input.Addon;
     MaskedInput: Intergalactic.Component<'input', InputMaskValueProps & DatePickerMaskedInputProps>;
   };
+};
+
+declare const RangeInputTrigger: Intergalactic.Component<
+  'div',
+  DropdownTriggerProps & RangeInputTriggerProps
+> & {
+  Addon: typeof Input.Addon;
+  Value: typeof Input.Value;
   DateRange: Intergalactic.Component<'div', InputValueProps & DateRangeProps> & {
     Indicator: typeof Input.Addon;
     RangeSep: typeof Input.Addon;
@@ -366,7 +381,7 @@ declare const DateRangePicker: Intergalactic.Component<
     Addon: typeof BaseTrigger.Addon;
     Text: typeof BaseTrigger.Text;
   };
-  Trigger: typeof InputTrigger;
+  Trigger: typeof RangeInputTrigger;
   Popper: typeof Dropdown.Popper;
   Header: typeof Box;
   Title: Intergalactic.Component<'div', DateRangePickerProps, DateRangePickerContext>;
@@ -438,7 +453,7 @@ declare const MonthRangePicker: Intergalactic.Component<
     Addon: typeof BaseTrigger.Addon;
     Text: typeof BaseTrigger.Text;
   };
-  Trigger: typeof InputTrigger;
+  Trigger: typeof RangeInputTrigger;
   Popper: typeof Dropdown.Popper;
   Header: typeof Box;
   Title: Intergalactic.Component<'div', DateRangePickerProps, MonthRangePickerContext>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed types for `value` and `onChange` from `Date` to `Date[]` in `DateRangePicker.Trigger`

## Motivation and Context
#767 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Code cannot be tested automatically so I have tested it only manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
