### PR TITLE
[utils] React invalid Hooks call caused by `useFocusLock` in some rare cases from it's nested hooks

### DIFF
--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.7.3] - 2023-09-28
+
+### Fixed
+
+- React invalid Hooks call caused by `useFocusLock` in some rare cases from it's nested hooks.
+
 ## [4.7.2] - 2023-09-20
 
 ### Changed
@@ -12,7 +18,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Fixed
 
-- Reverse focus in modals (Fixed `useFocuseLock`. Call `safeMoveFocusInside` in `handleFocusIn` with correct second parameter (focusCameFrom instead of event.target))
+- Reversed focus trap looping.
 
 ## [4.7.0] - 2023-09-13
 

--- a/semcore/utils/src/use/useFocusLock.ts
+++ b/semcore/utils/src/use/useFocusLock.ts
@@ -78,17 +78,11 @@ const areBordersPlacedCorrectly = () => {
 type ReactT = typeof LocalReact;
 
 let uniqueId = 0;
-const useUniqueId = (React: ReactT, prefix: string) => {
-  const id = React.useMemo(
-    () => `${prefix}-${Math.random().toString(36).slice(2)}-${uniqueId++}`,
-    [],
-  ); // prefix is considered as a static value
-  const idRef = React.useRef(id);
-  return idRef.current;
-};
+const getUniqueId = (prefix: string) =>
+  `${prefix}-${Math.random().toString(36).slice(2)}-${uniqueId++}`;
 const useFocusBorders = (React: ReactT, disabled?: boolean) => {
-  const id = useUniqueId(React, 'focus-borders-consumer');
   React.useEffect(() => {
+    const id = getUniqueId('focus-borders-consumer');
     if (!disabled) {
       focusBordersConsumers.add(id);
     }
@@ -100,7 +94,7 @@ const useFocusBorders = (React: ReactT, disabled?: boolean) => {
       focusBordersConsumers.delete(id);
       if (focusBordersConsumers.size === 0) removeBorders();
     };
-  }, [id, disabled]);
+  }, [disabled]);
 };
 /**
  * In some cases same page might contain different versions of components.
@@ -251,8 +245,8 @@ const useFocusLockHook = (
     };
   }, [disabled, autoFocus, returnFocusTo, returnFocus]);
 
-  const id = useUniqueId(React, 'focus-lock-consumer');
   React.useEffect(() => {
+    const id = getUniqueId('focus-lock-consumer');
     if (disabled) return;
     focusLockUsedInMountedComponents.add(id);
     return () => {


### PR DESCRIPTION
## Motivation and Context

`useFocusLock` hook is merging if multiple versions of it is loaded on one page.
It's critical to provide smooth UX and prevent focus lock wars.

To make it work on page where multiple projects use multiple versions of React, the React isolation was added. However, it was added with a mistake – nested hooks wasn't isolating React.

This PR adds such isolation.

## How has this been tested?

It was tested manually and I am going to test prerelease version on real world project before publishing release.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
