### PR TITLE
[base-trigger] empty FilterTrigger now gets role `button` during empty state instead of `group`

### DIFF
--- a/semcore/base-trigger/CHANGELOG.md
+++ b/semcore/base-trigger/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.10.0] - 2023-10-22
+
+### Fixed
+
+- Empty FilterTrigger now gets role `button` during empty state instead of `group`.
+
 ## [4.9.2] - 2023-09-20
 
 ### Changed

--- a/semcore/base-trigger/src/FilterTrigger.jsx
+++ b/semcore/base-trigger/src/FilterTrigger.jsx
@@ -70,14 +70,18 @@ class RootFilterTrigger extends Component {
       id,
     } = this.asProps;
 
-    if (this.asProps.role === 'button') {
-      this.asProps.role = 'group';
-    }
+    const role = empty ? this.asProps.role ?? 'button' : 'group';
 
     const [controlProps] = getInputProps(this.asProps, includeInputProps);
 
     return sstyled(styles)(
-      <SWrapper render={Box} aria-label={getI18nText('filter')} __excludeProps={['id']}>
+      <SWrapper
+        render={Box}
+        aria-label={getI18nText('filter')}
+        __excludeProps={['id']}
+        use:role={role}
+        data-role={role}
+      >
         <NeighborLocation>
           <SFilterTrigger
             w='100%'

--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.8.0] - 2023-10-02
+
+### Fixed
+
+- Extended internal mechanism of component wrapper props modifying.
+
 ## [4.7.3] - 2023-09-28
 
 ### Fixed

--- a/semcore/utils/src/assignProps.ts
+++ b/semcore/utils/src/assignProps.ts
@@ -58,6 +58,18 @@ export default function assignProps<P extends AssignableProps, S extends Assigna
     ...props,
     ...assignHandlersInner(props, source),
   };
+  for (const key in source) {
+    if (key.startsWith('use:')) {
+      const originalKey = key.slice('use:'.length);
+      newProps[originalKey] = source[key];
+    }
+  }
+  for (const key in props) {
+    if (key.startsWith('use:')) {
+      const originalKey = key.slice('use:'.length);
+      newProps[originalKey] = props[key];
+    }
+  }
 
   // because react set getter for ref
   const sourceDescriptorRef = Object.getOwnPropertyDescriptor(source, 'ref');


### PR DESCRIPTION
## Motivation and Context

Initially filter trigger had `button` role. Then we found that it's wrong when container has role `button` while having buttons (clear buttons) inside. So we changed it to `group`. 

But action it's not so good. We always needed `button` role when filter empty has empty state and `group` when it has clear button inside. It wasn't implemented yet because props overriding hack (prefixing with `use:`) was working only with style props. Now I made it to work with any prop and made FilterTrigger role group work as needed.  

## How has this been tested?

All tests are passing. Manual tests confirmed that FilterTrigger role is changing

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
