### PR TITLE
[pills] fixed that pills with `behavior="tabs"` had focus ring both o…

### DIFF
--- a/semcore/pills/CHANGELOG.md
+++ b/semcore/pills/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.8.5] - 2023-10-06
+
+### Fixed
+
+- Pills with `behavior="tabs"` had focus ring both on container and on pills. Now focus ring is only on pills.
+- Focus ring of every pill was overlaped by the next sibling pill. 
+
 ## [5.8.4] - 2023-10-03
 
 ### Changed

--- a/semcore/pills/src/style/pills.shadow.css
+++ b/semcore/pills/src/style/pills.shadow.css
@@ -63,9 +63,12 @@ SPill[disabled] {
   }
 }
 
-SPills[keyboardFocused],
+SPills[keyboardFocused]:not([behavior=tabs]) {
+  box-shadow: var(--intergalactic-keyboard-focus, 0px 0px 0px 3px rgba(0, 143, 248, 0.5));
+}
 SPill[keyboardFocused] {
   box-shadow: var(--intergalactic-keyboard-focus, 0px 0px 0px 3px rgba(0, 143, 248, 0.5));
+  z-index: 1;
 }
 
 SText {


### PR DESCRIPTION
…n container and on pills. Now focus ring is only on pills. Also fixed that focus ring of every pill was overlaped by the next sibling pill

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

We had small visual issues with focus ring of Pills component. Checkout screenshots below.

## How has this been tested?

Only manual tests. The change is extremely simple.

## Screenshots:

Before:

<img width="209" alt="Screen Shot 2023-10-06 at 13 53 29" src="https://github.com/semrush/intergalactic/assets/31261408/f4306884-fadb-4716-9654-4b9d309ccd48">

After:

<img width="230" alt="Screen Shot 2023-10-06 at 13 53 43" src="https://github.com/semrush/intergalactic/assets/31261408/2364075e-89e6-43f6-bf73-b0addcb748ae">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
