### PR TITLE
[notice-bubble] added sticky position for non portal NoticeBubble's

### DIFF
--- a/semcore/notice-bubble/CHANGELOG.md
+++ b/semcore/notice-bubble/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.10.1] - 2023-10-10
+
+### Changed
+
+- For `NoticeBubbleContainer` with `disabledPortal` added new styles for `position sticky` behavior.
+
 ## [5.10.0] - 2023-10-09
 
 ### Added

--- a/semcore/notice-bubble/__tests__/index.test.tsx
+++ b/semcore/notice-bubble/__tests__/index.test.tsx
@@ -115,7 +115,7 @@ describe('NoticeBubble', () => {
     const component = (
       <>
         <NoticeBubbleContainer
-          style={{ position: 'static', width: 'auto' }}
+          style={{ position: 'static', width: 'auto', height: 'auto' }}
           disablePortal
           manager={manager}
         />
@@ -162,7 +162,7 @@ describe('NoticeBubble', () => {
     const component = (
       <>
         <NoticeBubbleContainer
-          style={{ position: 'static', width: 'auto' }}
+          style={{ position: 'static', width: 'auto', height: 'auto' }}
           disablePortal
           manager={manager}
         />
@@ -178,7 +178,7 @@ describe('NoticeBubble', () => {
     const component = (
       <>
         <NoticeBubbleContainer
-          style={{ position: 'static', width: 'auto' }}
+          style={{ position: 'static', width: 'auto', height: 'auto' }}
           disablePortal
           manager={manager}
         />
@@ -210,10 +210,10 @@ describe('NoticeBubble', () => {
   test.concurrent('Should render correctly for screen size 760px', async ({ task }) => {
     const manager = new NoticeBubbleManager();
     const component = (
-      <>
+      <div style={{ width: '320px', height: '90px', position: 'relative' }}>
         <NoticeBubbleContainer disablePortal manager={manager} />
         <NoticeBubbleImport manager={manager}>Message</NoticeBubbleImport>
-      </>
+      </div>
     );
     await expect(
       await snapshot(component, {

--- a/semcore/notice-bubble/src/style/notice-bubble.shadow.css
+++ b/semcore/notice-bubble/src/style/notice-bubble.shadow.css
@@ -55,6 +55,11 @@ SNoticeBubble {
     width: calc(100% - var(--intergalactic-spacing-6x, 24px));
   }
 }
+SNoticeBubble[disablePortal] {
+  position: sticky;
+  margin-left: auto;
+  height: 0;
+}
 
 SMessage a {
   color: var(--intergalactic-text-link-invert, #8ecdff);

--- a/website/docs/components/notice-bubble/examples/not-in-portal.tsx
+++ b/website/docs/components/notice-bubble/examples/not-in-portal.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { NoticeBubbleContainer, NoticeBubbleManager } from '@semcore/ui/notice-bubble';
+import Button from '@semcore/ui/button';
+import Link from '@semcore/ui/link';
+
+const manager = new NoticeBubbleManager();
+
+const Demo = () => {
+  const handleClick = () => {
+    manager.add({
+      children: (
+        <>
+          Link was moved to <Link href='#'>Cats from outer space group</Link>
+        </>
+      ),
+      initialAnimation: true,
+      duration: 3000,
+    });
+  };
+
+  return (
+    <div style={{ background: '#eee', height: '180px', position: 'relative', overflow: 'auto' }}>
+      <div style={{ height: '800px' }}>
+        <NoticeBubbleContainer manager={manager} disablePortal={true} />{' '}
+        {/* Should be before another content! */}
+        <Button onClick={handleClick}>Show basic notice</Button>
+      </div>
+    </div>
+  );
+};
+export default Demo;

--- a/website/docs/components/notice-bubble/examples/not-in-portal.tsx
+++ b/website/docs/components/notice-bubble/examples/not-in-portal.tsx
@@ -14,15 +14,16 @@ const Demo = () => {
         </>
       ),
       initialAnimation: true,
-      duration: 3000,
+      duration: 300000,
     });
   };
 
   return (
-    <div style={{ background: '#eee', height: '180px', position: 'relative', overflow: 'auto' }}>
+    <div
+      style={{ border: '1px dashed #eee', height: '180px', position: 'relative', overflow: 'auto' }}
+    >
       <div style={{ height: '800px' }}>
-        <NoticeBubbleContainer manager={manager} disablePortal={true} />{' '}
-        {/* Should be before another content! */}
+        <NoticeBubbleContainer manager={manager} disablePortal={true} />
         <Button onClick={handleClick}>Show basic notice</Button>
       </div>
     </div>

--- a/website/docs/components/notice-bubble/notice-bubble-example.md
+++ b/website/docs/components/notice-bubble/notice-bubble-example.md
@@ -8,6 +8,14 @@ Please note that each example uses its own instance of `NoticeBubbleManager`, wh
 
 @example simple
 
+@## NoticeBubble not in portal
+
+If NoticeBubbleContainer has `disablePortal` it will add `position: sticky` to `Bubbles`.
+
+Parent should have `position: relative` and `overflow` with scroll.
+
+@example not-in-portal
+
 @## Undo action
 
 @example action-button


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fixed view NoticeBubble in Container without portal
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
I have tested it manually, added example in the documents and fixed unit tests for new behavior

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):
<img width="818" alt="Screenshot 2023-10-09 at 10 30 10" src="https://github.com/semrush/intergalactic/assets/8787452/355e3781-383f-4d76-ab67-605f14357999">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [X] I have added new unit tests on added of fixed functionality.
