### PR TITLE
[popper] Prevent to return focus to `Trigger` after popper is closed

### DIFF
--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Fixed
 
-- Prevent to return focus to `Trigger` after popper is closed
+- Prevent to scroll to `Trigger` item after `Popper` is closed. 
 
 ## [5.7.5] - 2023-10-06
 

--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.7.6] - 2023-10-10
+
+### Fixed
+
+- Prevent to return focus to `Trigger` after popper is closed
+
 ## [5.7.5] - 2023-10-06
 
 ### Changed

--- a/semcore/popper/__tests__/index.test.jsx
+++ b/semcore/popper/__tests__/index.test.jsx
@@ -302,4 +302,46 @@ describe('focus control', () => {
     expect(document.activeElement.nodeName).toBe('DIV');
     vi.useRealTimers();
   });
+
+  test('prevent focus return', () => {
+    let hidePopper = undefined;
+    vi.useFakeTimers();
+    const Component = () => {
+      const [visible, setVisible] = React.useState(true);
+      hidePopper = () => setVisible(false);
+
+      return (
+        <>
+          <Popper visible={visible} preventFocusCatch={true}>
+            <Popper.Trigger data-testid='trigger'>trigger</Popper.Trigger>
+            <Popper.Popper autoFocus data-testid='popper'>
+              <div tabIndex={0} data-testid='focusable-in-popper'>
+                popper
+              </div>
+            </Popper.Popper>
+          </Popper>
+        </>
+      );
+    };
+    const { getByTestId } = render(
+      <div data-testid='container'>
+        <Component />
+      </div>,
+    );
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(getByTestId('popper')).toHaveFocus();
+
+    act(() => hidePopper());
+    fireEvent.animationEnd(getByTestId('popper'));
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(getByTestId('trigger')).not.toHaveFocus();
+    vi.useRealTimers();
+  });
 });

--- a/semcore/popper/__tests__/index.test.jsx
+++ b/semcore/popper/__tests__/index.test.jsx
@@ -302,46 +302,4 @@ describe('focus control', () => {
     expect(document.activeElement.nodeName).toBe('DIV');
     vi.useRealTimers();
   });
-
-  test('prevent focus return', () => {
-    let hidePopper = undefined;
-    vi.useFakeTimers();
-    const Component = () => {
-      const [visible, setVisible] = React.useState(true);
-      hidePopper = () => setVisible(false);
-
-      return (
-        <>
-          <Popper visible={visible} preventFocusCatch={true}>
-            <Popper.Trigger data-testid='trigger'>trigger</Popper.Trigger>
-            <Popper.Popper autoFocus data-testid='popper'>
-              <div tabIndex={0} data-testid='focusable-in-popper'>
-                popper
-              </div>
-            </Popper.Popper>
-          </Popper>
-        </>
-      );
-    };
-    const { getByTestId } = render(
-      <div data-testid='container'>
-        <Component />
-      </div>,
-    );
-
-    act(() => {
-      vi.runAllTimers();
-    });
-
-    expect(getByTestId('popper')).toHaveFocus();
-
-    act(() => hidePopper());
-    fireEvent.animationEnd(getByTestId('popper'));
-    act(() => {
-      vi.runAllTimers();
-    });
-
-    expect(getByTestId('trigger')).not.toHaveFocus();
-    vi.useRealTimers();
-  });
 });

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -434,7 +434,7 @@ const useFocusCatch = (active, popperRef) => {
   return { focusCatch, handleFocusCatchBlur, handleFocusCatchRef };
 };
 
-const focusCatcherStyles = { position: 'absolute' };
+const focusCatcherStyles = { position: 'fixed' };
 function Trigger(props) {
   const STrigger = Root;
   const SFocusHint = 'span';


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
disable scrolling to a Select component when Select.Menu is opened and I click outside of the menu
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
I have added unit tests, and I have tested it manually on playground
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [X] I have added new unit tests on added of fixed functionality.
