### PR TITLE
[popper] added additional checks to prevent focus catching after popp…

### DIFF
--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.7.7] - 2023-10-10
+
+### Fixed
+
+- Added additional checks to prevent focus catching after popper close in some cases when focus is moved to another component and focus catch is not necessary.
+
 ## [5.7.6] - 2023-10-10
 
 ### Fixed

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -417,7 +417,12 @@ const useFocusCatch = (active, popperRef) => {
 
   const [focusCatch, setFocusCatch] = React.useState(false);
   const handleFocusCatchBlur = React.useCallback(() => setFocusCatch(false), []);
-  const handleFocusCatchRef = React.useCallback((node) => node?.focus(), []);
+  const handleFocusCatchRef = React.useCallback((node) => {
+    if (activeRef.current) return setFocusCatch(false);
+    if (!isFocusInside(popperRef.current) && document.activeElement !== document.body)
+      return setFocusCatch(false);
+    node?.focus();
+  }, []);
 
   React.useEffect(() => {
     if (!active) return;


### PR DESCRIPTION
…er close in some cases when focus is moved to another component and focus catch is not necessary

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

https://github.com/semrush/intergalactic/issues/822

The case was found on combination of InlineInput + DropDownMenu.

Focus catch is the mechanism to return focus to the position near trigger if it "lost" (moved to document.body) and preserve normal focus flow.

Focus catch performs it checks in setTimeout after 1ms – if checks are passed the focus catch block is scheduled to be created.

The issues comes from the fact that between scheduling of creating the focus catch block and focus catch block mount another component may take the user focus on it. If such happens, the focus catch block is mounting and catching focus anyway.

I have added similar checks to happen after focus catch block mounting. If focus is already taken by something else the focus catch block will just unmount without catching the focus.

## How has this been tested?

Only manual tests, such functionality is extremely hard to check in unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
