### PR TITLE
[utils] fixed focus lock merging was causing invalid hooks order error

### DIFF
--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.8.4] - 2023-10-13
+
+### Fixed
+
+- Focus lock merging was causing invalid hooks order error.
+
 ## [4.8.3] - 2023-10-13
 
 ### Changed

--- a/semcore/utils/src/use/useFocusLock.ts
+++ b/semcore/utils/src/use/useFocusLock.ts
@@ -81,6 +81,7 @@ let uniqueId = 0;
 const getUniqueId = (prefix: string) =>
   `${prefix}-${Math.random().toString(36).slice(2)}-${uniqueId++}`;
 const useFocusBorders = (React: ReactT, disabled?: boolean) => {
+  useUniqueIdHookMock(React);
   React.useEffect(() => {
     const id = getUniqueId('focus-borders-consumer');
     if (!disabled) {
@@ -97,6 +98,7 @@ const useFocusBorders = (React: ReactT, disabled?: boolean) => {
   }, [disabled]);
 };
 /**
+ * # Focus lock hook merging
  * In some cases same page might contain different versions of components.
  * In such cases, we need to ensure that only one version of focus lock hook is used.
  * So, it's why we have `useFocusLockHook` function that is wrapped into `useFocusLock`.
@@ -106,6 +108,7 @@ const useFocusBorders = (React: ReactT, disabled?: boolean) => {
  * The last condition is very important because we are unable to replace React hook without reimplementing
  * React hooks lifecycle in some kind of wrapper.
  *
+ * ## Versioning
  * Such versions merging requires us to keep hook api backward compatible.
  * When hook logic changes, the variable `focusLockVersion` should be incremented.
  *
@@ -114,6 +117,14 @@ const useFocusBorders = (React: ReactT, disabled?: boolean) => {
  *
  * Initially (for a several versions) key was `__intergalactic_focus_lock_hook_`.
  * Making it respect react version required to change key. So key was changed to `__intergalactic_focus_lock_hook_react_v_respectful`.
+ *
+ * ## React hooks order
+ * When updating from version 2 to version 3 `useUniqueId` hook was removed.
+ * Due to replacing useFocusLock hook in runtime, the order of hooks must be preserved.
+ * So, useUniqueIdHookMock helps to preserve hooks order when hook is being replaced from version 2 to version 3.
+ *
+ * If new update requires to remove some hooks – add mocks instead of them.
+ * If new update requires to add some hooks and no workaround with current hooks list is possible – probably focus lock hook key should be changed.
  */
 const focusLockVersion = 3;
 const globalFocusLockHookKey = '__intergalactic_focus_lock_hook_react_v_respectful';
@@ -129,6 +140,13 @@ const focusLockUsedInMountedComponents = new Set<string>();
  * The last element in focus masters stack is considered as a current focus master.
  */
 const focusMastersStack: HTMLElement[] = [];
+
+const noop = () => {};
+const useUniqueIdHookMock = (React: ReactT) => {
+  React.useState(undefined);
+  const useEnhancedEffect = canUseDOM() ? React.useLayoutEffect : React.useEffect;
+  useEnhancedEffect(noop, []);
+};
 
 const useFocusLockHook = (
   React: ReactT,
@@ -245,6 +263,7 @@ const useFocusLockHook = (
     };
   }, [disabled, autoFocus, returnFocusTo, returnFocus]);
 
+  useUniqueIdHookMock(React);
   React.useEffect(() => {
     const id = getUniqueId('focus-lock-consumer');
     if (disabled) return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

When updating focus lock from version 2 to version 3 `useUniqueId` hook was removed.
Due to replacing useFocusLock hook in runtime, the order of hooks must be preserved.
So, useUniqueIdHookMock helps to preserve hooks order when hook is being replaced from version 2 to version 3.

## How has this been tested?

It was tested on stage that uses multiple versions of `@semcore/ui` and where both focus lock v2 and focus lock v3 are present.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
