### PR TITLE
[utils] update values for old twitter and facebook variables

### DIFF
--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.8.5] - 2023-10-25
+
+### Changed
+
+- Values for `--facebook`, `--twitter` and `--linkedIn` variables to new ones.
+
 ## [4.8.4] - 2023-10-13
 
 ### Fixed

--- a/semcore/utils/style/var.css
+++ b/semcore/utils/style/var.css
@@ -86,9 +86,9 @@
   --pinterest: #bd081c;
   --instagram: #e4405f;
   --youtube: #ff0000;
-  --facebook: #3b5998;
-  --linkedIn: #1a7ab2;
-  --twitter: #2bafeb;
+  --facebook: #1877F2;
+  --linkedIn: #0A66C2;
+  --twitter: #1D9BF0;
   --google-my-business: #1a73e8;
   --google-blue: #1a0dab;
   --google-green: #016723;


### PR DESCRIPTION
## Motivation and Context

Teams still use variables from the old var.css, so we need to update the values for three variables:
- `--facebook`
- `--linkedIn`
- `--twitter`

## How has this been tested?

No specific tests needed in this case.

## Types of changes

- [x] Nice improve.

## Checklist:

- [x] I have updated the documentation accordingly or it's not required.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
