### PR TITLE
[side-panel] added passing ignorePortalsStacking prop to the Portal

### DIFF
--- a/semcore/side-panel/CHANGELOG.md
+++ b/semcore/side-panel/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
+## [3.15.0] - 2023-11-01
+
+### Added
+
+- Added passing `ignorePortalsStacking` prop to `Portal`.
 
 ## [3.14.0] - 2023-10-27
 

--- a/semcore/side-panel/__tests__/index.test.jsx
+++ b/semcore/side-panel/__tests__/index.test.jsx
@@ -4,6 +4,7 @@ import { expect, test, describe, beforeEach, vi } from '@semcore/testing-utils/v
 import { render, fireEvent, cleanup } from '@semcore/testing-utils/testing-library';
 
 import SidePanel from '../src';
+import Portal from '@semcore/portal/src';
 
 describe('SidePanel', () => {
   beforeEach(cleanup);
@@ -187,5 +188,23 @@ describe('SidePanel', () => {
         { selector: 'body', width: 320, height: 100, actions: { hover: '#back' } },
       ),
     ).toMatchImageSnapshot(task);
+  });
+
+  test.concurrent('Should support ignorePortalsStacking prop', async ({ expect }) => {
+    const component = render(
+      <Portal>
+        <SidePanel visible data-testid={'inP'}>
+          Content in portal
+          <SidePanel ignorePortalsStacking visible data-testid={'outP'}>
+            Content in body
+          </SidePanel>
+        </SidePanel>
+      </Portal>,
+    );
+
+    // 5 because: border-focus (before + after), empty div, div with `Content in portal`
+    // and div with `Content in body` should be in body too.
+    // Without `ignorePortalsStacking`, it'll be in the first `SidePanel`.
+    expect(document.body.children).toHaveLength(5);
   });
 });

--- a/semcore/side-panel/src/SidePanel.jsx
+++ b/semcore/side-panel/src/SidePanel.jsx
@@ -108,10 +108,10 @@ class RootSidePanel extends Component {
   }
 
   render() {
-    const { Children, disablePortal } = this.asProps;
+    const { Children, disablePortal, ignorePortalsStacking } = this.asProps;
 
     return (
-      <Portal disablePortal={disablePortal}>
+      <Portal disablePortal={disablePortal} ignorePortalsStacking={ignorePortalsStacking}>
         {this.isAdvanceMode() ? (
           <Children />
         ) : (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
In Api for SidePanel we have `PortalProps`, but in fact, we supported only `disablePortal`. I have added `ignorePortalsStacking` too.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
I have added unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [X] I have added new unit tests on added of fixed functionality.
