### PR TITLE
[base-trigger] Do not animate the width/height of a node if they are specified as a percentage

### DIFF
--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.10.0] - 2023-11-01
+
+### Changed
+
+- Don't animate the width/height of a node if they are specified as a percentage.
+
 ## [4.9.0] - 2023-10-26
 
 ### Added

--- a/semcore/utils/src/enhances/animatedSizeEnhance.tsx
+++ b/semcore/utils/src/enhances/animatedSizeEnhance.tsx
@@ -50,7 +50,10 @@ function animatedSizeEnhance({
       const sizes: (number | undefined)[] = [];
       for (let i = 0; i < animateProps.length; i++) {
         sizes[i] = node.getBoundingClientRect()[animateProps[i]];
-        if (Math.abs(lastSizesRef.current[i]! - sizes[i]!) < 3) {
+        if (
+          Math.abs(lastSizesRef.current[i]! - sizes[i]!) < 3 ||
+          node.style.getPropertyValue(animateProps[i]).endsWith('%')
+        ) {
           lastSizesRef.current[i] = sizes[i];
           sizes[i] = undefined;
         }

--- a/website/docs/components/select/examples/custom-trigger.tsx
+++ b/website/docs/components/select/examples/custom-trigger.tsx
@@ -9,7 +9,7 @@ export default () => {
   const [value, setValue] = React.useState(null);
 
   return (
-    <Flex>
+    <>
       <Select onChange={setValue} placeholder='Select country'>
         <Select.Trigger w={180}>
           <Select.Trigger.Addon>
@@ -26,6 +26,24 @@ export default () => {
           ))}
         </Select.Menu>
       </Select>
-    </Flex>
+      <br />
+      <br />
+      <Select onChange={setValue} placeholder='Select country'>
+        <Select.Trigger w={'100%'}>
+          <Select.Trigger.Addon>
+            <Flags iso2={value} />
+          </Select.Trigger.Addon>
+          <Select.Trigger.Text>{formatName(iso2Name[value])}</Select.Trigger.Text>
+        </Select.Trigger>
+        <Select.Menu hMax={180}>
+          {Object.keys(iso2Name).map((value) => (
+            <Select.Option key={value} value={value}>
+              <Flags iso2={value as keyof typeof iso2Name} mr={2} />
+              {formatName(iso2Name[value])}
+            </Select.Option>
+          ))}
+        </Select.Menu>
+      </Select>
+    </>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Code cannot be tested automatically so I have tested it only manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
