### PR TITLE
[utils, website] fixed old palette resolving and also fixed palette view on website

### DIFF
--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.10.2] - 2023-11-09
+
+### Fixed
+
+- Fixed old palette colors resolving that was broken in `@semcore/utils@4.9.0`.
+
 ## [4.10.1] - 2023-10-27
 
 ### Changed

--- a/semcore/utils/src/use/useColorResolver.ts
+++ b/semcore/utils/src/use/useColorResolver.ts
@@ -168,13 +168,12 @@ export const useColorResolver = () => {
   return (color?: string) => {
     if (!color) return undefined as any;
     if (color.startsWith('--')) {
-      const clearColor = color.substring(2);
-      if (deprecatedPalette[clearColor]) {
+      if (deprecatedPalette[color]) {
         logger.warn(true, makeDeprecationMessage(color), undefined);
-        return deprecatedPalette[clearColor];
+        return deprecatedPalette[color];
       }
-      if (basicPalette[clearColor]) {
-        return basicPalette[clearColor];
+      if (basicPalette[color]) {
+        return basicPalette[color];
       }
       let resolvedColor: string | undefined;
 

--- a/website/docs2/data-display/color-palette/color-palette.md
+++ b/website/docs2/data-display/color-palette/color-palette.md
@@ -44,8 +44,7 @@ This way helps to choose colors with a predefined order and contrast for your da
 import React from 'react';
 import Color from '@components/Color';
 
-const group = {
-  basicPack: [
+const colors = [
     '--blue-300',
     '--green-200',
     '--orange-400',
@@ -54,44 +53,10 @@ const group = {
     '--violet-400',
     '--red-300',
     '--salad-200',
-  ],
-  secondPack: [
-    '--blue-400',
-    '--green-300',
-    '--orange-200',
-    '--pink-400',
-    '--yellow-300',
-    '--violet-200',
-    '--red-400',
-    '--salad-300',
-  ],
-  thirdPack: [
-    '--blue-200',
-    '--green-400',
-    '--orange-300',
-    '--pink-200',
-    '--yellow-400',
-    '--violet-300',
-    '--red-200',
-    '--salad-400',
-  ],
-  otherData: ['--gray-200'],
-  blue: ['--blue-100', '--blue-200', '--blue-300', '--blue-400', '--blue-500'],
-  green: ['--green-100', '--green-200', '--green-300', '--green-400', '--green-500'],
-  salad: ['--salad-100', '--salad-200', '--salad-300', '--salad-400', '--salad-500'],
-  orange: ['--orange-100', '--orange-200', '--orange-300', '--orange-400', '--orange-500'],
-  yellow: ['--yellow-100', '--yellow-200', '--yellow-300', '--yellow-400', '--yellow-500'],
-  red: ['--red-100', '--red-200', '--red-300', '--red-400', '--red-500'],
-  pink: ['--pink-100', '--pink-200', '--pink-300', '--pink-400', '--pink-500'],
-  violet: ['--violet-100', '--violet-200', '--violet-300', '--violet-400', '--violet-500'],
-  gray: ['--gray-100', '--gray-200', '--gray-300', '--gray-400', '--gray-500'],
-};
+  ] // basicPack
+
 
 const App = function (props) {
-  const colors = group[props.group];
-  if (!colors) {
-    return `Group "${props.group}" not found`;
-  }
   return (
     <div style={{ marginBottom: 32 }}>
       {colors.map((colorName, i) => {
@@ -118,18 +83,7 @@ const App = function (props) {
 import React from 'react';
 import Color from '@components/Color';
 
-const group = {
-  basicPack: [
-    '--blue-300',
-    '--green-200',
-    '--orange-400',
-    '--pink-300',
-    '--yellow-200',
-    '--violet-400',
-    '--red-300',
-    '--salad-200',
-  ],
-  secondPack: [
+const colors = [
     '--blue-400',
     '--green-300',
     '--orange-200',
@@ -138,34 +92,9 @@ const group = {
     '--violet-200',
     '--red-400',
     '--salad-300',
-  ],
-  thirdPack: [
-    '--blue-200',
-    '--green-400',
-    '--orange-300',
-    '--pink-200',
-    '--yellow-400',
-    '--violet-300',
-    '--red-200',
-    '--salad-400',
-  ],
-  otherData: ['--gray-200'],
-  blue: ['--blue-100', '--blue-200', '--blue-300', '--blue-400', '--blue-500'],
-  green: ['--green-100', '--green-200', '--green-300', '--green-400', '--green-500'],
-  salad: ['--salad-100', '--salad-200', '--salad-300', '--salad-400', '--salad-500'],
-  orange: ['--orange-100', '--orange-200', '--orange-300', '--orange-400', '--orange-500'],
-  yellow: ['--yellow-100', '--yellow-200', '--yellow-300', '--yellow-400', '--yellow-500'],
-  red: ['--red-100', '--red-200', '--red-300', '--red-400', '--red-500'],
-  pink: ['--pink-100', '--pink-200', '--pink-300', '--pink-400', '--pink-500'],
-  violet: ['--violet-100', '--violet-200', '--violet-300', '--violet-400', '--violet-500'],
-  gray: ['--gray-100', '--gray-200', '--gray-300', '--gray-400', '--gray-500'],
-};
+  ] // secondPack
 
 const App = function (props) {
-  const colors = group[props.group];
-  if (!colors) {
-    return `Group "${props.group}" not found`;
-  }
   return (
     <div style={{ marginBottom: 32 }}>
       {colors.map((colorName, i) => {
@@ -192,28 +121,7 @@ const App = function (props) {
 import React from 'react';
 import Color from '@components/Color';
 
-const group = {
-  basicPack: [
-    '--blue-300',
-    '--green-200',
-    '--orange-400',
-    '--pink-300',
-    '--yellow-200',
-    '--violet-400',
-    '--red-300',
-    '--salad-200',
-  ],
-  secondPack: [
-    '--blue-400',
-    '--green-300',
-    '--orange-200',
-    '--pink-400',
-    '--yellow-300',
-    '--violet-200',
-    '--red-400',
-    '--salad-300',
-  ],
-  thirdPack: [
+const colors = [
     '--blue-200',
     '--green-400',
     '--orange-300',
@@ -222,24 +130,9 @@ const group = {
     '--violet-300',
     '--red-200',
     '--salad-400',
-  ],
-  otherData: ['--gray-200'],
-  blue: ['--blue-100', '--blue-200', '--blue-300', '--blue-400', '--blue-500'],
-  green: ['--green-100', '--green-200', '--green-300', '--green-400', '--green-500'],
-  salad: ['--salad-100', '--salad-200', '--salad-300', '--salad-400', '--salad-500'],
-  orange: ['--orange-100', '--orange-200', '--orange-300', '--orange-400', '--orange-500'],
-  yellow: ['--yellow-100', '--yellow-200', '--yellow-300', '--yellow-400', '--yellow-500'],
-  red: ['--red-100', '--red-200', '--red-300', '--red-400', '--red-500'],
-  pink: ['--pink-100', '--pink-200', '--pink-300', '--pink-400', '--pink-500'],
-  violet: ['--violet-100', '--violet-200', '--violet-300', '--violet-400', '--violet-500'],
-  gray: ['--gray-100', '--gray-200', '--gray-300', '--gray-400', '--gray-500'],
-};
+  ] // thirdPack
 
 const App = function (props) {
-  const colors = group[props.group];
-  if (!colors) {
-    return `Group "${props.group}" not found`;
-  }
   return (
     <div style={{ marginBottom: 32 }}>
       {colors.map((colorName, i) => {
@@ -268,54 +161,9 @@ Use `--chart-palette-order-other-data` token to indicate voids, missing or some 
 import React from 'react';
 import Color from '@components/Color';
 
-const group = {
-  basicPack: [
-    '--blue-300',
-    '--green-200',
-    '--orange-400',
-    '--pink-300',
-    '--yellow-200',
-    '--violet-400',
-    '--red-300',
-    '--salad-200',
-  ],
-  secondPack: [
-    '--blue-400',
-    '--green-300',
-    '--orange-200',
-    '--pink-400',
-    '--yellow-300',
-    '--violet-200',
-    '--red-400',
-    '--salad-300',
-  ],
-  thirdPack: [
-    '--blue-200',
-    '--green-400',
-    '--orange-300',
-    '--pink-200',
-    '--yellow-400',
-    '--violet-300',
-    '--red-200',
-    '--salad-400',
-  ],
-  otherData: ['--gray-200'],
-  blue: ['--blue-100', '--blue-200', '--blue-300', '--blue-400', '--blue-500'],
-  green: ['--green-100', '--green-200', '--green-300', '--green-400', '--green-500'],
-  salad: ['--salad-100', '--salad-200', '--salad-300', '--salad-400', '--salad-500'],
-  orange: ['--orange-100', '--orange-200', '--orange-300', '--orange-400', '--orange-500'],
-  yellow: ['--yellow-100', '--yellow-200', '--yellow-300', '--yellow-400', '--yellow-500'],
-  red: ['--red-100', '--red-200', '--red-300', '--red-400', '--red-500'],
-  pink: ['--pink-100', '--pink-200', '--pink-300', '--pink-400', '--pink-500'],
-  violet: ['--violet-100', '--violet-200', '--violet-300', '--violet-400', '--violet-500'],
-  gray: ['--gray-100', '--gray-200', '--gray-300', '--gray-400', '--gray-500'],
-};
+const colors = ['--gray-200'] // otherData
 
 const App = function (props) {
-  const colors = group[props.group];
-  if (!colors) {
-    return `Group "${props.group}" not found`;
-  }
   return (
     <div style={{ marginBottom: 32 }}>
       {colors.map((colorName, i) => {
@@ -346,54 +194,9 @@ This way helps to color your data in a monochromatic way. In this case use token
 import React from 'react';
 import Color from '@components/Color';
 
-const group = {
-  basicPack: [
-    '--blue-300',
-    '--green-200',
-    '--orange-400',
-    '--pink-300',
-    '--yellow-200',
-    '--violet-400',
-    '--red-300',
-    '--salad-200',
-  ],
-  secondPack: [
-    '--blue-400',
-    '--green-300',
-    '--orange-200',
-    '--pink-400',
-    '--yellow-300',
-    '--violet-200',
-    '--red-400',
-    '--salad-300',
-  ],
-  thirdPack: [
-    '--blue-200',
-    '--green-400',
-    '--orange-300',
-    '--pink-200',
-    '--yellow-400',
-    '--violet-300',
-    '--red-200',
-    '--salad-400',
-  ],
-  otherData: ['--gray-200'],
-  blue: ['--blue-100', '--blue-200', '--blue-300', '--blue-400', '--blue-500'],
-  green: ['--green-100', '--green-200', '--green-300', '--green-400', '--green-500'],
-  salad: ['--salad-100', '--salad-200', '--salad-300', '--salad-400', '--salad-500'],
-  orange: ['--orange-100', '--orange-200', '--orange-300', '--orange-400', '--orange-500'],
-  yellow: ['--yellow-100', '--yellow-200', '--yellow-300', '--yellow-400', '--yellow-500'],
-  red: ['--red-100', '--red-200', '--red-300', '--red-400', '--red-500'],
-  pink: ['--pink-100', '--pink-200', '--pink-300', '--pink-400', '--pink-500'],
-  violet: ['--violet-100', '--violet-200', '--violet-300', '--violet-400', '--violet-500'],
-  gray: ['--gray-100', '--gray-200', '--gray-300', '--gray-400', '--gray-500'],
-};
+const colors = ['--blue-100', '--blue-200', '--blue-300', '--blue-400', '--blue-500'] // blue
 
 const App = function (props) {
-  const colors = group[props.group];
-  if (!colors) {
-    return `Group "${props.group}" not found`;
-  }
   return (
     <div style={{ marginBottom: 32 }}>
       {colors.map((colorName, i) => {
@@ -420,54 +223,9 @@ const App = function (props) {
 import React from 'react';
 import Color from '@components/Color';
 
-const group = {
-  basicPack: [
-    '--blue-300',
-    '--green-200',
-    '--orange-400',
-    '--pink-300',
-    '--yellow-200',
-    '--violet-400',
-    '--red-300',
-    '--salad-200',
-  ],
-  secondPack: [
-    '--blue-400',
-    '--green-300',
-    '--orange-200',
-    '--pink-400',
-    '--yellow-300',
-    '--violet-200',
-    '--red-400',
-    '--salad-300',
-  ],
-  thirdPack: [
-    '--blue-200',
-    '--green-400',
-    '--orange-300',
-    '--pink-200',
-    '--yellow-400',
-    '--violet-300',
-    '--red-200',
-    '--salad-400',
-  ],
-  otherData: ['--gray-200'],
-  blue: ['--blue-100', '--blue-200', '--blue-300', '--blue-400', '--blue-500'],
-  green: ['--green-100', '--green-200', '--green-300', '--green-400', '--green-500'],
-  salad: ['--salad-100', '--salad-200', '--salad-300', '--salad-400', '--salad-500'],
-  orange: ['--orange-100', '--orange-200', '--orange-300', '--orange-400', '--orange-500'],
-  yellow: ['--yellow-100', '--yellow-200', '--yellow-300', '--yellow-400', '--yellow-500'],
-  red: ['--red-100', '--red-200', '--red-300', '--red-400', '--red-500'],
-  pink: ['--pink-100', '--pink-200', '--pink-300', '--pink-400', '--pink-500'],
-  violet: ['--violet-100', '--violet-200', '--violet-300', '--violet-400', '--violet-500'],
-  gray: ['--gray-100', '--gray-200', '--gray-300', '--gray-400', '--gray-500'],
-};
+const colors = ['--green-100', '--green-200', '--green-300', '--green-400', '--green-500'] // green
 
 const App = function (props) {
-  const colors = group[props.group];
-  if (!colors) {
-    return `Group "${props.group}" not found`;
-  }
   return (
     <div style={{ marginBottom: 32 }}>
       {colors.map((colorName, i) => {
@@ -494,54 +252,9 @@ const App = function (props) {
 import React from 'react';
 import Color from '@components/Color';
 
-const group = {
-  basicPack: [
-    '--blue-300',
-    '--green-200',
-    '--orange-400',
-    '--pink-300',
-    '--yellow-200',
-    '--violet-400',
-    '--red-300',
-    '--salad-200',
-  ],
-  secondPack: [
-    '--blue-400',
-    '--green-300',
-    '--orange-200',
-    '--pink-400',
-    '--yellow-300',
-    '--violet-200',
-    '--red-400',
-    '--salad-300',
-  ],
-  thirdPack: [
-    '--blue-200',
-    '--green-400',
-    '--orange-300',
-    '--pink-200',
-    '--yellow-400',
-    '--violet-300',
-    '--red-200',
-    '--salad-400',
-  ],
-  otherData: ['--gray-200'],
-  blue: ['--blue-100', '--blue-200', '--blue-300', '--blue-400', '--blue-500'],
-  green: ['--green-100', '--green-200', '--green-300', '--green-400', '--green-500'],
-  salad: ['--salad-100', '--salad-200', '--salad-300', '--salad-400', '--salad-500'],
-  orange: ['--orange-100', '--orange-200', '--orange-300', '--orange-400', '--orange-500'],
-  yellow: ['--yellow-100', '--yellow-200', '--yellow-300', '--yellow-400', '--yellow-500'],
-  red: ['--red-100', '--red-200', '--red-300', '--red-400', '--red-500'],
-  pink: ['--pink-100', '--pink-200', '--pink-300', '--pink-400', '--pink-500'],
-  violet: ['--violet-100', '--violet-200', '--violet-300', '--violet-400', '--violet-500'],
-  gray: ['--gray-100', '--gray-200', '--gray-300', '--gray-400', '--gray-500'],
-};
+const colors = ['--salad-100', '--salad-200', '--salad-300', '--salad-400', '--salad-500'] // salad
 
 const App = function (props) {
-  const colors = group[props.group];
-  if (!colors) {
-    return `Group "${props.group}" not found`;
-  }
   return (
     <div style={{ marginBottom: 32 }}>
       {colors.map((colorName, i) => {
@@ -568,54 +281,9 @@ const App = function (props) {
 import React from 'react';
 import Color from '@components/Color';
 
-const group = {
-  basicPack: [
-    '--blue-300',
-    '--green-200',
-    '--orange-400',
-    '--pink-300',
-    '--yellow-200',
-    '--violet-400',
-    '--red-300',
-    '--salad-200',
-  ],
-  secondPack: [
-    '--blue-400',
-    '--green-300',
-    '--orange-200',
-    '--pink-400',
-    '--yellow-300',
-    '--violet-200',
-    '--red-400',
-    '--salad-300',
-  ],
-  thirdPack: [
-    '--blue-200',
-    '--green-400',
-    '--orange-300',
-    '--pink-200',
-    '--yellow-400',
-    '--violet-300',
-    '--red-200',
-    '--salad-400',
-  ],
-  otherData: ['--gray-200'],
-  blue: ['--blue-100', '--blue-200', '--blue-300', '--blue-400', '--blue-500'],
-  green: ['--green-100', '--green-200', '--green-300', '--green-400', '--green-500'],
-  salad: ['--salad-100', '--salad-200', '--salad-300', '--salad-400', '--salad-500'],
-  orange: ['--orange-100', '--orange-200', '--orange-300', '--orange-400', '--orange-500'],
-  yellow: ['--yellow-100', '--yellow-200', '--yellow-300', '--yellow-400', '--yellow-500'],
-  red: ['--red-100', '--red-200', '--red-300', '--red-400', '--red-500'],
-  pink: ['--pink-100', '--pink-200', '--pink-300', '--pink-400', '--pink-500'],
-  violet: ['--violet-100', '--violet-200', '--violet-300', '--violet-400', '--violet-500'],
-  gray: ['--gray-100', '--gray-200', '--gray-300', '--gray-400', '--gray-500'],
-};
+const colors = ['--orange-100', '--orange-200', '--orange-300', '--orange-400', '--orange-500'] // orange
 
 const App = function (props) {
-  const colors = group[props.group];
-  if (!colors) {
-    return `Group "${props.group}" not found`;
-  }
   return (
     <div style={{ marginBottom: 32 }}>
       {colors.map((colorName, i) => {
@@ -642,54 +310,9 @@ const App = function (props) {
 import React from 'react';
 import Color from '@components/Color';
 
-const group = {
-  basicPack: [
-    '--blue-300',
-    '--green-200',
-    '--orange-400',
-    '--pink-300',
-    '--yellow-200',
-    '--violet-400',
-    '--red-300',
-    '--salad-200',
-  ],
-  secondPack: [
-    '--blue-400',
-    '--green-300',
-    '--orange-200',
-    '--pink-400',
-    '--yellow-300',
-    '--violet-200',
-    '--red-400',
-    '--salad-300',
-  ],
-  thirdPack: [
-    '--blue-200',
-    '--green-400',
-    '--orange-300',
-    '--pink-200',
-    '--yellow-400',
-    '--violet-300',
-    '--red-200',
-    '--salad-400',
-  ],
-  otherData: ['--gray-200'],
-  blue: ['--blue-100', '--blue-200', '--blue-300', '--blue-400', '--blue-500'],
-  green: ['--green-100', '--green-200', '--green-300', '--green-400', '--green-500'],
-  salad: ['--salad-100', '--salad-200', '--salad-300', '--salad-400', '--salad-500'],
-  orange: ['--orange-100', '--orange-200', '--orange-300', '--orange-400', '--orange-500'],
-  yellow: ['--yellow-100', '--yellow-200', '--yellow-300', '--yellow-400', '--yellow-500'],
-  red: ['--red-100', '--red-200', '--red-300', '--red-400', '--red-500'],
-  pink: ['--pink-100', '--pink-200', '--pink-300', '--pink-400', '--pink-500'],
-  violet: ['--violet-100', '--violet-200', '--violet-300', '--violet-400', '--violet-500'],
-  gray: ['--gray-100', '--gray-200', '--gray-300', '--gray-400', '--gray-500'],
-};
+const colors = ['--yellow-100', '--yellow-200', '--yellow-300', '--yellow-400', '--yellow-500'] // yellow
 
 const App = function (props) {
-  const colors = group[props.group];
-  if (!colors) {
-    return `Group "${props.group}" not found`;
-  }
   return (
     <div style={{ marginBottom: 32 }}>
       {colors.map((colorName, i) => {
@@ -716,54 +339,9 @@ const App = function (props) {
 import React from 'react';
 import Color from '@components/Color';
 
-const group = {
-  basicPack: [
-    '--blue-300',
-    '--green-200',
-    '--orange-400',
-    '--pink-300',
-    '--yellow-200',
-    '--violet-400',
-    '--red-300',
-    '--salad-200',
-  ],
-  secondPack: [
-    '--blue-400',
-    '--green-300',
-    '--orange-200',
-    '--pink-400',
-    '--yellow-300',
-    '--violet-200',
-    '--red-400',
-    '--salad-300',
-  ],
-  thirdPack: [
-    '--blue-200',
-    '--green-400',
-    '--orange-300',
-    '--pink-200',
-    '--yellow-400',
-    '--violet-300',
-    '--red-200',
-    '--salad-400',
-  ],
-  otherData: ['--gray-200'],
-  blue: ['--blue-100', '--blue-200', '--blue-300', '--blue-400', '--blue-500'],
-  green: ['--green-100', '--green-200', '--green-300', '--green-400', '--green-500'],
-  salad: ['--salad-100', '--salad-200', '--salad-300', '--salad-400', '--salad-500'],
-  orange: ['--orange-100', '--orange-200', '--orange-300', '--orange-400', '--orange-500'],
-  yellow: ['--yellow-100', '--yellow-200', '--yellow-300', '--yellow-400', '--yellow-500'],
-  red: ['--red-100', '--red-200', '--red-300', '--red-400', '--red-500'],
-  pink: ['--pink-100', '--pink-200', '--pink-300', '--pink-400', '--pink-500'],
-  violet: ['--violet-100', '--violet-200', '--violet-300', '--violet-400', '--violet-500'],
-  gray: ['--gray-100', '--gray-200', '--gray-300', '--gray-400', '--gray-500'],
-};
+const colors = ['--red-100', '--red-200', '--red-300', '--red-400', '--red-500'] // red
 
 const App = function (props) {
-  const colors = group[props.group];
-  if (!colors) {
-    return `Group "${props.group}" not found`;
-  }
   return (
     <div style={{ marginBottom: 32 }}>
       {colors.map((colorName, i) => {
@@ -790,54 +368,9 @@ const App = function (props) {
 import React from 'react';
 import Color from '@components/Color';
 
-const group = {
-  basicPack: [
-    '--blue-300',
-    '--green-200',
-    '--orange-400',
-    '--pink-300',
-    '--yellow-200',
-    '--violet-400',
-    '--red-300',
-    '--salad-200',
-  ],
-  secondPack: [
-    '--blue-400',
-    '--green-300',
-    '--orange-200',
-    '--pink-400',
-    '--yellow-300',
-    '--violet-200',
-    '--red-400',
-    '--salad-300',
-  ],
-  thirdPack: [
-    '--blue-200',
-    '--green-400',
-    '--orange-300',
-    '--pink-200',
-    '--yellow-400',
-    '--violet-300',
-    '--red-200',
-    '--salad-400',
-  ],
-  otherData: ['--gray-200'],
-  blue: ['--blue-100', '--blue-200', '--blue-300', '--blue-400', '--blue-500'],
-  green: ['--green-100', '--green-200', '--green-300', '--green-400', '--green-500'],
-  salad: ['--salad-100', '--salad-200', '--salad-300', '--salad-400', '--salad-500'],
-  orange: ['--orange-100', '--orange-200', '--orange-300', '--orange-400', '--orange-500'],
-  yellow: ['--yellow-100', '--yellow-200', '--yellow-300', '--yellow-400', '--yellow-500'],
-  red: ['--red-100', '--red-200', '--red-300', '--red-400', '--red-500'],
-  pink: ['--pink-100', '--pink-200', '--pink-300', '--pink-400', '--pink-500'],
-  violet: ['--violet-100', '--violet-200', '--violet-300', '--violet-400', '--violet-500'],
-  gray: ['--gray-100', '--gray-200', '--gray-300', '--gray-400', '--gray-500'],
-};
+const colors = ['--pink-100', '--pink-200', '--pink-300', '--pink-400', '--pink-500'] // pink
 
 const App = function (props) {
-  const colors = group[props.group];
-  if (!colors) {
-    return `Group "${props.group}" not found`;
-  }
   return (
     <div style={{ marginBottom: 32 }}>
       {colors.map((colorName, i) => {
@@ -864,54 +397,9 @@ const App = function (props) {
 import React from 'react';
 import Color from '@components/Color';
 
-const group = {
-  basicPack: [
-    '--blue-300',
-    '--green-200',
-    '--orange-400',
-    '--pink-300',
-    '--yellow-200',
-    '--violet-400',
-    '--red-300',
-    '--salad-200',
-  ],
-  secondPack: [
-    '--blue-400',
-    '--green-300',
-    '--orange-200',
-    '--pink-400',
-    '--yellow-300',
-    '--violet-200',
-    '--red-400',
-    '--salad-300',
-  ],
-  thirdPack: [
-    '--blue-200',
-    '--green-400',
-    '--orange-300',
-    '--pink-200',
-    '--yellow-400',
-    '--violet-300',
-    '--red-200',
-    '--salad-400',
-  ],
-  otherData: ['--gray-200'],
-  blue: ['--blue-100', '--blue-200', '--blue-300', '--blue-400', '--blue-500'],
-  green: ['--green-100', '--green-200', '--green-300', '--green-400', '--green-500'],
-  salad: ['--salad-100', '--salad-200', '--salad-300', '--salad-400', '--salad-500'],
-  orange: ['--orange-100', '--orange-200', '--orange-300', '--orange-400', '--orange-500'],
-  yellow: ['--yellow-100', '--yellow-200', '--yellow-300', '--yellow-400', '--yellow-500'],
-  red: ['--red-100', '--red-200', '--red-300', '--red-400', '--red-500'],
-  pink: ['--pink-100', '--pink-200', '--pink-300', '--pink-400', '--pink-500'],
-  violet: ['--violet-100', '--violet-200', '--violet-300', '--violet-400', '--violet-500'],
-  gray: ['--gray-100', '--gray-200', '--gray-300', '--gray-400', '--gray-500'],
-};
+const colors = ['--violet-100', '--violet-200', '--violet-300', '--violet-400', '--violet-500'] // violet
 
 const App = function (props) {
-  const colors = group[props.group];
-  if (!colors) {
-    return `Group "${props.group}" not found`;
-  }
   return (
     <div style={{ marginBottom: 32 }}>
       {colors.map((colorName, i) => {
@@ -938,54 +426,9 @@ const App = function (props) {
 import React from 'react';
 import Color from '@components/Color';
 
-const group = {
-  basicPack: [
-    '--blue-300',
-    '--green-200',
-    '--orange-400',
-    '--pink-300',
-    '--yellow-200',
-    '--violet-400',
-    '--red-300',
-    '--salad-200',
-  ],
-  secondPack: [
-    '--blue-400',
-    '--green-300',
-    '--orange-200',
-    '--pink-400',
-    '--yellow-300',
-    '--violet-200',
-    '--red-400',
-    '--salad-300',
-  ],
-  thirdPack: [
-    '--blue-200',
-    '--green-400',
-    '--orange-300',
-    '--pink-200',
-    '--yellow-400',
-    '--violet-300',
-    '--red-200',
-    '--salad-400',
-  ],
-  otherData: ['--gray-200'],
-  blue: ['--blue-100', '--blue-200', '--blue-300', '--blue-400', '--blue-500'],
-  green: ['--green-100', '--green-200', '--green-300', '--green-400', '--green-500'],
-  salad: ['--salad-100', '--salad-200', '--salad-300', '--salad-400', '--salad-500'],
-  orange: ['--orange-100', '--orange-200', '--orange-300', '--orange-400', '--orange-500'],
-  yellow: ['--yellow-100', '--yellow-200', '--yellow-300', '--yellow-400', '--yellow-500'],
-  red: ['--red-100', '--red-200', '--red-300', '--red-400', '--red-500'],
-  pink: ['--pink-100', '--pink-200', '--pink-300', '--pink-400', '--pink-500'],
-  violet: ['--violet-100', '--violet-200', '--violet-300', '--violet-400', '--violet-500'],
-  gray: ['--gray-100', '--gray-200', '--gray-300', '--gray-400', '--gray-500'],
-};
+const colors = ['--gray-100', '--gray-200', '--gray-300', '--gray-400', '--gray-500'] // gray
 
 const App = function (props) {
-  const colors = group[props.group];
-  if (!colors) {
-    return `Group "${props.group}" not found`;
-  }
   return (
     <div style={{ marginBottom: 32 }}>
       {colors.map((colorName, i) => {

--- a/website/src/docs-components/Color.jsx
+++ b/website/src/docs-components/Color.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import styles from './Color.module.css';
 import Copy from '../components/Copy';
+import { useColorResolver } from '@semcore/ui/utils/use/useColorResolver';
 
 const cssVariableFile = `
 @custom-media --desktop (min-width: 480px);
@@ -68,6 +69,7 @@ const cssVariable = Object.fromEntries(
 const Color = ({ name, className, ...other }) => {
   const varValue = cssVariable[name];
   const value = varValue || name;
+  const resolveColor = useColorResolver();
 
   return (
     <Copy
@@ -84,7 +86,7 @@ const Color = ({ name, className, ...other }) => {
         className={cx(styles.paintedElement, className)}
         {...other}
         value={value}
-        style={{ ...(other.style ?? {}), backgroundColor: value }}
+        style={{ ...(other.style ?? {}), backgroundColor: resolveColor(value) }}
       />
     </Copy>
   );


### PR DESCRIPTION
## Motivation and Context

The color resolver contained a very stupid mistake that was making using old color palette impossible. It has been existing in our codebase for about two weeks and it's insane that we haven't spotted it.

Basically it was removing `--` prefix from variable name and then was checking does this variable exist in map where all names had prefix `--`. So our potential users had to use `----{variable_name}` syntax if they were trying to overcome the issue.

## How has this been tested?

The fix is clear.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
