### PR TITLE
[scroll-area] fixed that sometimes scroll area focus ring was overlapped by sibling elements

### DIFF
--- a/semcore/scroll-area/CHANGELOG.md
+++ b/semcore/scroll-area/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.12.2] - 2023-11-09
+
+### Fixed
+
+- Sometimes scroll area focus ring was overlapped by sibling elements.
+
 ## [5.12.1] - 2023-11-09
 
 ### Changed

--- a/semcore/scroll-area/src/style/scroll-area.shadow.css
+++ b/semcore/scroll-area/src/style/scroll-area.shadow.css
@@ -6,6 +6,7 @@ SScrollArea {
 
 SShadowHorizontal,
 SShadowVertical {
+
   &:before,
   &:after {
     content: '';
@@ -17,6 +18,7 @@ SShadowVertical {
 }
 
 SShadowHorizontal {
+
   &:before,
   &:after {
     top: 0;
@@ -29,42 +31,35 @@ SShadowHorizontal {
 SShadowHorizontal[position='median'] {
   &:before {
     left: 0;
-    background: var(
-      --intergalactic-scroll-area-shadow-left,
-      linear-gradient(to right, rgba(25, 27, 35, 0.1) 20.55%, rgba(255, 255, 255, 0.0001) 100%)
-    );
+    background: var(--intergalactic-scroll-area-shadow-left,
+    linear-gradient(to right, rgba(25, 27, 35, 0.1) 20.55%, rgba(255, 255, 255, 0.0001) 100%));
   }
 
   &:after {
     right: 0;
-    background: var(
-      --intergalactic-scroll-area-shadow-right,
-      linear-gradient(to left, rgba(25, 27, 35, 0.1) 20.55%, rgba(255, 255, 255, 0.0001) 100%)
-    );
+    background: var(--intergalactic-scroll-area-shadow-right,
+    linear-gradient(to left, rgba(25, 27, 35, 0.1) 20.55%, rgba(255, 255, 255, 0.0001) 100%));
   }
 }
 
 SShadowHorizontal[position='start'] {
   &:before {
     left: 0;
-    background: var(
-      --intergalactic-scroll-area-shadow-left,
-      linear-gradient(to right, rgba(25, 27, 35, 0.1) 20.55%, rgba(255, 255, 255, 0.0001) 100%)
-    );
+    background: var(--intergalactic-scroll-area-shadow-left,
+    linear-gradient(to right, rgba(25, 27, 35, 0.1) 20.55%, rgba(255, 255, 255, 0.0001) 100%));
   }
 }
 
 SShadowHorizontal[position='end'] {
   &:after {
     right: 0;
-    background: var(
-      --intergalactic-scroll-area-shadow-right,
-      linear-gradient(to left, rgba(25, 27, 35, 0.1) 20.55%, rgba(255, 255, 255, 0.0001) 100%)
-    );
+    background: var(--intergalactic-scroll-area-shadow-right,
+    linear-gradient(to left, rgba(25, 27, 35, 0.1) 20.55%, rgba(255, 255, 255, 0.0001) 100%));
   }
 }
 
 SShadowVertical {
+
   &:before,
   &:after {
     left: 0;
@@ -77,38 +72,30 @@ SShadowVertical {
 SShadowVertical[position='median'] {
   &:before {
     top: 0;
-    background: var(
-      --intergalactic-scroll-area-shadow-top,
-      linear-gradient(to bottom, rgba(25, 27, 35, 0.1) 20.55%, rgba(255, 255, 255, 0.0001) 100%)
-    );
+    background: var(--intergalactic-scroll-area-shadow-top,
+    linear-gradient(to bottom, rgba(25, 27, 35, 0.1) 20.55%, rgba(255, 255, 255, 0.0001) 100%));
   }
 
   &:after {
     bottom: 0;
-    background: var(
-      --intergalactic-scroll-area-shadow-bottom,
-      linear-gradient(to top, rgba(25, 27, 35, 0.1) 20.55%, rgba(255, 255, 255, 0.0001) 100%)
-    );
+    background: var(--intergalactic-scroll-area-shadow-bottom,
+    linear-gradient(to top, rgba(25, 27, 35, 0.1) 20.55%, rgba(255, 255, 255, 0.0001) 100%));
   }
 }
 
 SShadowVertical[position='start'] {
   &:before {
     top: 0;
-    background: var(
-      --intergalactic-scroll-area-shadow-top,
-      linear-gradient(to bottom, rgba(25, 27, 35, 0.1) 20.55%, rgba(255, 255, 255, 0.0001) 100%)
-    );
+    background: var(--intergalactic-scroll-area-shadow-top,
+    linear-gradient(to bottom, rgba(25, 27, 35, 0.1) 20.55%, rgba(255, 255, 255, 0.0001) 100%));
   }
 }
 
 SShadowVertical[position='end'] {
   &:after {
     bottom: 0;
-    background: var(
-      --intergalactic-scroll-area-shadow-bottom,
-      linear-gradient(to top, rgba(25, 27, 35, 0.1) 20.55%, rgba(255, 255, 255, 0.0001) 100%)
-    );
+    background: var(--intergalactic-scroll-area-shadow-bottom,
+    linear-gradient(to top, rgba(25, 27, 35, 0.1) 20.55%, rgba(255, 255, 255, 0.0001) 100%));
   }
 }
 
@@ -139,5 +126,5 @@ SContainer[keyboardFocused]:focus::after {
   inset: 0;
   box-shadow: var(--intergalactic-keyboard-focus, 0px 0px 0px 3px rgba(0, 143, 248, 0.5));
   pointer-events: none;
-  z-index: 1;
+  z-index: 2;
 }


### PR DESCRIPTION

## Motivation and Context

https://github.com/semrush/intergalactic/issues/867

It's not general solution but should fix most cases as far normally focus ring should overlap even z-indexed elements. 

## How has this been tested?

Only manual tests.

## Screenshots:

Before:
![image](https://github.com/semrush/intergalactic/assets/31261408/07ce9827-9ba5-430b-abb4-e330f3d6d0f6)

After:
<img width="888" alt="Screen Shot 2023-11-09 at 17 37 54" src="https://github.com/semrush/intergalactic/assets/31261408/ec6bb2b6-6d0f-461a-971b-1c9c813b31d4">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
