### PR TITLE
[data-table] fixed lighthouse accessibility warning about existing scrollbar role element inside of the table

### DIFF
--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -6,267 +6,273 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Added
 
-- Sort icon is visible when column is focused by keyboard.
+* Sort icon is visible when column is focused by keyboard.
+
+## [4.18.1] - 2023-11-28
+
+### Fixed
+
+* Lighthouse accessibility warning about existing scrollbar role element inside of the table.
 
 ## [4.18.0] - 2023-11-24
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/utils` [4.10.3 ~> 4.13.0], `@semcore/core` [2.9.2 ~> 2.10.0]).
+* Version preminor update due to children dependencies update (`@semcore/utils` [4.10.3 ~> 4.13.0], `@semcore/core` [2.9.2 ~> 2.10.0]).
 
 ## [4.17.2] - 2023-11-21
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/core` [2.9.1 ~> 2.9.2]).
+* Version prepatch update due to children dependencies update (`@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/core` [2.9.1 ~> 2.9.2]).
 
 ## [4.17.1-prerelease.1] - 2023-11-20
 
 ### Changed
 
-- Removed animation from sort icon.
+* Removed animation from sort icon.
 
 ## [4.17.0] - 2023-11-13
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/icon` [4.15.0 ~> 4.16.0]).
+* Version preminor update due to children dependencies update (`@semcore/icon` [4.15.0 ~> 4.16.0]).
 
 ## [4.16.2] - 2023-11-10
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/icon` [4.14.1 ~> 4.15.0], `@semcore/scroll-area` [5.12.1 ~> 5.12.2]).
+* Version prepatch update due to children dependencies update (`@semcore/icon` [4.14.1 ~> 4.15.0], `@semcore/scroll-area` [5.12.1 ~> 5.12.2]).
 
 ## [4.16.1] - 2023-11-09
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/utils` [4.10.1 ~> 4.10.2], `@semcore/core` [2.9.0 ~> 2.9.1]).
+* Version prepatch update due to children dependencies update (`@semcore/utils` [4.10.1 ~> 4.10.2], `@semcore/core` [2.9.0 ~> 2.9.1]).
 
 ## [4.16.0] - 2023-11-06
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/icon` [4.13.0 ~> 4.14.0], `@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/core` [2.8.0 ~> 2.9.0]).
+* Version preminor update due to children dependencies update (`@semcore/icon` [4.13.0 ~> 4.14.0], `@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/core` [2.8.0 ~> 2.9.0]).
 
 ## [4.15.0] - 2023-10-27
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/icon` [4.12.0 ~> 4.13.0], `@semcore/utils` [4.8.4 ~> 4.9.0], `@semcore/core` [2.7.7 ~> 2.8.0]).
+* Version preminor update due to children dependencies update (`@semcore/icon` [4.12.0 ~> 4.13.0], `@semcore/utils` [4.8.4 ~> 4.9.0], `@semcore/core` [2.7.7 ~> 2.8.0]).
 
 ## [4.14.1] - 2023-10-27
 
 ### Changed
 
-- Value for `--intergalactic-icon-secondary-neutral-hover-active` token.
+* Value for `--intergalactic-icon-secondary-neutral-hover-active` token.
 
 ## [4.14.0] - 2023-10-26
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/icon` [4.11.2 ~> 4.12.0]).
+* Version preminor update due to children dependencies update (`@semcore/icon` [4.11.2 ~> 4.12.0]).
 
 ## [4.13.2] - 2023-10-24
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/core` [2.7.6 ~> 2.7.7]).
+* Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/core` [2.7.6 ~> 2.7.7]).
 
 ## [4.13.1] - 2023-10-16
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/core` [2.7.5 ~> 2.7.6]).
+* Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/core` [2.7.5 ~> 2.7.6]).
 
 ## [4.13.0] - 2023-10-10
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/flex-box` [5.7.5 ~> 5.8.0]).
+* Version preminor update due to children dependencies update (`@semcore/flex-box` [5.7.5 ~> 5.8.0]).
 
 ## [4.12.3] - 2023-10-03
 
 ### Fixed
 
-- Table with columns with fixed position was not displayed correctly.
+* Table with columns with fixed position was not displayed correctly.
 
 ## [4.12.2] - 2023-10-03
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/core` [2.7.3 ~> 2.7.4]).
+* Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/core` [2.7.3 ~> 2.7.4]).
 
 ## [4.12.1] - 2023-10-02
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/icon` [4.9.2 ~> 4.10.0], `@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/core` [2.7.2 ~> 2.7.3]).
+* Version prepatch update due to children dependencies update (`@semcore/icon` [4.9.2 ~> 4.10.0], `@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/core` [2.7.2 ~> 2.7.3]).
 
 ## [4.12.0] - 2023-09-21
 
 ### Added
 
-- `font-variant-numeric` for table cells
+* `font-variant-numeric` for table cells
 
 ## [4.11.2] - 2023-09-20
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/core` [2.7.1 ~> 2.7.2]).
+* Version prepatch update due to children dependencies update (`@semcore/core` [2.7.1 ~> 2.7.2]).
 
 ## [4.11.1] - 2023-09-20
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/utils` [4.7.0 ~> 4.7.1], `@semcore/core` [2.7.0 ~> 2.7.1]).
+* Version prepatch update due to children dependencies update (`@semcore/utils` [4.7.0 ~> 4.7.1], `@semcore/core` [2.7.0 ~> 2.7.1]).
 
 ## [4.11.0] - 2023-09-19
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/icon` [4.8.3 ~> 4.9.0]).
+* Version preminor update due to children dependencies update (`@semcore/icon` [4.8.3 ~> 4.9.0]).
 
 ## [4.10.4] - 2023-09-13
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/icon` [4.8.2 ~> 4.8.3], `@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
+* Version prepatch update due to children dependencies update (`@semcore/icon` [4.8.2 ~> 4.8.3], `@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
 
 ## [4.10.3] - 2023-09-12
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/core` [2.6.2 ~> 2.6.3]).
+* Version prepatch update due to children dependencies update (`@semcore/core` [2.6.2 ~> 2.6.3]).
 
 ## [4.10.2] - 2023-09-08
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
+* Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
 
 ## [4.10.1] - 2023-09-08
 
 ### Fixed
 
-- Fixed initial columns rendering width when `wMax` or `wMin` props provided.
+* Fixed initial columns rendering width when `wMax` or `wMin` props provided.
 
 ## [4.10.0] - 2023-09-05
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/icon` [4.7.1 ~> 4.8.0]).
+* Version preminor update due to children dependencies update (`@semcore/icon` [4.7.1 ~> 4.8.0]).
 
 ## [4.9.1] - 2023-09-05
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/core` [2.6.0 ~> 2.6.1]).
+* Version prepatch update due to children dependencies update (`@semcore/core` [2.6.0 ~> 2.6.1]).
 
 ## [4.9.0] - 2023-09-04
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/core` [2.5.0 ~> 2.6.0]).
+* Version preminor update due to children dependencies update (`@semcore/core` [2.5.0 ~> 2.6.0]).
 
 ## [4.8.0] - 2023-08-28
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
+* Version preminor update due to children dependencies update (`@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
 
 ## [4.7.1] - 2023-08-24
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
+* Version prepatch update due to children dependencies update (`@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
 
 ## [4.7.0] - 2023-08-23
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/scroll-area` [5.5.0 ~> 5.6.0]).
+* Version preminor update due to children dependencies update (`@semcore/scroll-area` [5.5.0 ~> 5.6.0]).
 
 ## [4.6.0] - 2023-08-23
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/icon` [4.4.1 ~> 4.5.0], `@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
+* Version preminor update due to children dependencies update (`@semcore/icon` [4.4.1 ~> 4.5.0], `@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
 
 ## [4.5.1] - 2023-08-21
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/core` [2.3.0 ~> 2.3.1]).
+* Version prepatch update due to children dependencies update (`@semcore/core` [2.3.0 ~> 2.3.1]).
 
 ## [4.5.0] - 2023-08-18
 
 ### Added
 
-- `data` prop for `DataTable.Cell` and `DataTable.Row` that allows more convenient typings than `DataTable.Cell<typeof data>`.
+* `data` prop for `DataTable.Cell` and `DataTable.Row` that allows more convenient typings than `DataTable.Cell<typeof data>`.
 
 ### Fixed
 
-- Collapsing of table included in row of other table.
+* Collapsing of table included in row of other table.
 
 ## [4.4.0] - 2023-08-17
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/scroll-area` [5.2.1 ~> 5.3.0]).
+* Version preminor update due to children dependencies update (`@semcore/scroll-area` [5.2.1 ~> 5.3.0]).
 
 ## [4.3.1] - 2023-08-14
 
 ### Changed
 
-- Version minor update due to children dependencies update (`@semcore/core` [2.2.0 ~> 2.2.1]).
+* Version minor update due to children dependencies update (`@semcore/core` [2.2.0 ~> 2.2.1]).
 
 ## [4.3.0] - 2023-08-07
 
 ### Changed
 
-- Version minor update due to children dependencies update (`@semcore/utils` [4.0.0 ~> 4.1.0]).
+* Version minor update due to children dependencies update (`@semcore/utils` [4.0.0 ~> 4.1.0]).
 
 ## [4.2.1] - 2023-08-01
 
 ### Fixed
 
-- Using special characters and spaces in the data keys were braking columns width.
+* Using special characters and spaces in the data keys were braking columns width.
 
 ## [4.2.0] - 2023-08-01
 
 ### Changed
 
-- Version minor update due to children dependencies update (`@semcore/flex-box` [5.0.0 ~> 5.1.0], `@semcore/icon` [4.1.0 ~> 4.2.0]).
+* Version minor update due to children dependencies update (`@semcore/flex-box` [5.0.0 ~> 5.1.0], `@semcore/icon` [4.1.0 ~> 4.2.0]).
 
 ## [4.1.0] - 2023-07-27
 
 ### Changed
 
-- Use `event.key` instead of `event.code` for better support of non QWERTY keyboard layouts.
+* Use `event.key` instead of `event.code` for better support of non QWERTY keyboard layouts.
 
 ## [4.0.2] - 2023-07-18
 
 ### Fixed
 
-- Fixed `disabledScroll` visual behavior.
+* Fixed `disabledScroll` visual behavior.
 
 ## [4.0.1] - 2023-07-18
 
 ### Fixed
 
-- Removed ResizeObserver initiating during SSR.
+* Removed ResizeObserver initiating during SSR.
 
 ## [4.0.0] - 2023-07-17
 
 ### Break
 
-- Strict, backward incompatible typings.
+* Strict, backward incompatible typings.
 
 ### Changed
 
-- Version major update due to children dependencies update (`@semcore/icon` [4.0.0 ~> 4.0.0]).
+* Version major update due to children dependencies update (`@semcore/icon` [4.0.0 ~> 4.0.0]).
 
 ## [3.11.1] - 2023-06-30
 
@@ -274,457 +280,457 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Added
 
-- Added background for active state for `Row`.
+* Added background for active state for `Row`.
 
 ## [3.10.3] - 2023-06-28
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/icon` [3.15.3 ~> 3.16.0]).
+* Version patch update due to children dependencies update (`@semcore/icon` [3.15.3 ~> 3.16.0]).
 
 ## [3.10.2] - 2023-06-27
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.53.4 ~> 3.54.0]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.53.4 ~> 3.54.0]).
 
 ## [3.10.1] - 2023-06-16
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.13 ~> 4.4.0]).
+* Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.13 ~> 4.4.0]).
 
 ## [3.10.0] - 2023-06-15
 
 ### Changed
 
-- Moved `role="rowgroup"` on focusable scroll areas to match automatic a11y checks.
+* Moved `role="rowgroup"` on focusable scroll areas to match automatic a11y checks.
 
 ## [3.9.7] - 2023-06-14
 
 ### Fixed
 
-- Grouped rows aria roles.
+* Grouped rows aria roles.
 
 ## [3.9.6] - 2023-06-13
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.10 ~> 4.3.11]).
+* Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.10 ~> 4.3.11]).
 
 ## [3.9.5] - 2023-06-12
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.53.2 ~> 3.53.3]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.53.2 ~> 3.53.3]).
 
 ## [3.9.4] - 2023-06-09
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/icon` [3.14.16 ~> 3.15.0], `@semcore/utils` [3.53.1 ~> 3.53.2]).
+* Version patch update due to children dependencies update (`@semcore/icon` [3.14.16 ~> 3.15.0], `@semcore/utils` [3.53.1 ~> 3.53.2]).
 
 ## [3.9.3] - 2023-06-07
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.7 ~> 4.3.8], `@semcore/utils` [3.53.0 ~> 3.53.1]).
+* Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.7 ~> 4.3.8], `@semcore/utils` [3.53.0 ~> 3.53.1]).
 
 ## [3.9.2] - 2023-05-31
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.52.0 ~> 3.53.0]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.52.0 ~> 3.53.0]).
 
 ## [3.9.1] - 2023-05-25
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.51.1 ~> 3.52.0]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.51.1 ~> 3.52.0]).
 
 ## [3.9.0] - 2023-05-25
 
 ### Changed
 
-- Improved `DataTable` typings, now props `sort`, `onSortChange`, `uniqueKey` types are automatically infered from `data` prop and children rendering row data might be better typed like `<DataTable.Cell<{}, typeof data> name="keyword">`.
+* Improved `DataTable` typings, now props `sort`, `onSortChange`, `uniqueKey` types are automatically infered from `data` prop and children rendering row data might be better typed like `<DataTable.Cell<{}, typeof data> name="keyword">`.
 
 ## [3.8.9] - 2023-05-22
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.50.7 ~> 3.51.0]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.50.7 ~> 3.51.0]).
 
 ## [3.8.8] - 2023-05-11
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7]).
 
 ## [3.8.7] - 2023-05-04
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.50.5 ~> 3.50.6]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.50.5 ~> 3.50.6]).
 
 ## [3.8.4] - 2023-04-28
 
 ### Fixed
 
-- Semantically connected cells with corresponding headers.
-- Added `scope` for table header.
+* Semantically connected cells with corresponding headers.
+* Added `scope` for table header.
 
 ## [3.8.3] - 2023-04-25
 
 ### Fixed
 
-- Fixed missing `key` warning.
+* Fixed missing `key` warning.
 
 ## [3.8.1] - 2023-04-17
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.50.0 ~> 3.50.3]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.50.0 ~> 3.50.3]).
 
 ## [3.8.0] - 2023-03-31
 
 ### Changed
 
-- Changed the presentation of the sort icon. Now it always runs into the text.
+* Changed the presentation of the sort icon. Now it always runs into the text.
 
 ## [3.7.29] - 2023-03-28
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.49.1 ~> 3.50.0]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.49.1 ~> 3.50.0]).
 
 ## [3.7.17] - 2023-02-22
 
 ### Fixed
 
-- Fixed empty table body with virtual scroll enabled displays unexpected "0".
+* Fixed empty table body with virtual scroll enabled displays unexpected "0".
 
 ## [3.7.15] - 2023-02-20
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.46.1 ~> 3.47.0]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.46.1 ~> 3.47.0]).
 
 ## [3.7.13] - 2023-02-13
 
 ### Fixed
 
-- Fixed view of cells when using cell grouping and columns at the same time.
+* Fixed view of cells when using cell grouping and columns at the same time.
 
 ## [3.7.9] - 2023-01-20
 
 ### Fixed
 
-- Fix floating sort icon to right align.
+* Fix floating sort icon to right align.
 
 ## [3.7.8] - 2023-01-20
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/icon` [3.7.0 ~> 3.8.0], `@semcore/utils` [3.45.0 ~> 3.46.0]).
+* Version patch update due to children dependencies update (`@semcore/icon` [3.7.0 ~> 3.8.0], `@semcore/utils` [3.45.0 ~> 3.46.0]).
 
 ## [3.7.1] - 2022-12-22
 
 ### Fixed
 
-- Fix style for `resizable`.
+* Fix style for `resizable`.
 
 ## [3.7.0] - 2022-12-21
 
 ### Changed
 
-- Removed vertical borders from header cells.
-- Added props `vBorders`, `borderLeft` and `borderRight` to have possibility to render vertical borders.
-- Added prop `compact` to reduce table paddings.
-- Added gradient to the sorting icon.
+* Removed vertical borders from header cells.
+* Added props `vBorders`, `borderLeft` and `borderRight` to have possibility to render vertical borders.
+* Added prop `compact` to reduce table paddings.
+* Added gradient to the sorting icon.
 
 ## [3.6.3] - 2022-12-19
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.44.0 ~> 3.44.1]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.44.0 ~> 3.44.1]).
 
 ## [3.6.2] - 2022-12-16
 
 ### Changed
 
-- Added `react-dom` to peer dependencies.
+* Added `react-dom` to peer dependencies.
 
 ## [3.6.0] - 2022-12-12
 
 ### Added
 
-- Design tokens based theming.
+* Design tokens based theming.
 
 ## [3.5.1] - 2022-11-08
 
 ### Added
 
-- Support for inheritance of `alignItems` prop from header to cells.
+* Support for inheritance of `alignItems` prop from header to cells.
 
 ## [3.4.1] - 2022-10-28
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/icon` [3.1.1 ~> 3.1.2], `@semcore/utils` [3.40.0 ~> 3.40.0]).
+* Version patch update due to children dependencies update (`@semcore/icon` [3.1.1 ~> 3.1.2], `@semcore/utils` [3.40.0 ~> 3.40.0]).
 
 ## [3.4.0] - 2022-10-25
 
 ### Added
 
-- Added `disabledScroll` property that disables scrolling in tables.
-- Added the ability(`flex="inherit"`) to inherit the size from the top table.
+* Added `disabledScroll` property that disables scrolling in tables.
+* Added the ability(`flex="inherit"`) to inherit the size from the top table.
 
 ## [3.3.4] - 2022-10-24
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/icon` [3.1.0 ~> 3.1.1]).
+* Version patch update due to children dependencies update (`@semcore/icon` [3.1.0 ~> 3.1.1]).
 
 ## [3.3.0] - 2022-10-10
 
 ### Changed
 
-- Added support for React 18 🔥
-- Extended version range for dependency `@semcore/icons`.
+* Added support for React 18 🔥
+* Extended version range for dependency `@semcore/icons`.
 
 ## [3.2.0] - 2022-10-07
 
 ### Added
 
-- Added support `ref` for `DataTable.Column` and `DataTable.Cell`.
+* Added support `ref` for `DataTable.Column` and `DataTable.Cell`.
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/icon` [2.32.2 ~> 2.33.0]).
+* Version patch update due to children dependencies update (`@semcore/icon` [2.32.2 ~> 2.33.0]).
 
 ## [3.1.9] - 2022-09-13
 
 ### Changed
 
-- Improved component accessibility in cases of virtual scroll and columns sorting.
+* Improved component accessibility in cases of virtual scroll and columns sorting.
 
 ## [3.1.8] - 2022-08-30
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.37.0 ~> 3.37.1]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.37.0 ~> 3.37.1]).
 
 ## [3.1.0] - 2022-07-18
 
 ### Changed
 
-- Add `onScroll` callback for `<Body/>`.
+* Add `onScroll` callback for `<Body/>`.
 
 ## [3.0.10] - 2022-07-07
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/icon` [2.27.0 ~> 2.28.0], `@semcore/utils` [3.33.0 ~> 3.34.0]).
+* Version patch update due to children dependencies update (`@semcore/icon` [2.27.0 ~> 2.28.0], `@semcore/utils` [3.33.0 ~> 3.34.0]).
 
 ## [3.0.9] - 2022-07-04
 
 ### Fixed
 
-- Fixed scrolling of table when enable virtual scrolling.
+* Fixed scrolling of table when enable virtual scrolling.
 
 ## [3.0.8] - 2022-06-09
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/progress-bar` [3.0.3 ~> 3.0.4]).
+* Version patch update due to children dependencies update (`@semcore/progress-bar` [3.0.3 ~> 3.0.4]).
 
 ## [3.0.1] - 2022-05-17
 
 ### Fixed
 
-- Fixed collapsing of header grouped cells.
+* Fixed collapsing of header grouped cells.
 
 ## [3.0.0] - 2022-05-17
 
 ### BREAK
 
-- Updated styles according to the library redesign policy.
+* Updated styles according to the library redesign policy.
 
 ## [2.2.9] - 2022-05-16
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/skeleton` [3.2.1 ~> 3.3.0]).
+* Version patch update due to children dependencies update (`@semcore/skeleton` [3.2.1 ~> 3.3.0]).
 
 ## [2.2.6] - 2022-04-27
 
 ### Fixed
 
-- Fixed columns width was usually not controlled by `w`, `wMin` and `wMax` props
+* Fixed columns width was usually not controlled by `w`, `wMin` and `wMax` props
 
 ## [2.2.5] - 2022-04-26
 
 ### Fixed
 
-- Fixed package lost typings.
+* Fixed package lost typings.
 
 ## [2.2.4] - 2022-04-25
 
 ### Changed
 
-- Fixed grouped rows hover highlight.
+* Fixed grouped rows hover highlight.
 
 ## [2.2.3] - 2022-04-25
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/scroll-area` [3.7.0 ~> 3.7.1]).
+* Version patch update due to children dependencies update (`@semcore/scroll-area` [3.7.0 ~> 3.7.1]).
 
 ## [2.2.0] - 2022-04-14
 
 ### Added
 
-- Virtual scroll support.
+* Virtual scroll support.
 
 ## [2.1.0] - 2022-04-07
 
 ### Changed
 
-- Internal enhances, rewritten from js to ts, render algorithmic performance increased.
+* Internal enhances, rewritten from js to ts, render algorithmic performance increased.
 
 ## [2.0.0] - 2022-04-06
 
 ### Fixed
 
-- Fixed uninitialized columns width from fixed size to equal flex-boxes.
+* Fixed uninitialized columns width from fixed size to equal flex-boxes.
 
 ## [1.5.4] - 2022-03-21
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/icon` [2.19.4 ~> 2.20.0]).
+* Version patch update due to children dependencies update (`@semcore/icon` [2.19.4 ~> 2.20.0]).
 
 ## [1.5.2] - 2022-02-24
 
 ### Added
 
-- Added repository field to package.json file.
+* Added repository field to package.json file.
 
 ## [1.5.1] - 2022-02-04
 
 ### Changed
 
-- Changed background-color from `transparent` to `#fff` for `use="secondary"` `DataTable.Column` and `DataTable.Cell`.
+* Changed background-color from `transparent` to `#fff` for `use="secondary"` `DataTable.Column` and `DataTable.Cell`.
 
 ## [1.5.0] - 2022-01-18
 
 ### Changed
 
-- Up version icons and use new icon.
+* Up version icons and use new icon.
 
 ## [1.4.6] - 2021-09-10
 
 ### Changed
 
-- Fixed position table for fixed columns.
-- Added support property `onResize` for `DataTable.Body`.
+* Fixed position table for fixed columns.
+* Added support property `onResize` for `DataTable.Body`.
 
 ## [1.4.5] - 2021-08-26
 
 ### Changed
 
-- Add 'sideEffect=false' for more optimal build via webpack
+* Add 'sideEffect=false' for more optimal build via webpack
 
 ## [1.4.4] - 2021-06-25
 
 ### Added
 
-- [A11y] Added support keyboard for sortable column.
+* [A11y] Added support keyboard for sortable column.
 
 ## [1.4.2] - 2021-03-17
 
 ### Fixed
 
-- Fixed automatic set property `flexBasis` for `DataTable.Column`.
+* Fixed automatic set property `flexBasis` for `DataTable.Column`.
 
 ## [1.4.1] - 2021-02-02
 
 ### Fixed
 
-- Removed calculation min width head and body because this is caused bugs.
+* Removed calculation min width head and body because this is caused bugs.
 
 ## [1.4.0] - 2021-01-19
 
 ### Added
 
-- Added `style` folder with css in build folder `lib`.
+* Added `style` folder with css in build folder `lib`.
 
 ## [1.3.0] - 2020-12-17
 
 ### Added
 
-- Added supported react@17.
+* Added supported react@17.
 
 ## [1.2.1] - 2020-12-14
 
 ### Fixed
 
-- Fixed `css` styles for DataTable include class name `use`.
+* Fixed `css` styles for DataTable include class name `use`.
 
 ## [1.2.0] - 2020-12-09
 
 ### Added
 
-- Added `secondary` theme for `DataTable`. Example `<DataTable use='secondary'/>`.
+* Added `secondary` theme for `DataTable`. Example `<DataTable use='secondary'/>`.
 
 ## [1.1.0] - 2020-12-03
 
 ### Changed
 
-- Added warning for deprecated prop 'sticky'.
+* Added warning for deprecated prop 'sticky'.
 
 ### Fixed
 
-- Replace special characters in column names because they apply as css variables.
+* Replace special characters in column names because they apply as css variables.
 
 ## [1.0.0] - 2020-11-20
 
 ### Changed
 
-- Replaced `title` prop with children parse for group column.
+* Replaced `title` prop with children parse for group column.
 
 ## [0.0.1-6] - 2020-11-03
 
 ### Fixed
 
-- Set size width column in css variable `Table`
+* Set size width column in css variable `Table`
 
 ## [0.0.1-5] - 2020-10-30
 
 ### Added
 
-- Set min-width for `Head and Body`, which calculate from width `Cell`
+* Set min-width for `Head and Body`, which calculate from width `Cell`
 
 ## [0.0.1-4] - 2020-10-14
 
 ### Fixed
 
-- fixed wrong path for ES6 build
+* fixed wrong path for ES6 build
 
 ## [0.0.1-3] - 2020-10-09
 
 ### Changed
 
-- Changed type for prop `sort`.
+* Changed type for prop `sort`.
 
 ## [0.0.1-2] - 2020-10-08
 
 ### Added
 
-- Add prop `active` for `Row`.
+* Add prop `active` for `Row`.
 
 ## [0.0.1-0] - 2020-09-11
 
 ### Added
 
-- Initial release
+* Initial release

--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -2,277 +2,277 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.19.1] - 2023-11-30
+
+### Fixed
+
+- Lighthouse accessibility warning about existing scrollbar role element inside of the table.
+
 ## [4.19.0] - 2023-11-30
 
 ### Added
 
-* Sort icon is visible when column is focused by keyboard.
-
-## [4.18.1] - 2023-11-28
-
-### Fixed
-
-* Lighthouse accessibility warning about existing scrollbar role element inside of the table.
+- Sort icon is visible when column is focused by keyboard.
 
 ## [4.18.0] - 2023-11-24
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.10.3 ~> 4.13.0], `@semcore/core` [2.9.2 ~> 2.10.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.10.3 ~> 4.13.0], `@semcore/core` [2.9.2 ~> 2.10.0]).
 
 ## [4.17.2] - 2023-11-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/core` [2.9.1 ~> 2.9.2]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/core` [2.9.1 ~> 2.9.2]).
 
 ## [4.17.1-prerelease.1] - 2023-11-20
 
 ### Changed
 
-* Removed animation from sort icon.
+- Removed animation from sort icon.
 
 ## [4.17.0] - 2023-11-13
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.15.0 ~> 4.16.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.15.0 ~> 4.16.0]).
 
 ## [4.16.2] - 2023-11-10
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/icon` [4.14.1 ~> 4.15.0], `@semcore/scroll-area` [5.12.1 ~> 5.12.2]).
+- Version prepatch update due to children dependencies update (`@semcore/icon` [4.14.1 ~> 4.15.0], `@semcore/scroll-area` [5.12.1 ~> 5.12.2]).
 
 ## [4.16.1] - 2023-11-09
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.10.1 ~> 4.10.2], `@semcore/core` [2.9.0 ~> 2.9.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.10.1 ~> 4.10.2], `@semcore/core` [2.9.0 ~> 2.9.1]).
 
 ## [4.16.0] - 2023-11-06
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.13.0 ~> 4.14.0], `@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/core` [2.8.0 ~> 2.9.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.13.0 ~> 4.14.0], `@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/core` [2.8.0 ~> 2.9.0]).
 
 ## [4.15.0] - 2023-10-27
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.12.0 ~> 4.13.0], `@semcore/utils` [4.8.4 ~> 4.9.0], `@semcore/core` [2.7.7 ~> 2.8.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.12.0 ~> 4.13.0], `@semcore/utils` [4.8.4 ~> 4.9.0], `@semcore/core` [2.7.7 ~> 2.8.0]).
 
 ## [4.14.1] - 2023-10-27
 
 ### Changed
 
-* Value for `--intergalactic-icon-secondary-neutral-hover-active` token.
+- Value for `--intergalactic-icon-secondary-neutral-hover-active` token.
 
 ## [4.14.0] - 2023-10-26
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.11.2 ~> 4.12.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.11.2 ~> 4.12.0]).
 
 ## [4.13.2] - 2023-10-24
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/core` [2.7.6 ~> 2.7.7]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/core` [2.7.6 ~> 2.7.7]).
 
 ## [4.13.1] - 2023-10-16
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/core` [2.7.5 ~> 2.7.6]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/core` [2.7.5 ~> 2.7.6]).
 
 ## [4.13.0] - 2023-10-10
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/flex-box` [5.7.5 ~> 5.8.0]).
+- Version preminor update due to children dependencies update (`@semcore/flex-box` [5.7.5 ~> 5.8.0]).
 
 ## [4.12.3] - 2023-10-03
 
 ### Fixed
 
-* Table with columns with fixed position was not displayed correctly.
+- Table with columns with fixed position was not displayed correctly.
 
 ## [4.12.2] - 2023-10-03
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/core` [2.7.3 ~> 2.7.4]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/core` [2.7.3 ~> 2.7.4]).
 
 ## [4.12.1] - 2023-10-02
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/icon` [4.9.2 ~> 4.10.0], `@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/core` [2.7.2 ~> 2.7.3]).
+- Version prepatch update due to children dependencies update (`@semcore/icon` [4.9.2 ~> 4.10.0], `@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/core` [2.7.2 ~> 2.7.3]).
 
 ## [4.12.0] - 2023-09-21
 
 ### Added
 
-* `font-variant-numeric` for table cells
+- `font-variant-numeric` for table cells
 
 ## [4.11.2] - 2023-09-20
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/core` [2.7.1 ~> 2.7.2]).
+- Version prepatch update due to children dependencies update (`@semcore/core` [2.7.1 ~> 2.7.2]).
 
 ## [4.11.1] - 2023-09-20
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.7.0 ~> 4.7.1], `@semcore/core` [2.7.0 ~> 2.7.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.7.0 ~> 4.7.1], `@semcore/core` [2.7.0 ~> 2.7.1]).
 
 ## [4.11.0] - 2023-09-19
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.8.3 ~> 4.9.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.8.3 ~> 4.9.0]).
 
 ## [4.10.4] - 2023-09-13
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/icon` [4.8.2 ~> 4.8.3], `@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
+- Version prepatch update due to children dependencies update (`@semcore/icon` [4.8.2 ~> 4.8.3], `@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
 
 ## [4.10.3] - 2023-09-12
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/core` [2.6.2 ~> 2.6.3]).
+- Version prepatch update due to children dependencies update (`@semcore/core` [2.6.2 ~> 2.6.3]).
 
 ## [4.10.2] - 2023-09-08
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
 
 ## [4.10.1] - 2023-09-08
 
 ### Fixed
 
-* Fixed initial columns rendering width when `wMax` or `wMin` props provided.
+- Fixed initial columns rendering width when `wMax` or `wMin` props provided.
 
 ## [4.10.0] - 2023-09-05
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.7.1 ~> 4.8.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.7.1 ~> 4.8.0]).
 
 ## [4.9.1] - 2023-09-05
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/core` [2.6.0 ~> 2.6.1]).
+- Version prepatch update due to children dependencies update (`@semcore/core` [2.6.0 ~> 2.6.1]).
 
 ## [4.9.0] - 2023-09-04
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/core` [2.5.0 ~> 2.6.0]).
+- Version preminor update due to children dependencies update (`@semcore/core` [2.5.0 ~> 2.6.0]).
 
 ## [4.8.0] - 2023-08-28
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
 
 ## [4.7.1] - 2023-08-24
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
 
 ## [4.7.0] - 2023-08-23
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/scroll-area` [5.5.0 ~> 5.6.0]).
+- Version preminor update due to children dependencies update (`@semcore/scroll-area` [5.5.0 ~> 5.6.0]).
 
 ## [4.6.0] - 2023-08-23
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.4.1 ~> 4.5.0], `@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.4.1 ~> 4.5.0], `@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
 
 ## [4.5.1] - 2023-08-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/core` [2.3.0 ~> 2.3.1]).
+- Version prepatch update due to children dependencies update (`@semcore/core` [2.3.0 ~> 2.3.1]).
 
 ## [4.5.0] - 2023-08-18
 
 ### Added
 
-* `data` prop for `DataTable.Cell` and `DataTable.Row` that allows more convenient typings than `DataTable.Cell<typeof data>`.
+- `data` prop for `DataTable.Cell` and `DataTable.Row` that allows more convenient typings than `DataTable.Cell<typeof data>`.
 
 ### Fixed
 
-* Collapsing of table included in row of other table.
+- Collapsing of table included in row of other table.
 
 ## [4.4.0] - 2023-08-17
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/scroll-area` [5.2.1 ~> 5.3.0]).
+- Version preminor update due to children dependencies update (`@semcore/scroll-area` [5.2.1 ~> 5.3.0]).
 
 ## [4.3.1] - 2023-08-14
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/core` [2.2.0 ~> 2.2.1]).
+- Version minor update due to children dependencies update (`@semcore/core` [2.2.0 ~> 2.2.1]).
 
 ## [4.3.0] - 2023-08-07
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.0.0 ~> 4.1.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.0.0 ~> 4.1.0]).
 
 ## [4.2.1] - 2023-08-01
 
 ### Fixed
 
-* Using special characters and spaces in the data keys were braking columns width.
+- Using special characters and spaces in the data keys were braking columns width.
 
 ## [4.2.0] - 2023-08-01
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/flex-box` [5.0.0 ~> 5.1.0], `@semcore/icon` [4.1.0 ~> 4.2.0]).
+- Version minor update due to children dependencies update (`@semcore/flex-box` [5.0.0 ~> 5.1.0], `@semcore/icon` [4.1.0 ~> 4.2.0]).
 
 ## [4.1.0] - 2023-07-27
 
 ### Changed
 
-* Use `event.key` instead of `event.code` for better support of non QWERTY keyboard layouts.
+- Use `event.key` instead of `event.code` for better support of non QWERTY keyboard layouts.
 
 ## [4.0.2] - 2023-07-18
 
 ### Fixed
 
-* Fixed `disabledScroll` visual behavior.
+- Fixed `disabledScroll` visual behavior.
 
 ## [4.0.1] - 2023-07-18
 
 ### Fixed
 
-* Removed ResizeObserver initiating during SSR.
+- Removed ResizeObserver initiating during SSR.
 
 ## [4.0.0] - 2023-07-17
 
 ### Break
 
-* Strict, backward incompatible typings.
+- Strict, backward incompatible typings.
 
 ### Changed
 
-* Version major update due to children dependencies update (`@semcore/icon` [4.0.0 ~> 4.0.0]).
+- Version major update due to children dependencies update (`@semcore/icon` [4.0.0 ~> 4.0.0]).
 
 ## [3.11.1] - 2023-06-30
 
@@ -280,457 +280,457 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Added
 
-* Added background for active state for `Row`.
+- Added background for active state for `Row`.
 
 ## [3.10.3] - 2023-06-28
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [3.15.3 ~> 3.16.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [3.15.3 ~> 3.16.0]).
 
 ## [3.10.2] - 2023-06-27
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.4 ~> 3.54.0]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.4 ~> 3.54.0]).
 
 ## [3.10.1] - 2023-06-16
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.13 ~> 4.4.0]).
+- Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.13 ~> 4.4.0]).
 
 ## [3.10.0] - 2023-06-15
 
 ### Changed
 
-* Moved `role="rowgroup"` on focusable scroll areas to match automatic a11y checks.
+- Moved `role="rowgroup"` on focusable scroll areas to match automatic a11y checks.
 
 ## [3.9.7] - 2023-06-14
 
 ### Fixed
 
-* Grouped rows aria roles.
+- Grouped rows aria roles.
 
 ## [3.9.6] - 2023-06-13
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.10 ~> 4.3.11]).
+- Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.10 ~> 4.3.11]).
 
 ## [3.9.5] - 2023-06-12
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.2 ~> 3.53.3]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.2 ~> 3.53.3]).
 
 ## [3.9.4] - 2023-06-09
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [3.14.16 ~> 3.15.0], `@semcore/utils` [3.53.1 ~> 3.53.2]).
+- Version patch update due to children dependencies update (`@semcore/icon` [3.14.16 ~> 3.15.0], `@semcore/utils` [3.53.1 ~> 3.53.2]).
 
 ## [3.9.3] - 2023-06-07
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.7 ~> 4.3.8], `@semcore/utils` [3.53.0 ~> 3.53.1]).
+- Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.7 ~> 4.3.8], `@semcore/utils` [3.53.0 ~> 3.53.1]).
 
 ## [3.9.2] - 2023-05-31
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.52.0 ~> 3.53.0]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.52.0 ~> 3.53.0]).
 
 ## [3.9.1] - 2023-05-25
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.51.1 ~> 3.52.0]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.51.1 ~> 3.52.0]).
 
 ## [3.9.0] - 2023-05-25
 
 ### Changed
 
-* Improved `DataTable` typings, now props `sort`, `onSortChange`, `uniqueKey` types are automatically infered from `data` prop and children rendering row data might be better typed like `<DataTable.Cell<{}, typeof data> name="keyword">`.
+- Improved `DataTable` typings, now props `sort`, `onSortChange`, `uniqueKey` types are automatically infered from `data` prop and children rendering row data might be better typed like `<DataTable.Cell<{}, typeof data> name="keyword">`.
 
 ## [3.8.9] - 2023-05-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.7 ~> 3.51.0]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.7 ~> 3.51.0]).
 
 ## [3.8.8] - 2023-05-11
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7]).
 
 ## [3.8.7] - 2023-05-04
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.5 ~> 3.50.6]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.5 ~> 3.50.6]).
 
 ## [3.8.4] - 2023-04-28
 
 ### Fixed
 
-* Semantically connected cells with corresponding headers.
-* Added `scope` for table header.
+- Semantically connected cells with corresponding headers.
+- Added `scope` for table header.
 
 ## [3.8.3] - 2023-04-25
 
 ### Fixed
 
-* Fixed missing `key` warning.
+- Fixed missing `key` warning.
 
 ## [3.8.1] - 2023-04-17
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.0 ~> 3.50.3]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.0 ~> 3.50.3]).
 
 ## [3.8.0] - 2023-03-31
 
 ### Changed
 
-* Changed the presentation of the sort icon. Now it always runs into the text.
+- Changed the presentation of the sort icon. Now it always runs into the text.
 
 ## [3.7.29] - 2023-03-28
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.49.1 ~> 3.50.0]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.49.1 ~> 3.50.0]).
 
 ## [3.7.17] - 2023-02-22
 
 ### Fixed
 
-* Fixed empty table body with virtual scroll enabled displays unexpected "0".
+- Fixed empty table body with virtual scroll enabled displays unexpected "0".
 
 ## [3.7.15] - 2023-02-20
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.46.1 ~> 3.47.0]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.46.1 ~> 3.47.0]).
 
 ## [3.7.13] - 2023-02-13
 
 ### Fixed
 
-* Fixed view of cells when using cell grouping and columns at the same time.
+- Fixed view of cells when using cell grouping and columns at the same time.
 
 ## [3.7.9] - 2023-01-20
 
 ### Fixed
 
-* Fix floating sort icon to right align.
+- Fix floating sort icon to right align.
 
 ## [3.7.8] - 2023-01-20
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [3.7.0 ~> 3.8.0], `@semcore/utils` [3.45.0 ~> 3.46.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [3.7.0 ~> 3.8.0], `@semcore/utils` [3.45.0 ~> 3.46.0]).
 
 ## [3.7.1] - 2022-12-22
 
 ### Fixed
 
-* Fix style for `resizable`.
+- Fix style for `resizable`.
 
 ## [3.7.0] - 2022-12-21
 
 ### Changed
 
-* Removed vertical borders from header cells.
-* Added props `vBorders`, `borderLeft` and `borderRight` to have possibility to render vertical borders.
-* Added prop `compact` to reduce table paddings.
-* Added gradient to the sorting icon.
+- Removed vertical borders from header cells.
+- Added props `vBorders`, `borderLeft` and `borderRight` to have possibility to render vertical borders.
+- Added prop `compact` to reduce table paddings.
+- Added gradient to the sorting icon.
 
 ## [3.6.3] - 2022-12-19
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.44.0 ~> 3.44.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.44.0 ~> 3.44.1]).
 
 ## [3.6.2] - 2022-12-16
 
 ### Changed
 
-* Added `react-dom` to peer dependencies.
+- Added `react-dom` to peer dependencies.
 
 ## [3.6.0] - 2022-12-12
 
 ### Added
 
-* Design tokens based theming.
+- Design tokens based theming.
 
 ## [3.5.1] - 2022-11-08
 
 ### Added
 
-* Support for inheritance of `alignItems` prop from header to cells.
+- Support for inheritance of `alignItems` prop from header to cells.
 
 ## [3.4.1] - 2022-10-28
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [3.1.1 ~> 3.1.2], `@semcore/utils` [3.40.0 ~> 3.40.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [3.1.1 ~> 3.1.2], `@semcore/utils` [3.40.0 ~> 3.40.0]).
 
 ## [3.4.0] - 2022-10-25
 
 ### Added
 
-* Added `disabledScroll` property that disables scrolling in tables.
-* Added the ability(`flex="inherit"`) to inherit the size from the top table.
+- Added `disabledScroll` property that disables scrolling in tables.
+- Added the ability(`flex="inherit"`) to inherit the size from the top table.
 
 ## [3.3.4] - 2022-10-24
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [3.1.0 ~> 3.1.1]).
+- Version patch update due to children dependencies update (`@semcore/icon` [3.1.0 ~> 3.1.1]).
 
 ## [3.3.0] - 2022-10-10
 
 ### Changed
 
-* Added support for React 18 🔥
-* Extended version range for dependency `@semcore/icons`.
+- Added support for React 18 🔥
+- Extended version range for dependency `@semcore/icons`.
 
 ## [3.2.0] - 2022-10-07
 
 ### Added
 
-* Added support `ref` for `DataTable.Column` and `DataTable.Cell`.
+- Added support `ref` for `DataTable.Column` and `DataTable.Cell`.
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [2.32.2 ~> 2.33.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [2.32.2 ~> 2.33.0]).
 
 ## [3.1.9] - 2022-09-13
 
 ### Changed
 
-* Improved component accessibility in cases of virtual scroll and columns sorting.
+- Improved component accessibility in cases of virtual scroll and columns sorting.
 
 ## [3.1.8] - 2022-08-30
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.37.0 ~> 3.37.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.37.0 ~> 3.37.1]).
 
 ## [3.1.0] - 2022-07-18
 
 ### Changed
 
-* Add `onScroll` callback for `<Body/>`.
+- Add `onScroll` callback for `<Body/>`.
 
 ## [3.0.10] - 2022-07-07
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [2.27.0 ~> 2.28.0], `@semcore/utils` [3.33.0 ~> 3.34.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [2.27.0 ~> 2.28.0], `@semcore/utils` [3.33.0 ~> 3.34.0]).
 
 ## [3.0.9] - 2022-07-04
 
 ### Fixed
 
-* Fixed scrolling of table when enable virtual scrolling.
+- Fixed scrolling of table when enable virtual scrolling.
 
 ## [3.0.8] - 2022-06-09
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/progress-bar` [3.0.3 ~> 3.0.4]).
+- Version patch update due to children dependencies update (`@semcore/progress-bar` [3.0.3 ~> 3.0.4]).
 
 ## [3.0.1] - 2022-05-17
 
 ### Fixed
 
-* Fixed collapsing of header grouped cells.
+- Fixed collapsing of header grouped cells.
 
 ## [3.0.0] - 2022-05-17
 
 ### BREAK
 
-* Updated styles according to the library redesign policy.
+- Updated styles according to the library redesign policy.
 
 ## [2.2.9] - 2022-05-16
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/skeleton` [3.2.1 ~> 3.3.0]).
+- Version patch update due to children dependencies update (`@semcore/skeleton` [3.2.1 ~> 3.3.0]).
 
 ## [2.2.6] - 2022-04-27
 
 ### Fixed
 
-* Fixed columns width was usually not controlled by `w`, `wMin` and `wMax` props
+- Fixed columns width was usually not controlled by `w`, `wMin` and `wMax` props
 
 ## [2.2.5] - 2022-04-26
 
 ### Fixed
 
-* Fixed package lost typings.
+- Fixed package lost typings.
 
 ## [2.2.4] - 2022-04-25
 
 ### Changed
 
-* Fixed grouped rows hover highlight.
+- Fixed grouped rows hover highlight.
 
 ## [2.2.3] - 2022-04-25
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/scroll-area` [3.7.0 ~> 3.7.1]).
+- Version patch update due to children dependencies update (`@semcore/scroll-area` [3.7.0 ~> 3.7.1]).
 
 ## [2.2.0] - 2022-04-14
 
 ### Added
 
-* Virtual scroll support.
+- Virtual scroll support.
 
 ## [2.1.0] - 2022-04-07
 
 ### Changed
 
-* Internal enhances, rewritten from js to ts, render algorithmic performance increased.
+- Internal enhances, rewritten from js to ts, render algorithmic performance increased.
 
 ## [2.0.0] - 2022-04-06
 
 ### Fixed
 
-* Fixed uninitialized columns width from fixed size to equal flex-boxes.
+- Fixed uninitialized columns width from fixed size to equal flex-boxes.
 
 ## [1.5.4] - 2022-03-21
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [2.19.4 ~> 2.20.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [2.19.4 ~> 2.20.0]).
 
 ## [1.5.2] - 2022-02-24
 
 ### Added
 
-* Added repository field to package.json file.
+- Added repository field to package.json file.
 
 ## [1.5.1] - 2022-02-04
 
 ### Changed
 
-* Changed background-color from `transparent` to `#fff` for `use="secondary"` `DataTable.Column` and `DataTable.Cell`.
+- Changed background-color from `transparent` to `#fff` for `use="secondary"` `DataTable.Column` and `DataTable.Cell`.
 
 ## [1.5.0] - 2022-01-18
 
 ### Changed
 
-* Up version icons and use new icon.
+- Up version icons and use new icon.
 
 ## [1.4.6] - 2021-09-10
 
 ### Changed
 
-* Fixed position table for fixed columns.
-* Added support property `onResize` for `DataTable.Body`.
+- Fixed position table for fixed columns.
+- Added support property `onResize` for `DataTable.Body`.
 
 ## [1.4.5] - 2021-08-26
 
 ### Changed
 
-* Add 'sideEffect=false' for more optimal build via webpack
+- Add 'sideEffect=false' for more optimal build via webpack
 
 ## [1.4.4] - 2021-06-25
 
 ### Added
 
-* [A11y] Added support keyboard for sortable column.
+- [A11y] Added support keyboard for sortable column.
 
 ## [1.4.2] - 2021-03-17
 
 ### Fixed
 
-* Fixed automatic set property `flexBasis` for `DataTable.Column`.
+- Fixed automatic set property `flexBasis` for `DataTable.Column`.
 
 ## [1.4.1] - 2021-02-02
 
 ### Fixed
 
-* Removed calculation min width head and body because this is caused bugs.
+- Removed calculation min width head and body because this is caused bugs.
 
 ## [1.4.0] - 2021-01-19
 
 ### Added
 
-* Added `style` folder with css in build folder `lib`.
+- Added `style` folder with css in build folder `lib`.
 
 ## [1.3.0] - 2020-12-17
 
 ### Added
 
-* Added supported react@17.
+- Added supported react@17.
 
 ## [1.2.1] - 2020-12-14
 
 ### Fixed
 
-* Fixed `css` styles for DataTable include class name `use`.
+- Fixed `css` styles for DataTable include class name `use`.
 
 ## [1.2.0] - 2020-12-09
 
 ### Added
 
-* Added `secondary` theme for `DataTable`. Example `<DataTable use='secondary'/>`.
+- Added `secondary` theme for `DataTable`. Example `<DataTable use='secondary'/>`.
 
 ## [1.1.0] - 2020-12-03
 
 ### Changed
 
-* Added warning for deprecated prop 'sticky'.
+- Added warning for deprecated prop 'sticky'.
 
 ### Fixed
 
-* Replace special characters in column names because they apply as css variables.
+- Replace special characters in column names because they apply as css variables.
 
 ## [1.0.0] - 2020-11-20
 
 ### Changed
 
-* Replaced `title` prop with children parse for group column.
+- Replaced `title` prop with children parse for group column.
 
 ## [0.0.1-6] - 2020-11-03
 
 ### Fixed
 
-* Set size width column in css variable `Table`
+- Set size width column in css variable `Table`
 
 ## [0.0.1-5] - 2020-10-30
 
 ### Added
 
-* Set min-width for `Head and Body`, which calculate from width `Cell`
+- Set min-width for `Head and Body`, which calculate from width `Cell`
 
 ## [0.0.1-4] - 2020-10-14
 
 ### Fixed
 
-* fixed wrong path for ES6 build
+- fixed wrong path for ES6 build
 
 ## [0.0.1-3] - 2020-10-09
 
 ### Changed
 
-* Changed type for prop `sort`.
+- Changed type for prop `sort`.
 
 ## [0.0.1-2] - 2020-10-08
 
 ### Added
 
-* Add prop `active` for `Row`.
+- Add prop `active` for `Row`.
 
 ## [0.0.1-0] - 2020-09-11
 
 ### Added
 
-* Initial release
+- Initial release

--- a/semcore/data-table/src/Body.tsx
+++ b/semcore/data-table/src/Body.tsx
@@ -16,6 +16,7 @@ const getCellsByColumn = (cells: NestedCells): RowData => {
   const flattenCells = cells.flat(20) as Cell[];
   return Object.fromEntries(flattenCells.map((cell) => [cell.name, cell.data]));
 };
+const displayContents = { display: 'contents' };
 
 type AsProps = {
   rows: NestedCells[];
@@ -303,13 +304,19 @@ class Body extends Component<AsProps, State> {
           <SScrollArea.Container ref={$scrollRef} disabledScroll={disabledScroll} role='rowgroup'>
             {body}
           </SScrollArea.Container>
-          <SScrollAreaBar
-            orientation='horizontal'
-            left={`${offsetLeftSum}px`}
-            right={`${offsetRightSum}px`}
-            offsetSum={`${offsetSum}px`}
-          />
-          <SScrollAreaBar orientation='vertical' />
+          <div style={displayContents} role='rowgroup'>
+            <div style={displayContents} role='row'>
+              <div style={displayContents} role='cell'>
+                <SScrollAreaBar
+                  orientation='horizontal'
+                  left={`${offsetLeftSum}px`}
+                  right={`${offsetRightSum}px`}
+                  offsetSum={`${offsetSum}px`}
+                />
+                <SScrollAreaBar orientation='vertical' />
+              </div>
+            </div>
+          </div>
         </SScrollArea>
         {Children.origin}
       </SBodyWrapper>


### PR DESCRIPTION
## Motivation and Context

axe-core (used by Lighthouse for a11y audits) rises warning if table (or anything with role='table') contains any non-table elements. It was also related to scrollbars inside of tables. 
Solution is ugly a little bit but should not break anything.

## How has this been tested?

Manually with lighthouse.

## Screenshots (if appropriate):

![image](https://github.com/semrush/intergalactic/assets/31261408/c1692473-2441-43ea-8eb5-8bcdda9a6453)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
