### PR TITLE
[breakpoints] removed defaultIndex from MediaList as unusable

### DIFF
--- a/semcore/breakpoints/CHANGELOG.md
+++ b/semcore/breakpoints/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [1.13.0] - 2023-11-30
+
+### Removed
+
+- `defaultIndex` from `MediaList` as unusable.
+
 ## [1.12.3] - 2023-11-24
 
 ### Fixed

--- a/semcore/breakpoints/src/Breakpoints.jsx
+++ b/semcore/breakpoints/src/Breakpoints.jsx
@@ -7,10 +7,8 @@ const DEFAULT_MEDIA = ['(min-width: 768px)', '(max-width: 767px)'];
 class MediaList {
   mediaQueries = [];
   listeners = [];
-  defaultIndex = 0;
 
-  constructor(media, defaultIndex) {
-    this.defaultIndex = defaultIndex ?? this.defaultIndex;
+  constructor(media) {
     if (canUseDOM()) {
       this.mediaQueries = media.map(window.matchMedia);
     }
@@ -28,9 +26,7 @@ class MediaList {
   });
 
   matches() {
-    const index = this.mediaQueries.findIndex((m) => m.matches);
-
-    return index > -1 ? index : this.defaultIndex;
+    return this.mediaQueries.findIndex((m) => m.matches);
   }
 
   addListener(listener) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
#918 and request from Slack
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Don't need to test it. Just turn back last behavior.
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
