### PR TITLE
[date-picker] fixed input trigger were not displaying date or date range when it is passed as number or string

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,7 +433,7 @@ importers:
   semcore/carousel:
     dependencies:
       '@semcore/breakpoints':
-        specifier: 1.13.0-prerelease.1
+        specifier: 1.13.0
         version: link:../breakpoints
       '@semcore/button':
         specifier: 5.12.0
@@ -2703,7 +2703,7 @@ importers:
         specifier: 5.16.2
         version: link:../breadcrumbs
       '@semcore/breakpoints':
-        specifier: 1.13.0-prerelease.1
+        specifier: 1.13.0
         version: link:../breakpoints
       '@semcore/button':
         specifier: 5.12.0
@@ -2712,7 +2712,7 @@ importers:
         specifier: 5.17.2
         version: link:../card
       '@semcore/carousel':
-        specifier: 3.19.0-prerelease.1
+        specifier: 3.19.0
         version: link:../carousel
       '@semcore/checkbox':
         specifier: 7.14.0
@@ -2730,7 +2730,7 @@ importers:
         specifier: 3.19.5
         version: link:../d3-chart
       '@semcore/data-table':
-        specifier: 4.19.0-prerelease.1
+        specifier: 4.19.0
         version: link:../data-table
       '@semcore/date-picker':
         specifier: 4.18.0

--- a/semcore/date-picker/CHANGELOG.md
+++ b/semcore/date-picker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.19.0] - 2023-11-30
+
+### Fixed
+
+- Input trigger were not displaying date or date range when it is passed as number or string.
+
 ## [4.18.0] - 2023-11-28
 
 ### Added

--- a/semcore/date-picker/src/components/InputTrigger.jsx
+++ b/semcore/date-picker/src/components/InputTrigger.jsx
@@ -314,14 +314,17 @@ const MaskedInput = ({
   }, [locale, allowedParts]);
 
   const outer = React.useMemo(() => {
-    const validDate =
-      outerValue && outerValue instanceof Date && !Number.isNaN(outerValue.getTime());
+    let outerDate = outerValue;
+    if (typeof outerValue === 'number' || typeof outerValue === 'string') {
+      outerDate = new Date(outerValue);
+    }
+    const validDate = outerDate && outerDate instanceof Date && !Number.isNaN(outerDate.getTime());
     if (!validDate) return null;
 
     return {
-      year: outerValue.getFullYear().toString().padStart(4, '0'),
-      month: (outerValue.getMonth() + 1).toString().padStart(2, '0'),
-      day: outerValue.getDate().toString().padStart(2, '0'),
+      year: outerDate.getFullYear().toString().padStart(4, '0'),
+      month: (outerDate.getMonth() + 1).toString().padStart(2, '0'),
+      day: outerDate.getDate().toString().padStart(2, '0'),
     };
   }, [outerValue]);
   const stringifyValue = React.useCallback(
@@ -534,15 +537,18 @@ const MaskedInput = ({
     [sep, placeholders],
   );
   const humanizedDate = React.useMemo(() => {
-    const validDate =
-      outerValue && outerValue instanceof Date && !Number.isNaN(outerValue.getTime());
+    let outerDate = outerValue;
+    if (typeof outerValue === 'number' || typeof outerValue === 'string') {
+      outerDate = new Date(outerValue);
+    }
+    const validDate = outerDate && outerDate instanceof Date && !Number.isNaN(outerDate.getTime());
     if (!validDate) return null;
 
     return new Intl.DateTimeFormat(locale, {
       year: allowedParts.year ? 'numeric' : undefined,
       month: allowedParts.month ? 'short' : undefined,
       day: allowedParts.day ? '2-digit' : undefined,
-    }).format(outerValue);
+    }).format(outerDate);
   }, [outerValue, locale, allowedParts]);
 
   const SHumanizedDate = 'div';


### PR DESCRIPTION
## Motivation and Context

Date pickers accept `value` as Date, string or number. It wasn't working in input triggers (while displaying normally) inside of date picker calendar. I have added simple mapping inside of input trigger.

## How has this been tested?

I have tested it manually.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.
