### PR TITLE
[popper, tooltip] fixed incorrect behavior in Tooltip when it has a focusable elements inside themself and don't close from the first esc keypress

### DIFF
--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.12.1] - 2023-12-07
+
+### Fixed
+
+- `focusLock` behavior for `hover` interaction.
+
 ## [5.12.0] - 2023-11-28
 
 ### Added

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -533,7 +533,9 @@ function PopperPopper(props) {
   useFocusLock(
     ref,
     autoFocus,
-    interaction === 'focus' ? focusableTriggerReturnFocusToRef : triggerRef,
+    interaction === 'focus' || interaction === 'hover'
+      ? focusableTriggerReturnFocusToRef
+      : triggerRef,
     !visible || disableEnforceFocus,
     focusMaster,
   );

--- a/semcore/tooltip/CHANGELOG.md
+++ b/semcore/tooltip/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [6.12.1] - 2023-12-07
+
+### Fixed
+
+- Incorrect behavior in Tooltip when it has a focusable elements inside themself and don't close from the first `esc` keypress.
+
 ## [6.12.0] - 2023-11-29
 
 ### Changed

--- a/semcore/tooltip/src/Tooltip.jsx
+++ b/semcore/tooltip/src/Tooltip.jsx
@@ -39,7 +39,6 @@ class TooltipRoot extends Component {
     const { uid, visible, interaction } = this.asProps;
 
     return {
-      active: false,
       'aria-describedby': visible ? `igc-${uid}-popper` : undefined,
       'aria-haspopup': interaction !== 'hover' ? 'true' : 'false',
     };
@@ -99,7 +98,7 @@ function TooltipTrigger(props) {
   const STrigger = Root;
 
   return sstyled(styles)(
-    <STrigger render={Popper.Trigger} active={false} role={undefined}>
+    <STrigger render={Popper.Trigger} role={undefined}>
       <Children />
     </STrigger>,
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
#942 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
I have tested it manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
