### PR TITLE
[d3-chart] fixed chart legend table trimming with Ellipsis component

### DIFF
--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.21.1] - 2023-12-12
+
+### Fixed
+
+- `ChartLegendTable` labels trimming with `Ellipsis` component.
+
 ## [3.21.0] - 2023-12-06
 
 ### Changed

--- a/semcore/d3-chart/src/component/ChartLegend/LegendItem/legend-item.shadow.css
+++ b/semcore/d3-chart/src/component/ChartLegend/LegendItem/legend-item.shadow.css
@@ -1,4 +1,5 @@
 SLegendItem {
+  min-width: 0;
   align-items: flex-start;
 }
 
@@ -68,6 +69,10 @@ SIcon[size='l'] {
 
 SIcon[size='m'] {
   margin-top: 2px;
+}
+
+SLabel {
+  min-width: 0;
 }
 
 SLabel[size='l'], SAdditionalLabel[size='l'], SCount[size='l'] {


### PR DESCRIPTION
## Motivation and Context

Found that ellipsis doesn't work in the chart legend table grid.
I have found some wierd hacks ([1](https://css-tricks.com/preventing-a-grid-blowout/), [2](https://stackoverflow.com/questions/36230944/prevent-flex-items-from-overflowing-a-container)) that make everything work like a charm.

## How has this been tested?

It almost impossible to test in our screenshot unit tests because ellipsis needs a trimming rerender.

## Screenshots:

Before:

<img width="746" alt="Screen Shot 2023-12-12 at 14 15 42" src="https://github.com/semrush/intergalactic/assets/31261408/6596acc7-7085-4742-9331-599b17f9d205">

After:

<img width="610" alt="Screen Shot 2023-12-12 at 14 14 12" src="https://github.com/semrush/intergalactic/assets/31261408/4568e46c-b60c-4c18-b515-4aaa35344771">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
