### PR TITLE
[website] fixed 'Fixed header' example in data-table

### DIFF
--- a/website/docs/table-group/data-table/data-table-code.md
+++ b/website/docs/table-group/data-table/data-table-code.md
@@ -454,13 +454,8 @@ import ScrollArea from '@semcore/ui/scroll-area';
 const Demo = () => {
   const containerRef = React.useRef<HTMLDivElement>(null);
   const [container, setContainer] = React.useState(null);
-  const [top, setTop] = React.useState(0);
-  React.useEffect(() => {
-    containerRef.current &&
-      setContainer(containerRef.current.closest('[data-ui-name="ScrollArea.Container"]'));
-    const header = document.getElementsByTagName('header')[0];
-    header && setTop(header.offsetHeight);
-  }, []);
+  const top = 0; // Here should be height of Header in your application
+
   return (
     <>
       <DataTable data={data}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Resolved #978 

Since we've added `overflow: auto` for the `playground-runtime` containers, `top` property with `position: sticky` works incorrect. So, I removed `top` property in examples and added comment there.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):
<img width="646" alt="Screenshot 2023-12-20 at 09 23 46" src="https://github.com/semrush/intergalactic/assets/8787452/f8e89050-99b3-4d6d-9557-7b9c6fffe256">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
