### PR TITLE
[popper] added visual focus ring on trigger when focus is got by focus catcher

### DIFF
--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.14.0] - 2023-12-22
+
+### Changed
+
+- When keyboard users are focus-triggered closing popper, trigger is highlighted with focus ring while actually focus is placed on the sibling invisible element.
+
 ## [5.13.0] - 2023-12-14
 
 ### Fixed

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -523,18 +523,18 @@ function Trigger(props) {
           style={focusCatcherStyles}
         />
       )}
-      <STrigger
-        render={Box}
-        inline
-        role='button'
-        aria-haspopup={true}
-        onFocus={handleFocus}
-        ref={triggerRef}
-      >
-        <enforcedKeyboardFocusEnhanceContext.Provider value={enforceKeyboardFocused}>
+      <enforcedKeyboardFocusEnhanceContext.Provider value={enforceKeyboardFocused}>
+        <STrigger
+          render={Box}
+          inline
+          role='button'
+          aria-haspopup={true}
+          onFocus={handleFocus}
+          ref={triggerRef}
+        >
           <Children />
-        </enforcedKeyboardFocusEnhanceContext.Provider>
-      </STrigger>
+        </STrigger>
+      </enforcedKeyboardFocusEnhanceContext.Provider>
       {focusHint && false && (
         <SFocusHint aria-live='polite'>
           <ScreenReaderOnly>{focusHint}</ScreenReaderOnly>

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -432,7 +432,7 @@ const useFocusCatch = (active, popperRef) => {
   const activeRef = React.useRef(active);
   activeRef.current = active;
 
-  const [keyboardFocused, setKeyboardFocused] = React.useState(null);
+  const [keyboardFocused, setKeyboardFocused] = React.useState(false);
   const [focusCatch, setFocusCatch] = React.useState(false);
   const focusSourceRef = useFocusSource();
   const handleFocusCatchFocus = React.useCallback(() => {

--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.16.0] - 2023-12-22
+
+### Changed
+
+- `keyboardFocusEnhance` got context based keyboard focus enforcing.
+
 ## [4.15.1] - 2023-12-14
 
 ### Fixed

--- a/semcore/utils/src/enhances/keyboardFocusEnhance.tsx
+++ b/semcore/utils/src/enhances/keyboardFocusEnhance.tsx
@@ -14,6 +14,8 @@ export type KeyboardFocusProps = {
   autoFocus?: boolean;
 };
 
+export const enforcedKeyboardFocusEnhanceContext = React.createContext(false);
+
 let lastFocusSource: 'mouse' | 'keyboard' | 'none' = 'none';
 const focusSourceListeners: {
   setFocusSource: (source: 'mouse' | 'keyboard' | 'none') => void;
@@ -103,9 +105,11 @@ const keyboardFocusEnhance = (): KeyboardFocusEnhanceHook => {
       }
     }, [disabled]);
 
+    const enforcedKeyboardFocus = React.useContext(enforcedKeyboardFocusEnhanceContext);
+
     return assignProps(props, {
       tabIndex: disabled ? -1 : tabIndex,
-      keyboardFocused: keyboardFocused && !disabled,
+      keyboardFocused: (keyboardFocused || enforcedKeyboardFocus) && !disabled,
       onFocus: handleFocus,
       onBlur: handlerBlur,
       ref,


### PR DESCRIPTION
## Motivation and Context

Currently when focus on page is on the popper trigger focus catcher, the focus ring is not visible. 
I have added context that enabled components that use keyboardFocusEnhance inside of popper trigger to highlight when  some of trigger focus catchers are focused by keyboard interaction.

## How has this been tested?

Not sure how to add tests for that, ideas are welcome.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
