### PR TITLE
[website] isolated examples styles from website styles in shadow roots

### DIFF
--- a/website/docs/.vitepress/renderSandbox.ts
+++ b/website/docs/.vitepress/renderSandbox.ts
@@ -81,7 +81,7 @@ const makePlaygroundExecutableCode = (
     '; {\n' +
     importAliasLines.join('\n') +
     codeWithoutImports +
-    `;\n globalThis["render_${playgroundId}"] = () => { globalThis.createReactRoot?.(globalThis.document?.getElementById("${playgroundId}")).render(<${entryPoint} />); }; }`;
+    `;\n globalThis["render_${playgroundId}"] = (mountNode) => { globalThis.createReactRoot?.(mountNode).render(<${entryPoint} />); }; }`;
 
   return {
     executableCode,

--- a/website/docs/.vitepress/renderSandbox.ts
+++ b/website/docs/.vitepress/renderSandbox.ts
@@ -164,7 +164,9 @@ export const renderSandbox = (
 
       const encodedHtmlCode = btoa(htmlCode);
       const encodedRawCode = btoa(displayedCode);
-      return `<Sandbox playgroundId="${playgroundId}" hideCode="${hideCode}" htmlCode="${encodedHtmlCode}" rawCode="${encodedRawCode}">`;
+      return `<Sandbox playgroundId="${playgroundId}" hideCode="${hideCode}" htmlCode="${encodedHtmlCode}" rawCode="${encodedRawCode}" :stylesIsolation="${
+        htmlTag === 'sandbox'
+      }">`;
     }
     return '</Sandbox>';
   };

--- a/website/docs/.vitepress/theme/Sandbox.vue
+++ b/website/docs/.vitepress/theme/Sandbox.vue
@@ -22,7 +22,25 @@ const rawCode = atob(rawCodeEncoded!);
 const hideCode = hideCodeEncoded === 'true';
 
 onMounted(() => {
-  globalThis[`render_${playgroundId}`]?.()
+  if (!playgroundId) return;
+  const wrapper = document.querySelector(`#${playgroundId}`);
+  if (!wrapper) return;
+  wrapper.attachShadow({ mode: "open" });
+  const shadowRoot = wrapper.shadowRoot!;
+  const element = document.createElement("div");
+  shadowRoot.appendChild(element);
+  const reshadowContainer = document.querySelector("#__reshadow__");
+  if (reshadowContainer) {
+    shadowRoot.adoptedStyleSheets.push(...[...reshadowContainer.children].map((node) => {
+      const sheet = new CSSStyleSheet()
+      const styleNode = node as HTMLStyleElement
+      const cssRules = [...(styleNode.sheet?.cssRules ?? [])];
+      const cssText = cssRules.reduce((acc, rule) => acc + rule.cssText, '');
+      sheet.replaceSync(cssText)
+      return sheet;
+    }))
+  }
+  globalThis[`render_${playgroundId}`]?.(element)
 })
 
 const dataToLzCompressedJson = (data) => {

--- a/website/docs/.vitepress/theme/Sandbox.vue
+++ b/website/docs/.vitepress/theme/Sandbox.vue
@@ -16,29 +16,36 @@ const { compressToBase64: lzCompressToBase64 } = lzString;
 
 (globalThis as any).createReactRoot = createReactRoot;
 
-const { playgroundId, htmlCode: codeEncoded, rawCode: rawCodeEncoded, hideCode: hideCodeEncoded, } = defineProps({ playgroundId: String, htmlCode: String, rawCode: String, hideCode: String })
+const { playgroundId, htmlCode: codeEncoded, rawCode: rawCodeEncoded, hideCode: hideCodeEncoded, stylesIsolation } = defineProps({ playgroundId: String, htmlCode: String, rawCode: String, hideCode: String, stylesIsolation: Boolean })
 const htmlCode = atob(codeEncoded!);
 const rawCode = atob(rawCodeEncoded!);
 const hideCode = hideCodeEncoded === 'true';
 
+
 onMounted(() => {
+  console.log({ stylesIsolation })
   if (!playgroundId) return;
-  const wrapper = document.querySelector(`#${playgroundId}`);
+  const wrapper = document.querySelector(`#${playgroundId}`) as HTMLDivElement | undefined;
   if (!wrapper) return;
-  wrapper.attachShadow({ mode: "open" });
-  const shadowRoot = wrapper.shadowRoot!;
-  const element = document.createElement("div");
-  shadowRoot.appendChild(element);
-  const reshadowContainer = document.querySelector("#__reshadow__");
-  if (reshadowContainer) {
-    shadowRoot.adoptedStyleSheets.push(...[...reshadowContainer.children].map((node) => {
-      const sheet = new CSSStyleSheet()
-      const styleNode = node as HTMLStyleElement
-      const cssRules = [...(styleNode.sheet?.cssRules ?? [])];
-      const cssText = cssRules.reduce((acc, rule) => acc + rule.cssText, '');
-      sheet.replaceSync(cssText)
-      return sheet;
-    }))
+  let element: HTMLDivElement | null = null;
+  if (stylesIsolation) {
+    wrapper.attachShadow({ mode: "open" });
+    const shadowRoot = wrapper.shadowRoot!;
+    element = document.createElement("div");
+    shadowRoot.appendChild(element);
+    const reshadowContainer = document.querySelector("#__reshadow__");
+    if (reshadowContainer) {
+      shadowRoot.adoptedStyleSheets.push(...[...reshadowContainer.children].map((node) => {
+        const sheet = new CSSStyleSheet()
+        const styleNode = node as HTMLStyleElement
+        const cssRules = [...(styleNode.sheet?.cssRules ?? [])];
+        const cssText = cssRules.reduce((acc, rule) => acc + rule.cssText, '');
+        sheet.replaceSync(cssText)
+        return sheet;
+      }))
+    }
+  } else {
+    element = wrapper;
   }
   globalThis[`render_${playgroundId}`]?.(element)
 })

--- a/website/docs/.vitepress/theme/isolateStyles.ts
+++ b/website/docs/.vitepress/theme/isolateStyles.ts
@@ -1,0 +1,21 @@
+export const isolateStyles = (node: HTMLElement) => {
+  node.attachShadow({ mode: 'open' });
+  const shadowRoot = node.shadowRoot!;
+  const element = document.createElement('div');
+  shadowRoot.appendChild(element);
+  const reshadowContainer = document.querySelector('#__reshadow__');
+  if (reshadowContainer) {
+    shadowRoot.adoptedStyleSheets.push(
+      ...[...reshadowContainer.children].map((node) => {
+        const sheet = new CSSStyleSheet();
+        const styleNode = node as HTMLStyleElement;
+        const cssRules = [...(styleNode.sheet?.cssRules ?? [])];
+        const cssText = cssRules.reduce((acc, rule) => acc + rule.cssText, '');
+        sheet.replaceSync(cssText);
+        return sheet;
+      }),
+    );
+  }
+
+  return element;
+};

--- a/website/docs/.vitepress/theme/style.css
+++ b/website/docs/.vitepress/theme/style.css
@@ -565,7 +565,8 @@ img {
 }
 
 /* To remove double underline from the links in the sandboxes */
-.vp-doc .documentation-sandbox a:not([class]):hover, .vp-doc a:not([class]):active {
+.vp-doc .documentation-sandbox a:not([class]):hover,
+.vp-doc a:not([class]):active {
   text-decoration: none !important;
 }
 

--- a/website/src/components/playground/Playground.jsx
+++ b/website/src/components/playground/Playground.jsx
@@ -1,5 +1,23 @@
 import React, { Component } from 'react';
+import { createPortal } from 'react-dom';
 import reactElementToJSXString from 'react-element-to-jsx-string';
+import { isolateStyles } from '../../../docs/.vitepress/theme/isolateStyles';
+
+const ShadowRooted = ({ children }) => {
+  const ref = React.useRef();
+  const [shadowedRef, setShadowedRef] = React.useState();
+  React.useEffect(() => {
+    if (!ref.current) return;
+    const shadowed = isolateStyles(ref.current);
+    setShadowedRef(shadowed);
+  }, []);
+  return (
+    <>
+      <div ref={ref} />
+      {shadowedRef && createPortal(children, shadowedRef)}
+    </>
+  );
+};
 
 class Playground extends Component {
   static widgets = {};
@@ -81,7 +99,7 @@ class Playground extends Component {
 
     const component = preview(createGroupWidgets);
     return {
-      result: component,
+      result: <ShadowRooted>{component}</ShadowRooted>,
       source: reactElementToJSXString(component, {
         showDefaultProps: false,
         useFragmentShortSyntax: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Time to time website styles break code examples. I have put every code example inside of shadow root to isolate them.

## How has this been tested?

To test that isolation works I have added `* { color: red !important; }` to `website/docs/.vitepress/theme/style.css`. It changed color of both examples and everything else before change. After making change examples were the only things that wasn't red.

To test that nothing else broken I've just navigated over few pages – seems that nothing were broken.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
