### PR TITLE
[popper] fixed that after closing popper with interaction `click` focus is returned to the trigger instead of special focus catch element

### DIFF
--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.15.0] - 2024-01-11
+
+### Fixed
+
+- After closing popper with interaction `click` focus is returned to the trigger instead of special focus catch element.
+
 ## [5.14.2] - 2024-01-10
 
 ### Changed

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -428,7 +428,7 @@ const useReturnFocusEl = (interaction, onKeyboardFocus, disable) => {
     keyboardFocused,
   };
 };
-const useFocusCatch = (active, popperRef) => {
+const useFocusCatch = (active, interaction, triggerRef, popperRef) => {
   const activeRef = React.useRef(active);
   activeRef.current = active;
 
@@ -457,10 +457,15 @@ const useFocusCatch = (active, popperRef) => {
       setTimeout(() => {
         if (activeRef.current) return;
         if (!isFocusInside(popperRef.current) && document.activeElement !== document.body) return;
-        setFocusCatch(true);
+
+        if (interaction === 'hover' || interaction === 'focus') {
+          setFocusCatch(true);
+        } else {
+          triggerRef.current?.focus();
+        }
       }, 1);
     };
-  }, [active]);
+  }, [active, interaction]);
 
   return {
     focusCatch,
@@ -487,7 +492,7 @@ function Trigger(props) {
     highlighted,
   } = props;
 
-  const triggerRef = React.createRef();
+  const triggerRef = React.useRef();
 
   const {
     returnFocusEl,
@@ -502,7 +507,7 @@ function Trigger(props) {
     handleFocusCatchBlur,
     handleFocusCatchRef,
     keyboardFocused: focusCatchKeyboardFocused,
-  } = useFocusCatch(active, popperRef);
+  } = useFocusCatch(active, interaction, triggerRef, popperRef);
 
   const enforceKeyboardFocused = returnElKeyboardFocused || focusCatchKeyboardFocused;
 


### PR DESCRIPTION
## Motivation and Context

We have focus catch element that catches focus after closing popper. It's placed right next to the trigger and works like a charm for for `interaction=hover` и `interaction=focus` but extremely weird for `interaction=click`. 

After returning focus it looks like trigger is focused but keyboard pressing doesn't work. 

Also I found issue with `triggerRef` – instead of `useRef` it was using `createRef` that has no sense in functional components.

## How has this been tested?

Manual testing showed that everything works good.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
