### PR TITLE
[dropdown-menu] fixed pressing `ArrowUp`/`ArrowDown` on closed  trigger was causing error in console

### DIFF
--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.16.3] - 2024-01-10
+
+### Fixed
+
+- Pressing `ArrowUp`/`ArrowDown` on closed `DropdownMenu` trigger was causing error in console.
+
 ## [4.16.2] - 2024-01-10
 
 ### Changed

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -75,12 +75,12 @@ class DropdownMenuRoot extends Component {
     switch (e.key) {
       case 'ArrowDown': {
         isVisible && this.moveHighlightedIndex(amount, e);
-        (targetTagName === 'BUTTON' || targetTagName === 'A') && element.focus();
+        (targetTagName === 'BUTTON' || targetTagName === 'A') && element?.focus();
         break;
       }
       case 'ArrowUp': {
         isVisible && this.moveHighlightedIndex(-amount, e);
-        (targetTagName === 'BUTTON' || targetTagName === 'A') && element.focus();
+        (targetTagName === 'BUTTON' || targetTagName === 'A') && element?.focus();
         break;
       }
       case ' ':


### PR DESCRIPTION
## Motivation and Context

When popper is closed and not mounted, the updated code was trying to focus it. I have added optional chaining to fix it.

## How has this been tested?

No new tests needed. In manual testing the error is gone.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
