### PR TITLE
[global] New release

### DIFF
--- a/.github/workflows/publish-unlocked-release.yml
+++ b/.github/workflows/publish-unlocked-release.yml
@@ -1,7 +1,7 @@
 name: publish-unlocked-release
 on:
   push:
-    branches: [master, test-release]
+    branches: [master]
     paths: .ci/.unlocked-releases.txt
   workflow_dispatch:
 concurrency:
@@ -76,6 +76,7 @@ jobs:
       - uses: actions/checkout@v3.5.3
         with:
           token: ${{ secrets.BOT_ACCOUNT_GITHUB_TOKEN }}
+          fetch-depth: 10
       - uses: pnpm/action-setup@v2.2.4
         name: Install pnpm
         id: pnpm-install

--- a/.github/workflows/publish-unlocked-release.yml
+++ b/.github/workflows/publish-unlocked-release.yml
@@ -1,7 +1,7 @@
 name: publish-unlocked-release
 on:
   push:
-    branches: [master]
+    branches: [master, test-release]
     paths: .ci/.unlocked-releases.txt
   workflow_dispatch:
 concurrency:

--- a/tools/continuous-delivery/src/intg-release/publishPreRelease.ts
+++ b/tools/continuous-delivery/src/intg-release/publishPreRelease.ts
@@ -37,7 +37,7 @@ const publishPreRelease = async () => {
   fs.writeJsonSync(packageJsonFilePath, packageJson, { spaces: 2 });
 
   // 5) Publish package
-  await publishTarball(packageJson.name, dirname);
+  await publishTarball(packageJson.name, dirname, true);
 };
 
 export { publishPreRelease };

--- a/tools/continuous-delivery/src/intg-release/publishRelease.ts
+++ b/tools/continuous-delivery/src/intg-release/publishRelease.ts
@@ -41,15 +41,7 @@ const publishRelease = async () => {
 
   // 4) Get prerelease tarball
   const logs = await git.log({ maxCount: 10 });
-
-  // biome-ignore lint/suspicious/noConsoleLog:
-  console.log(logs);
-
   const filteredLogs = logs.all.filter((item) => item.author_name !== 'semrush-ci-whale');
-
-  // biome-ignore lint/suspicious/noConsoleLog:
-  console.log(logs.all);
-
   const hash = filteredLogs[0].hash;
   const shortHash = hash.slice(0, 8);
 

--- a/tools/continuous-delivery/src/intg-release/publishRelease.ts
+++ b/tools/continuous-delivery/src/intg-release/publishRelease.ts
@@ -42,6 +42,10 @@ const publishRelease = async () => {
   // 4) Get prerelease tarball
   const logs = await git.log({ maxCount: 10 });
   const filteredLogs = logs.all.filter((item) => item.author_name !== 'semrush-ci-whale');
+
+  // biome-ignore lint/suspicious/noConsoleLog:
+  console.log(logs.all);
+
   const hash = filteredLogs[0].hash;
   const shortHash = hash.slice(0, 8);
 

--- a/tools/continuous-delivery/src/intg-release/publishRelease.ts
+++ b/tools/continuous-delivery/src/intg-release/publishRelease.ts
@@ -41,6 +41,10 @@ const publishRelease = async () => {
 
   // 4) Get prerelease tarball
   const logs = await git.log({ maxCount: 10 });
+
+  // biome-ignore lint/suspicious/noConsoleLog:
+  console.log(logs);
+
   const filteredLogs = logs.all.filter((item) => item.author_name !== 'semrush-ci-whale');
 
   // biome-ignore lint/suspicious/noConsoleLog:

--- a/tools/continuous-delivery/src/intg-release/publishTarball.ts
+++ b/tools/continuous-delivery/src/intg-release/publishTarball.ts
@@ -1,14 +1,12 @@
 import { log } from '../utils';
 import { execSync } from 'child_process';
 
-export const publishTarball = async (name: string, dirname: string) => {
+export const publishTarball = async (name: string, dirname: string, prerelease?: boolean) => {
   log('Publishing package...');
 
   let pnpmOptions = process.argv.includes('--dry-run')
     ? '--dry-run --no-git-checks'
     : '--no-git-checks';
-
-  const prerelease = name.includes('prerelease');
 
   if (prerelease) {
     pnpmOptions += ' --tag beta';


### PR DESCRIPTION
We need to have a history of commits, for find correct one for publish, so, I've added `fetch-depth` to `checkout` step.

And I've fixed publish prereleases with `beta` tag.