### PR TITLE
[icon] fixed typings

### DIFF
--- a/semcore/icon/CHANGELOG.md
+++ b/semcore/icon/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.20.2] - 2024-01-15
+
+### Fixed
+
+- Icon typings was containing `{ [key: string]: unknown; }`.
+
 ## [4.20.1] - 2024-01-10
 
 ### Changed

--- a/tools/icon-transform-svg/__tests__/__fixtures__/color/circle/m/index.d.ts
+++ b/tools/icon-transform-svg/__tests__/__fixtures__/color/circle/m/index.d.ts
@@ -1,5 +1,5 @@
 import React from 'react';
 import { Merge } from '@semcore/core';
-import { IIconProps } from '@semcore/icon';
-declare const _default: import("@semcore/core").ComponentType<Merge<IIconProps, React.SVGAttributes<SVGElement>>, {}, {}>;
+import { IconProps } from '@semcore/icon';
+declare const _default: import("@semcore/core").ComponentType<Merge<IconProps, React.SVGAttributes<SVGElement>>, {}, {}>;
 export default _default;

--- a/tools/icon-transform-svg/__tests__/__fixtures__/color/circleNew/m/index.d.ts
+++ b/tools/icon-transform-svg/__tests__/__fixtures__/color/circleNew/m/index.d.ts
@@ -1,5 +1,5 @@
 import React from 'react';
 import { Merge } from '@semcore/core';
-import { IIconProps } from '@semcore/icon';
-declare const _default: import("@semcore/core").ComponentType<Merge<IIconProps, React.SVGAttributes<SVGElement>>, {}, {}>;
+import { IconProps } from '@semcore/icon';
+declare const _default: import("@semcore/core").ComponentType<Merge<IconProps, React.SVGAttributes<SVGElement>>, {}, {}>;
 export default _default;

--- a/tools/icon-transform-svg/__tests__/__fixtures__/external/mixNewl/index.d.ts
+++ b/tools/icon-transform-svg/__tests__/__fixtures__/external/mixNewl/index.d.ts
@@ -1,5 +1,5 @@
 import React from 'react';
 import { Merge } from '@semcore/core';
-import { IIconProps } from '@semcore/icon';
-declare const _default: import("@semcore/core").ComponentType<Merge<IIconProps, React.SVGAttributes<SVGElement>>, {}, {}>;
+import { IconProps } from '@semcore/icon';
+declare const _default: import("@semcore/core").ComponentType<Merge<IconProps, React.SVGAttributes<SVGElement>>, {}, {}>;
 export default _default;

--- a/tools/icon-transform-svg/__tests__/__fixtures__/external/mixl/index.d.ts
+++ b/tools/icon-transform-svg/__tests__/__fixtures__/external/mixl/index.d.ts
@@ -1,5 +1,5 @@
 import React from 'react';
 import { Merge } from '@semcore/core';
-import { IIconProps } from '@semcore/icon';
-declare const _default: import("@semcore/core").ComponentType<Merge<IIconProps, React.SVGAttributes<SVGElement>>, {}, {}>;
+import { IconProps } from '@semcore/icon';
+declare const _default: import("@semcore/core").ComponentType<Merge<IconProps, React.SVGAttributes<SVGElement>>, {}, {}>;
 export default _default;

--- a/tools/icon-transform-svg/__tests__/__fixtures__/path/m/index.d.ts
+++ b/tools/icon-transform-svg/__tests__/__fixtures__/path/m/index.d.ts
@@ -1,5 +1,5 @@
 import React from 'react';
 import { Merge } from '@semcore/core';
-import { IIconProps } from '@semcore/icon';
-declare const _default: import("@semcore/core").ComponentType<Merge<IIconProps, React.SVGAttributes<SVGElement>>, {}, {}>;
+import { IconProps } from '@semcore/icon';
+declare const _default: import("@semcore/core").ComponentType<Merge<IconProps, React.SVGAttributes<SVGElement>>, {}, {}>;
 export default _default;

--- a/tools/icon-transform-svg/__tests__/__fixtures__/pathNew/m/index.d.ts
+++ b/tools/icon-transform-svg/__tests__/__fixtures__/pathNew/m/index.d.ts
@@ -1,5 +1,5 @@
 import React from 'react';
 import { Merge } from '@semcore/core';
-import { IIconProps } from '@semcore/icon';
-declare const _default: import("@semcore/core").ComponentType<Merge<IIconProps, React.SVGAttributes<SVGElement>>, {}, {}>;
+import { IconProps } from '@semcore/icon';
+declare const _default: import("@semcore/core").ComponentType<Merge<IconProps, React.SVGAttributes<SVGElement>>, {}, {}>;
 export default _default;

--- a/tools/icon-transform-svg/__tests__/__fixtures__/pay/polygon/index.d.ts
+++ b/tools/icon-transform-svg/__tests__/__fixtures__/pay/polygon/index.d.ts
@@ -1,5 +1,5 @@
 import React from 'react';
 import { Merge } from '@semcore/core';
-import { IIconProps } from '@semcore/icon';
-declare const _default: import("@semcore/core").ComponentType<Merge<IIconProps, React.SVGAttributes<SVGElement>>, {}, {}>;
+import { IconProps } from '@semcore/icon';
+declare const _default: import("@semcore/core").ComponentType<Merge<IconProps, React.SVGAttributes<SVGElement>>, {}, {}>;
 export default _default;

--- a/tools/icon-transform-svg/__tests__/__fixtures__/pay/polygonNew/l/index.d.ts
+++ b/tools/icon-transform-svg/__tests__/__fixtures__/pay/polygonNew/l/index.d.ts
@@ -1,5 +1,5 @@
 import React from 'react';
 import { Merge } from '@semcore/core';
-import { IIconProps } from '@semcore/icon';
-declare const _default: import("@semcore/core").ComponentType<Merge<IIconProps, React.SVGAttributes<SVGElement>>, {}, {}>;
+import { IconProps } from '@semcore/icon';
+declare const _default: import("@semcore/core").ComponentType<Merge<IconProps, React.SVGAttributes<SVGElement>>, {}, {}>;
 export default _default;

--- a/tools/icon-transform-svg/config.js
+++ b/tools/icon-transform-svg/config.js
@@ -64,8 +64,8 @@ export default createBaseComponent(${obj.name})
       `,
     templateDTS: () => `
 import React from 'react';
-import { IIconProps } from '@semcore/icon';
-declare const _default: <T>(props: IIconProps & T) => React.ReactElement;
+import { IconProps } from '@semcore/icon';
+declare const _default: <T>(props: IconProps & T) => React.ReactElement;
 export default _default;
       `,
     transformer: () => {

--- a/website/docs/components/accordion/accordion-api.md
+++ b/website/docs/components/accordion/accordion-api.md
@@ -31,7 +31,7 @@ import { Accordion } from '@semcore/ui/accordion';
 <Accordion.Item.Toggle />;
 ```
 
-Has all properties as [IBoxProps](/layout/box-system/box-api) prop does.
+Has all properties as [BoxProps](/layout/box-system/box-api) prop does.
 
 ## Accordion.Item.Collapse
 
@@ -43,7 +43,7 @@ import { Accordion } from '@semcore/ui/accordion';
 
 <TypesView type="CollapseProps" :types={...types} />
 
-Has all properties as [IBoxProps](/layout/box-system/box-api) prop does.
+Has all properties as [BoxProps](/layout/box-system/box-api) prop does.
 
 ## Accordion.Item.Chevron
 
@@ -53,6 +53,6 @@ import { Accordion } from '@semcore/ui/accordion';
 <Accordion.Item.Chevron />;
 ```
 
-Has all properties as [IBoxProps](/layout/box-system/box-api) prop does.
+Has all properties as [BoxProps](/layout/box-system/box-api) prop does.
 
 <script setup>import { data as types } from '@types.data.ts';</script>

--- a/website/docs/components/modal/modal-api.md
+++ b/website/docs/components/modal/modal-api.md
@@ -15,7 +15,7 @@ import Modal from '@semcore/ui/modal';
 
 ## Modal.Overlay
 
-Component which represents the background. Has all properties as [IBoxProps](/layout/box-system/box-api) prop does.
+Component which represents the background. Has all properties as [BoxProps](/layout/box-system/box-api) prop does.
 
 ```jsx
 import Modal from '@semcore/ui/modal';
@@ -24,7 +24,7 @@ import Modal from '@semcore/ui/modal';
 
 ## Modal.Window
 
-Component which represents the modal window itself. Has all properties as [IBoxProps](/layout/box-system/box-api) prop does.
+Component which represents the modal window itself. Has all properties as [BoxProps](/layout/box-system/box-api) prop does.
 
 ```jsx
 import Modal from '@semcore/ui/modal';
@@ -33,7 +33,7 @@ import Modal from '@semcore/ui/modal';
 
 ## Modal.Close
 
-Component which represents the closing icon. The component is the `CloseS` icon with the configured styles. Has all properties as [IBoxProps](/layout/box-system/box-api) prop and [IIconProps](/style/icon/icon-api) prop does.
+Component which represents the closing icon. The component is the `CloseS` icon with the configured styles. Has all properties as [BoxProps](/layout/box-system/box-api) prop and [IconProps](/style/icon/icon-api) prop does.
 
 ```jsx
 import Modal from '@semcore/ui/modal';
@@ -42,7 +42,7 @@ import Modal from '@semcore/ui/modal';
 
 ## Modal.Title
 
-Component which represents the title. It adds `aria-labelledby` attribute to modal window. Has all properties as [ITextProps](/style/typography/typography-api) prop does.
+Component which represents the title. It adds `aria-labelledby` attribute to modal window. Has all properties as [TextProps](/style/typography/typography-api) prop does.
 
 ```jsx
 import Modal from '@semcore/ui/modal';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Icons typings are controlled by `icon-transform-svg` component. So during major typings update it was forgot to be updated. It's why `IIconProps` was used in component typings instead of `IconProps`.

Also I have updated all use of `I*Props` in docs

## How has this been tested?

All existing tests should pass

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
