### PR TITLE
[input-tags] removed `role=list` and `role=listitem` from tags container and tags as it was misleading screen readers and other assistive technologies

### DIFF
--- a/semcore/input-tags/CHANGELOG.md
+++ b/semcore/input-tags/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.17.0] - 2024-01-15
+
+### Fixed
+
+- Removed `role="list"` and `role="listitem"` from tags container and tags as it was misleading screen readers and other assistive technologies.
+
 ## [4.16.1] - 2024-01-10
 
 ### Changed

--- a/semcore/input-tags/src/InputTags.tsx
+++ b/semcore/input-tags/src/InputTags.tsx
@@ -187,7 +187,7 @@ class InputTags extends Component<IInputTagsProps> {
         onFocus={this.handleContainerFocus}
         container={this.scrollContainerRef}
       >
-        <SListAriaWrapper role='list'>
+        <SListAriaWrapper>
           <Children />
         </SListAriaWrapper>
       </SInputTags>,
@@ -245,7 +245,7 @@ class Value extends Component<IInputTagsValueProps> {
     return sstyled(this.asProps.styles)(
       <>
         <SValue render={Input.Value} style={{ width: this.state.width }} />
-        <SSpacer ref={this._spacer} role='none' />
+        <SSpacer ref={this._spacer} aria-hidden />
       </>,
     );
   }
@@ -263,7 +263,7 @@ function InputTag(props: any) {
   };
 
   return sstyled(props.styles)(
-    <STag data-value={props.value} render={Tag} role='listitem' onKeyDown={onKeyDown} />,
+    <STag data-value={props.value} render={Tag} onKeyDown={onKeyDown} />,
   );
 }
 


### PR DESCRIPTION
## Motivation and Context

Long time ago we have added  `role=list` and `role=listitem`  to input tags container and tags. 

It doesn't improve component a11y (VO doesn't describe it as list) and created new a11y issues because forced us to handle edge cases such inputs that are restricted in lists.

## How has this been tested?

I have tested it with Voice over in Safari. It's output became more informative (reading count of tags after reading first tag content). 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
