### PR TITLE
[d3-chart] fixed method for find next focusable element

### DIFF
--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Fixed
 
-- method for find next focusable element after chart plot.
+- Selection of next focusable element after chart plot.
 
 ## [3.23.0] - 2024-01-12
 

--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.23.1] - 2024-01-16
+
+### Fixed
+
+- method for find next focusable element after chart plot.
+
 ## [3.23.0] - 2024-01-12
 
 ### Changed

--- a/semcore/d3-chart/__tests__/index.test.tsx
+++ b/semcore/d3-chart/__tests__/index.test.tsx
@@ -2133,6 +2133,8 @@ describe('ChartLegend', () => {
 });
 
 describe('d3 charts visual regression', () => {
+  beforeEach(cleanup);
+
   test.concurrent('should render axis-grid', async ({ task }) => {
     const data = Array(20)
       .fill({})
@@ -2494,8 +2496,9 @@ describe('d3 charts visual regression', () => {
         x: i,
         y: Math.abs(Math.sin(Math.exp(i))) * 10,
       }));
+    const hints = makeDataHintsContainer();
 
-    const Component: React.FC = () => {
+    const PlotComponent: React.FC = () => {
       const plotRef = React.useRef<HTMLDivElement>(null);
 
       return (
@@ -2508,7 +2511,7 @@ describe('d3 charts visual regression', () => {
               plotLabel={'plot label'}
               locale={'en'}
               config={{}}
-              hints={makeDataHintsContainer()}
+              hints={hints}
             />
           </div>
           <div className={'one'}>
@@ -2526,7 +2529,7 @@ describe('d3 charts visual regression', () => {
       );
     };
 
-    const { getByTestId } = render(<Component />);
+    const { getByTestId } = render(<PlotComponent />);
 
     await userEvent.keyboard('[Tab]');
     await userEvent.keyboard('[Tab]');

--- a/semcore/d3-chart/__tests__/index.test.tsx
+++ b/semcore/d3-chart/__tests__/index.test.tsx
@@ -2496,7 +2496,7 @@ describe('d3 charts visual regression', () => {
       }));
 
     const Component: React.FC = () => {
-      const plotRef = React.useRef<Element>(null);
+      const plotRef = React.useRef<HTMLDivElement>(null);
 
       return (
         <>

--- a/semcore/d3-chart/__tests__/index.test.tsx
+++ b/semcore/d3-chart/__tests__/index.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { snapshot } from '@semcore/testing-utils/snapshot';
 import * as sharedTests from '@semcore/testing-utils/shared-tests';
 import { expect, test, describe, beforeEach, vi } from '@semcore/testing-utils/vitest';
-import { render, fireEvent, cleanup } from '@semcore/testing-utils/testing-library';
+import { render, fireEvent, cleanup, userEvent } from '@semcore/testing-utils/testing-library';
 const { shouldSupportClassName, shouldSupportRef } = sharedTests;
 
 import { scaleLinear, scaleBand } from 'd3-scale';
@@ -30,9 +30,11 @@ import {
   Radar,
   ChartLegend,
   ChartLegendTable,
+  makeDataHintsContainer,
   // @ts-ignore
 } from '../src';
 import { getIndexFromData } from '../src/utils';
+import { PlotA11yView } from '../src/a11y/PlotA11yView';
 
 import { curveCardinal } from 'd3-shape';
 import { Flex, Box } from '@semcore/flex-box';
@@ -2483,5 +2485,53 @@ describe('d3 charts visual regression', () => {
     };
 
     await expect(await snapshot(<Component />)).toMatchImageSnapshot(task);
+  });
+
+  test.concurrent('should correctly select next focusable element', async ({ expect }) => {
+    const data = Array(20)
+      .fill({})
+      .map((d, i) => ({
+        x: i,
+        y: Math.abs(Math.sin(Math.exp(i))) * 10,
+      }));
+
+    const Component: React.FC = () => {
+      const plotRef = React.useRef<Element>(null);
+
+      return (
+        <>
+          <div ref={plotRef}>
+            <PlotA11yView
+              id={'plotView'}
+              data={data}
+              plotRef={plotRef}
+              plotLabel={'plot label'}
+              locale={'en'}
+              config={{}}
+              hints={makeDataHintsContainer()}
+            />
+          </div>
+          <div className={'one'}>
+            <div className={'two'}>
+              <div className={'tree'}>some text</div>
+            </div>
+          </div>
+          <div>some data</div>
+          <div className={'one'}>
+            <div className={'two'} tabIndex={0} data-testid={'focusableElement'}>
+              <div className={'tree'}>some text 2</div>
+            </div>
+          </div>
+        </>
+      );
+    };
+
+    const { getByTestId } = render(<Component />);
+
+    await userEvent.keyboard('[Tab]');
+    await userEvent.keyboard('[Tab]');
+    await userEvent.keyboard('[Enter]');
+
+    expect(getByTestId('focusableElement')).toHaveFocus();
   });
 });

--- a/semcore/d3-chart/src/a11y/focus.ts
+++ b/semcore/d3-chart/src/a11y/focus.ts
@@ -14,6 +14,26 @@ const isFocusable = (element: Element) => {
 
 type FocusableElement = Element & { focus: () => void };
 
+const findNextFocusableElementInChildren = (element: Element | null): FocusableElement | null => {
+  const children = element?.children;
+
+  if (element && isFocusable(element)) {
+    return element as FocusableElement;
+  }
+
+  if (children) {
+    for (let i = 0; i < children.length; i++) {
+      const childChild = children.item(i);
+
+      if (childChild) {
+        return findNextFocusableElementInChildren(childChild);
+      }
+    }
+  }
+
+  return null;
+};
+
 export const heavyFindNextFocusableElement = (
   base: Element,
   trace: Map<Element, true> = new Map(),
@@ -27,13 +47,13 @@ export const heavyFindNextFocusableElement = (
       if (!child) continue;
       if (trace.has(child)) continue;
       if (isFocusable(child)) return child as FocusableElement;
-      const childInnerResult = heavyFindNextFocusableElement(child, trace);
+      const childInnerResult = findNextFocusableElementInChildren(child.children.item(0));
       if (childInnerResult) return childInnerResult;
     }
     while (sibling) {
       if (isFocusable(sibling)) return sibling as FocusableElement;
       if (!trace.has(sibling)) {
-        const siblingInnerResult = heavyFindNextFocusableElement(sibling, trace);
+        const siblingInnerResult = findNextFocusableElementInChildren(sibling.children.item(0));
         if (siblingInnerResult) return siblingInnerResult;
       }
       sibling = sibling.nextElementSibling;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
current realisation of method doesn't try to find focusable elements in children recursively, I've fixed it.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [x] I have added new unit tests on added of fixed functionality.
