### PR TITLE
[outside-click, utils] fixed outside clicks handling in shadow dom

### DIFF
--- a/semcore/outside-click/CHANGELOG.md
+++ b/semcore/outside-click/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.15.0] - 2024-01-19
+
+### Fixed
+
+- Clicks were always considered as outside in Shadow DOM.
+
 ## [3.14.0] - 2024-01-19
 
 ### Changed

--- a/semcore/outside-click/src/OutsideClick.tsx
+++ b/semcore/outside-click/src/OutsideClick.tsx
@@ -31,15 +31,17 @@ const noop = () => {};
 function OutsideClick(props: IFunctionProps<IOutsideClickProps>) {
   const { Children, forwardRef, root, excludeRefs = [], onOutsideClick = noop } = props;
   const children = getOriginChildren(Children);
-  const nodeRef = React.useRef(null);
-  const targetRef = React.useRef(null);
+  const nodeRef = React.useRef<Node | null>(null);
+  const targetRef = React.useRef<Node | null>(null);
 
   const handleRef = useForkRef(children ? children.ref : null, nodeRef, forwardRef!);
 
   const handleOutsideClick = useEventCallback((event: any) => {
     const isTargetEvent = [...(excludeRefs as any), nodeRef]
       .filter((node) => getNodeByRef(node))
-      .some((node) => getNodeByRef(node)?.contains(targetRef.current || getEventTarget(event)));
+      .some((node) =>
+        getNodeByRef(node)?.contains(targetRef.current || (getEventTarget(event) as Node | null)),
+      );
 
     if (!isTargetEvent) {
       onOutsideClick?.(event);
@@ -47,7 +49,7 @@ function OutsideClick(props: IFunctionProps<IOutsideClickProps>) {
   });
 
   const handleMouseDown = useEventCallback((event: any) => {
-    targetRef.current = getEventTarget(event);
+    targetRef.current = getEventTarget(event) as Node | null;
   });
 
   React.useEffect(() => {

--- a/semcore/outside-click/src/OutsideClick.tsx
+++ b/semcore/outside-click/src/OutsideClick.tsx
@@ -4,6 +4,7 @@ import { getNodeByRef, NodeByRef, useForkRef } from '@semcore/utils/lib/ref';
 import ownerDocument from '@semcore/utils/lib/ownerDocument';
 import useEventCallback from '@semcore/utils/lib/use/useEventCallback';
 import getOriginChildren from '@semcore/utils/lib/getOriginChildren';
+import { getEventTarget } from '@semcore/utils/lib/getEventTarget';
 
 /** @deprecated */
 export interface IOutsideClickProps extends OutsideClickProps, UnknownProperties {}
@@ -38,7 +39,7 @@ function OutsideClick(props: IFunctionProps<IOutsideClickProps>) {
   const handleOutsideClick = useEventCallback((event: any) => {
     const isTargetEvent = [...(excludeRefs as any), nodeRef]
       .filter((node) => getNodeByRef(node))
-      .some((node) => getNodeByRef(node)?.contains(targetRef.current || event.target));
+      .some((node) => getNodeByRef(node)?.contains(targetRef.current || getEventTarget(event)));
 
     if (!isTargetEvent) {
       onOutsideClick?.(event);
@@ -46,7 +47,7 @@ function OutsideClick(props: IFunctionProps<IOutsideClickProps>) {
   });
 
   const handleMouseDown = useEventCallback((event: any) => {
-    targetRef.current = event.target;
+    targetRef.current = getEventTarget(event);
   });
 
   React.useEffect(() => {

--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.18.0] - 2024-01-19
+
+### Added
+
+- Internal utility to handle DOM events inside of Shadow DOM.
+
 ## [4.17.0] - 2024-01-19
 
 ### Changed

--- a/semcore/utils/src/getEventTarget.ts
+++ b/semcore/utils/src/getEventTarget.ts
@@ -1,0 +1,11 @@
+export const getEventTarget = (event: React.SyntheticEvent | Event): EventTarget | null => {
+  if ('composedPath' in event) {
+    return event.composedPath()?.[0] || event.target;
+  }
+  if (event.nativeEvent) {
+    if ('composedPath' in event.nativeEvent) {
+      return event.nativeEvent.composedPath()?.[0] || event.target;
+    }
+  }
+  return event.target;
+};

--- a/semcore/utils/src/getEventTarget.ts
+++ b/semcore/utils/src/getEventTarget.ts
@@ -2,10 +2,8 @@ export const getEventTarget = (event: React.SyntheticEvent | Event): EventTarget
   if ('composedPath' in event) {
     return event.composedPath()?.[0] || event.target;
   }
-  if (event.nativeEvent) {
-    if ('composedPath' in event.nativeEvent) {
-      return event.nativeEvent.composedPath()?.[0] || event.target;
-    }
+  if (event.nativeEvent && 'composedPath' in event.nativeEvent) {
+    return event.nativeEvent.composedPath()?.[0] || event.target;
   }
   return event.target;
 };

--- a/website/docs/utils/popper/popper.md
+++ b/website/docs/utils/popper/popper.md
@@ -19,7 +19,7 @@ import React from 'react';
 import Popper from '@semcore/ui/popper';
 import { Flex } from '@semcore/ui/flex-box';
 
-const style = { background: '#FFF', border: '1px solid black', padding: '10px' };
+const style = { background: '#FFF', color: '#000', border: '1px solid #000', padding: '10px' };
 
 const Demo = () => {
   const [visible, setVisible] = React.useState(false);
@@ -60,7 +60,7 @@ When these events are activated, the `onVisibleChange` handler is called with th
 import React from 'react';
 import Popper from '@semcore/ui/popper';
 
-const style = { background: '#FFF', border: '1px solid black', padding: '20px' };
+const style = { background: '#FFF', color: '#000', border: '1px solid #000', padding: '10px' };
 
 const Demo = () => (
   <Popper interaction='hover'>
@@ -86,7 +86,7 @@ You can subscribe to the `onOutsideClick` event. It will be called when a clicke
 import React from 'react';
 import Popper from '@semcore/ui/popper';
 
-const style = { background: '#FFF', border: '1px solid black', padding: '20px' };
+const style = { background: '#FFF', color: '#000', border: '1px solid #000', padding: '10px' };
 
 const Demo = () => (
   <Popper
@@ -117,7 +117,7 @@ import { Box } from '@semcore/ui/flex-box';
 import Popper from '@semcore/ui/popper';
 import Button from '@semcore/ui/button';
 
-const style = { background: '#FFF', border: '1px solid black', padding: '20px' };
+const style = { background: '#FFF', color: '#000', border: '1px solid #000', padding: '10px' };
 
 const styleBox = {
   display: 'grid',
@@ -232,7 +232,7 @@ import Popper from '@semcore/ui/popper';
 import Button from '@semcore/ui/button';
 import HamburgerM from '@semcore/ui/icon/Hamburger/m';
 
-const style = { background: '#FFF', border: '1px solid black', padding: '20px' };
+const style = { background: '#FFF', color: '#000', border: '1px solid #000', padding: '10px' };
 
 const Demo = () => (
   <Popper>
@@ -264,7 +264,7 @@ Inside the function, the first argument provides the component props and the `ge
 import React from 'react';
 import Popper from '@semcore/ui/popper';
 
-const style = { background: '#FFF', border: '1px solid black', padding: '20px' };
+const style = { background: '#FFF', color: '#000', border: '1px solid #000', padding: '10px' };
 
 const Demo = () => (
   <Popper interaction='focus'>
@@ -291,7 +291,7 @@ import React from 'react';
 import Button from '@semcore/ui/button';
 import Popper from '@semcore/ui/popper';
 
-const style = { background: '#FFF', border: '1px solid black', padding: '20px' };
+const style = { background: '#FFF', color: '#000', border: '1px solid #000', padding: '10px' };
 
 const Demo = () => (
   <Popper>
@@ -335,7 +335,7 @@ import React from 'react';
 import Popper from '@semcore/ui/popper';
 import Button from '@semcore/ui/button';
 
-const style = { background: '#FFF', border: '1px solid black', padding: '20px' };
+const style = { background: '#FFF', color: '#000', border: '1px solid #000', padding: '10px' };
 
 const Demo = () => (
   <>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context


We recently moved all website examples into Shadow DON while all components was never tested to work in Shadow DOM. It was found that https://developer.semrush.com/intergalactic/utils/popper/popper render function examples closes immediately after opening. 

The example was broken because OutsideClick tries to get what element is clicked and in case of using shadow dom elements it's the shadow dom container – the whole playground. So, for outside click component every click was the outside one.

## How has this been tested?

The change is extremely simple – I've just made it to support shadow DOM with full backward capability. 
So I think we do not need shadow DOM tests for now. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
