### PR TITLE
[utils, popper, tooltip] added Popper focusLoop api

### DIFF
--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.18.0] - 2024-01-25
+
+### Added
+
+- `focusLoop` (`true` by default) prop that enabled focus loop inside of the popper. When disabled the focus goes through the popper to the next element after the trigger.
+
 ## [5.17.0] - 2024-01-19
 
 ### Changed

--- a/semcore/popper/src/index.d.ts
+++ b/semcore/popper/src/index.d.ts
@@ -82,6 +82,11 @@ export type PopperProps = OutsideClickProps &
      * Disabled focus trap, autofocus and focus return
      */
     disableEnforceFocus?: boolean;
+    /**
+     * Loops focus inside the popper, when disabled the focus goes through the popper to the next element after the trigger.
+     * @default true
+     */
+    focusLoop?: boolean;
   };
 
 /** @deprecated */

--- a/semcore/tooltip/CHANGELOG.md
+++ b/semcore/tooltip/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [6.17.0] - 2024-01-19
+
+### Changed
+
+- Tooltip focus looping is disabled by default.
+
 ## [6.16.0] - 2024-01-19
 
 ### Changed

--- a/semcore/tooltip/__tests__/tooltip.browser-test.tsx
+++ b/semcore/tooltip/__tests__/tooltip.browser-test.tsx
@@ -8,7 +8,7 @@ test.describe('Tooltip', () => {
 
     await page.setContent(htmlContent);
 
-    const trigger = await page.locator('text=Trigger');
+    const trigger = await page.locator('article:has-text("Trigger');
     const triggerRect = (await trigger.boundingBox())!;
 
     await page.mouse.move(
@@ -32,5 +32,40 @@ test.describe('Tooltip', () => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     await expect(page).toHaveScreenshot();
+  });
+
+  test.only('Passes focus through', async ({ page }) => {
+    const standPath = 'website/docs/components/tooltip/examples/with_focusable_elements.tsx';
+    const htmlContent = await e2eStandToHtml(standPath, 'en');
+
+    await page.setContent(htmlContent);
+
+    await page.keyboard.press('Tab');
+
+    const linkBefore = await page.locator('a:has-text("Normal link before tooltip")');
+
+    await expect(linkBefore).toBeFocused();
+
+    await page.keyboard.press('Tab');
+
+    const trigger = await page.locator('a:has-text("Link with tooltip")');
+    await expect(trigger).toBeFocused();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+
+    const popperLink = await page.locator('[data-ui-name="Tooltip.Popper"] a:has-text("link")');
+    await expect(popperLink).toBeFocused();
+
+    await page.keyboard.press('Tab');
+
+    await expect(popperLink).toHaveCount(0);
+
+    await page.keyboard.press('Tab');
+
+    const linkAfter = await page.locator('a:has-text("Normal link after tooltip")');
+    await expect(linkAfter).toBeFocused();
   });
 });

--- a/semcore/tooltip/src/Tooltip.jsx
+++ b/semcore/tooltip/src/Tooltip.jsx
@@ -26,6 +26,7 @@ class TooltipRoot extends Component {
       flipVariationsByContent: true,
     },
     defaultVisible: false,
+    focusLoop: false,
   };
   state = { popperChildren: null };
 

--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.19.0] - 2024-01-25
+
+### Changed
+
+- Extended internal focus lock api for more precision control over browser focus.
+
 ## [4.18.0] - 2024-01-19
 
 ### Added

--- a/website/docs/components/tooltip/examples/with_focusable_elements.tsx
+++ b/website/docs/components/tooltip/examples/with_focusable_elements.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Tooltip from '@semcore/ui/tooltip';
+import { Box, Flex } from '@semcore/ui/flex-box';
+import Link from '@semcore/ui/link';
+
+const Demo = () => (
+  <Flex gap={10} flexWrap>
+    <Link>Normal link before tooltip</Link>
+    <Tooltip>
+      <Tooltip.Trigger>
+        <Link>Link with tooltip</Link>
+      </Tooltip.Trigger>
+      <Tooltip.Popper>
+        For more information, see the <Link href='#'>link</Link>
+      </Tooltip.Popper>
+    </Tooltip>
+    <Link>Normal link after tooltip</Link>
+  </Flex>
+);
+
+export default Demo;

--- a/website/docs/components/tooltip/tooltip-code.md
+++ b/website/docs/components/tooltip/tooltip-code.md
@@ -39,6 +39,20 @@ The code below replicates the functionality of the previous example.
 
 :::
 
+
+## With focusable elements
+
+If tooltip contains focusable elements, keyboard focus is navigated throw the popper.
+
+::: sandbox
+
+<script lang="tsx">
+  export Demo from './examples/with_focusable_elements.tsx';
+</script>
+
+:::
+
+
 ## Singleton
 
 You can use a single tooltip for multiple reference elements. This allows you to "group" tooltips with a shared timer to improve the user experience.


### PR DESCRIPTION
## Motivation and Context

There is a popular edge case with our tooltips. When tooltip contains focusable elements it locks user focus inside of tooltip popper until user presses Escape or closes tooltip with mouse.

I have added low level api to `useFocusLock` hook that allowed me to implement `focusLoop` api over the Popper component. If it's toggled to false, focus may just go through the popper to elements after the trigger.

## How has this been tested?

I have added a new browser test for that functionality 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [x] I have added new unit tests on added of fixed functionality.
