### PR TITLE
[86bx9c953][textarea] prevented changing size of textarea while calculating rows

### DIFF
--- a/semcore/textarea/CHANGELOG.md
+++ b/semcore/textarea/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.19.2] - 2024-02-07
+
+### Fixed
+
+- Prevented changing size of textarea while calculating rows.
+
 ## [5.19.1] - 2024-02-06
 
 ### Changed

--- a/semcore/textarea/src/Textarea.jsx
+++ b/semcore/textarea/src/Textarea.jsx
@@ -53,15 +53,22 @@ class Textarea extends Component {
     const { rows, minRows, maxRows } = this.asProps;
     if (!node || !canUseDOM() || rows || !(minRows || maxRows)) return;
 
-    const lh = cssToIntDefault(getComputedStyle(node).getPropertyValue('line-height'));
     const previousRows = node.rows;
+    const clonnedNode = node.cloneNode(true);
 
-    node.rows = minRows;
+    clonnedNode.style.visibility = 'hidden';
 
-    const computed = Math.floor(node.scrollHeight / lh);
+    document.body.appendChild(clonnedNode);
+
+    const lh = cssToIntDefault(getComputedStyle(clonnedNode).getPropertyValue('line-height'));
+
+    clonnedNode.rows = minRows;
+
+    const computed = Math.floor(clonnedNode.scrollHeight / lh);
+
+    document.body.removeChild(clonnedNode);
 
     if (computed === previousRows) {
-      node.rows = computed;
       return;
     }
     if (computed <= minRows) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
We've had an incorrect behaviour in `ScrollArea` with auto resizable `Textarea` inside, because in function of calculation rows in `Textarea` we've changed it size. I've cloned node for calculations.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
I've tested it in playground
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
