### PR TITLE
[86bxczer3][base-trigger] added filter trigger triggerRef prop and corresponding docs

### DIFF
--- a/semcore/base-trigger/CHANGELOG.md
+++ b/semcore/base-trigger/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.25.0] - 2024-02-07
+
+### Added
+
+- `triggerRef` prop for FilterTrigger component to access inner trigger.
+
 ## [4.24.1] - 2024-02-05
 
 ### Fixed

--- a/semcore/base-trigger/src/FilterTrigger.jsx
+++ b/semcore/base-trigger/src/FilterTrigger.jsx
@@ -39,15 +39,16 @@ class RootFilterTrigger extends Component {
     includeInputProps: inputProps,
     i18n: localizedMessages,
     locale: 'en',
+    triggerRef: React.createRef(),
+    role: 'group',
   };
-  triggerRef = React.createRef();
 
   handleStopPropagation = (e) => e.stopPropagation();
 
   handleClear = () => {
     setTimeout(() => {
       if (document.activeElement === document.body) {
-        setFocus(this.triggerRef.current);
+        setFocus(this.asProps.triggerRef.current);
       }
     }, 0);
   };
@@ -68,9 +69,9 @@ class RootFilterTrigger extends Component {
       includeInputProps,
       uid,
       id,
+      triggerRef,
+      role,
     } = this.asProps;
-
-    const role = empty ? this.asProps.role ?? 'button' : 'group';
 
     const [controlProps] = getInputProps(this.asProps, includeInputProps);
 
@@ -80,10 +81,10 @@ class RootFilterTrigger extends Component {
         aria-label={getI18nText('filter')}
         __excludeProps={['id']}
         use:role={role}
-        data-role={role}
       >
         <NeighborLocation>
           <SFilterTrigger
+            tag='button'
             w='100%'
             size={size}
             placeholder={placeholder}
@@ -91,7 +92,7 @@ class RootFilterTrigger extends Component {
             selected={!empty}
             active={active}
             disabled={disabled}
-            ref={this.triggerRef}
+            ref={triggerRef}
             animationsDisabled
             {...controlProps}
           >

--- a/semcore/base-trigger/src/index.d.ts
+++ b/semcore/base-trigger/src/index.d.ts
@@ -69,7 +69,7 @@ export type FilterTriggerProps = BaseTriggerProps & {
   /** List of props that will be added to the select inside of filter */
   includeInputProps?: string[];
   /** Normal `ref` prop refers to FilterTrigger wrapper while `triggerRef` refers explicitly to trigger button */
-  triggerRef?: React.Ref;
+  triggerRef?: React.Ref<HTMLButtonElement>;
 };
 
 declare const BaseTrigger: Intergalactic.Component<'div', BaseTriggerProps> & {

--- a/semcore/base-trigger/src/index.d.ts
+++ b/semcore/base-trigger/src/index.d.ts
@@ -68,6 +68,8 @@ export type FilterTriggerProps = BaseTriggerProps & {
   locale?: string;
   /** List of props that will be added to the select inside of filter */
   includeInputProps?: string[];
+  /** Normal `ref` prop refers to FilterTrigger wrapper while `triggerRef` refers explicitly to trigger button */
+  triggerRef?: React.Ref;
 };
 
 declare const BaseTrigger: Intergalactic.Component<'div', BaseTriggerProps> & {

--- a/website/docs/components/filter-trigger/examples/programmatic_focus.tsx
+++ b/website/docs/components/filter-trigger/examples/programmatic_focus.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { FilterTrigger } from '@semcore/ui/base-trigger';
+import Select from '@semcore/ui/select';
+import { Text } from '@semcore/ui/typography';
+import { Box } from '@semcore/ui/flex-box';
+import Button from '@semcore/ui/button';
+
+const options = Array(6)
+  .fill(0)
+  .map((i, idx) => ({
+    title: `Option ${idx}`,
+  }));
+
+const Demo = () => {
+  const triggerRef = React.useRef<HTMLButtonElement>();
+  const [selectVisible, setSelectVisible] = React.useState(false);
+  const focusTrigger = React.useCallback(() => {
+    triggerRef.current?.focus();
+    setSelectVisible(true);
+  }, []);
+
+  return (
+    <>
+      <Text tag='label' htmlFor='another-filter-trigger' size={300}>
+        Filter trigger with options
+      </Text>
+      <Box mt={2}>
+        <Select visible={selectVisible} onVisibleChange={setSelectVisible}>
+          <Select.Trigger tag={FilterTrigger} triggerRef={triggerRef} id='another-filter-trigger' />
+          <Select.Menu>
+            {options.map((option, idx) => {
+              const { title } = option;
+              return (
+                <Select.Option value={title} key={idx}>
+                  {title}
+                </Select.Option>
+              );
+            })}
+          </Select.Menu>
+        </Select>
+      </Box>
+      <Button mt={4} onClick={focusTrigger}>
+        Focus on filter trigger
+      </Button>
+    </>
+  );
+};
+
+export default Demo;

--- a/website/docs/components/filter-trigger/filter-trigger-a11y.md
+++ b/website/docs/components/filter-trigger/filter-trigger-a11y.md
@@ -16,9 +16,8 @@ The list below describes roles and attributes that component already has.
 
 | Role     | Attribute    | Element             | Usage                                                                                                             |
 | -------- | ------------ | ------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `button` |              | `button` | Identifies the element as a button. Accessible name for the button is defined by the text content of the element. |
-| `group` |              | `div` | Identifies the `div` element as a group container for the buttons.                                                |
-|          | `aria-label` | `div` , `button` | The `aria-label` attribute defines a string value that labels an interactive element.                             |
+| `group`  |              | `div`               | Identifies the `div` element as a group container for the buttons.                                                |
+|          | `aria-label` | `div` , `button`    | The `aria-label` attribute defines a string value that labels an interactive element.                             |
 
 ## Other recommendations
 

--- a/website/docs/components/filter-trigger/filter-trigger-code.md
+++ b/website/docs/components/filter-trigger/filter-trigger-code.md
@@ -29,3 +29,15 @@ It is more complex example with [Dropdown](/components/dropdown/dropdown) and [C
 </script>
 
 :::
+
+## Programmatic focus 
+
+Filter trigger contains two elements in the wrapper – button that opens dropdown (the inner trigger) and the clear button that empties selected value. In case you want to set browser focus on filter trigger, use the `triggerRef` prop to access the inner trigger node.
+
+::: sandbox
+
+<script lang="tsx">
+  export Demo from './examples/programmatic_focus.tsx';
+</script>
+
+:::


### PR DESCRIPTION
## Motivation and Context

This PR fixes two issues:
1. FilterTrigger uses div with role="button" instead of just button. It's why label with htmlFor doesn't work for FilterTrigger.
2. FilterTrigger sets ref to it's wrapper. So developers can't set focus on focus trigger programmatically. I've added `triggerRef` prop and example how to use it.

## How has this been tested?

Manual testing on website examples.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
