### PR TITLE
[86bxfdpxp][d3-chart] dots was missing value prop in props mapping function

### DIFF
--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.27.3] - 2024-02-13
+
+### Fixed
+
+- `Dots` component was missing `value` prop in it's props mapping function.
+
 ## [3.27.2] - 2024-02-09
 
 ### Changed

--- a/semcore/d3-chart/src/Dots.jsx
+++ b/semcore/d3-chart/src/Dots.jsx
@@ -94,6 +94,7 @@ function Dots(props) {
             patternKey={patternKey}
             patterns={patterns}
             key={`${i}`}
+            value={d}
             visible={visible}
             active={active}
             hide={hide}
@@ -113,6 +114,7 @@ function Dots(props) {
             patternKey={patternKey}
             patterns={patterns}
             key={`${i}`}
+            value={d}
             visible={visible}
             active={active}
             hide={hide}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

During the chart patterns update I've accidentally removed `value` prop from d3 dots components. This PR adds it back.

## How has this been tested?

-


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
