### PR TITLE
[86bxd8qjz] added space keydown handler alongside all enter keydown handlers

### DIFF
--- a/semcore/carousel/CHANGELOG.md
+++ b/semcore/carousel/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.28.0] - 2024-02-13
+
+### Changed
+
+- Navigation buttons are clickable by `Space` now (along with `Enter` as before).
+
 ## [3.27.2] - 2024-02-09
 
 ### Changed

--- a/semcore/carousel/src/Carousel.tsx
+++ b/semcore/carousel/src/Carousel.tsx
@@ -315,8 +315,8 @@ class CarouselRoot extends Component<
   };
 
   bindHandlerKeydownControl = (direction: 'left' | 'right') => (e: React.KeyboardEvent) => {
-    const { key } = e;
-    if (key === 'Enter') {
+    const { code } = e;
+    if (code === 'Enter' || code === 'Space') {
       e.preventDefault();
       this.bindHandlerClick(direction)();
     }

--- a/semcore/color-picker/CHANGELOG.md
+++ b/semcore/color-picker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.25.0] - 2024-02-13
+
+### Changed
+
+- Color palette items are clickable by `Space` now (along with `Enter` as before).
+
 ## [2.24.2] - 2024-02-09
 
 ### Changed

--- a/semcore/color-picker/__tests__/index.test.tsx
+++ b/semcore/color-picker/__tests__/index.test.tsx
@@ -147,7 +147,7 @@ describe('ColorPicker', () => {
     const input = getByTestId('inputColor') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '635472' } });
     fireEvent.focus(input);
-    fireEvent.keyDown(input, { key: 'Enter', keyCode: 13 });
+    fireEvent.keyDown(input, { code: 'Enter', keyCode: 13 });
 
     expect(input.value).toBe('');
     expect(spy).toBeCalledTimes(1);
@@ -182,7 +182,7 @@ describe('ColorPicker', () => {
     expect(input.value).toBe('#635472');
 
     fireEvent.focus(input);
-    fireEvent.keyDown(input, { key: 'Enter', keyCode: 13 });
+    fireEvent.keyDown(input, { code: 'Enter', keyCode: 13 });
 
     expect(spy).toBeCalledTimes(1);
     expect(spy).toBeCalledWith(['#635472'], expect.anything());

--- a/semcore/color-picker/src/ColorPicker.tsx
+++ b/semcore/color-picker/src/ColorPicker.tsx
@@ -126,7 +126,8 @@ class ColorPickerRoot extends Component<RootAsProps> {
       displayLabel,
       onClick: this.bindHandlerItemClick(props.value),
       onKeyDown: (event: React.KeyboardEvent) => {
-        if (event.key === 'Enter' || event.key === 'Space') {
+        if (event.code === 'Enter' || event.code === 'Space') {
+          event.preventDefault();
           this.bindHandlerItemClick(props.value)(event);
         }
       },

--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.28.0] - 2024-02-13
+
+### Changed
+
+- A11y module links are clickable by `Space` now (along with `Enter` as before).
+
 ## [3.27.3] - 2024-02-13
 
 ### Fixed

--- a/semcore/d3-chart/src/a11y/PlotA11yView.tsx
+++ b/semcore/d3-chart/src/a11y/PlotA11yView.tsx
@@ -111,8 +111,9 @@ export const PlotA11yView: React.FC<A11yViewProps> = ({
   }, []);
   const handleSkipKeyboard = React.useCallback(
     (event: React.KeyboardEvent) => {
-      if (event.key !== 'Enter') return;
+      if (!(event.code === 'Enter' || event.code === 'Space')) return;
 
+      event.preventDefault();
       handleSkip();
     },
     [handleSkip],
@@ -122,8 +123,9 @@ export const PlotA11yView: React.FC<A11yViewProps> = ({
   }, []);
   const handleGoToTableKeyboard = React.useCallback(
     (event: React.KeyboardEvent) => {
-      if (event.key !== 'Enter') return;
+      if (!(event.code === 'Enter' || event.code === 'Space')) return;
 
+      event.preventDefault();
       handleGoToTable();
     },
     [handleGoToTable],

--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.27.0] - 2024-02-13
+
+### Changed
+
+- Header sorting cells are clickable by `Space` now (along with `Enter` as before).
+
 ## [4.26.2] - 2024-02-09
 
 ### Changed

--- a/semcore/data-table/src/Head.tsx
+++ b/semcore/data-table/src/Head.tsx
@@ -43,7 +43,8 @@ class Head extends Component<AsProps> {
   };
 
   bindHandlerKeyDown = (name: string) => (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter') {
+    if (event.code === 'Enter' || event.code === 'Space') {
+      event.preventDefault();
       this.asProps.$onSortClick(name, event);
     }
   };

--- a/semcore/icon/CHANGELOG.md
+++ b/semcore/icon/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.26.0] - 2024-02-13
+
+### Changed
+
+- Icons are clickable by `Space` now (along with `Enter` as before).
+
 ## [4.25.0] - 2024-o2-18
 
 ### Added

--- a/semcore/icon/src/Icon.jsx
+++ b/semcore/icon/src/Icon.jsx
@@ -44,7 +44,8 @@ function Icon(props, ref) {
       return propsEnhance.onKeyDown(event);
     }
 
-    if (interactive && event.key === 'Enter') {
+    if (interactive && (event.code === 'Enter' || event.code === 'Space')) {
+      event.preventDefault();
       propsEnhance.onClick?.(event);
     }
   }

--- a/semcore/icon/src/Icon.jsx
+++ b/semcore/icon/src/Icon.jsx
@@ -44,9 +44,9 @@ function Icon(props, ref) {
       return propsEnhance.onKeyDown(event);
     }
 
-    if (interactive && (event.code === 'Enter' || event.code === 'Space')) {
+    if (interactive && propsEnhance.onClick && (event.code === 'Enter' || event.code === 'Space')) {
       event.preventDefault();
-      propsEnhance.onClick?.(event);
+      propsEnhance.onClick(event);
     }
   }
 

--- a/semcore/inline-edit/CHANGELOG.md
+++ b/semcore/inline-edit/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.21.0] - 2024-02-13
+
+### Changed
+
+- `InlineEdit.View` are clickable by `Space` now (along with `Enter` as before).
+
 ## [4.20.2] - 2024-02-09
 
 ### Changed

--- a/semcore/inline-edit/src/InlineEdit.tsx
+++ b/semcore/inline-edit/src/InlineEdit.tsx
@@ -71,7 +71,7 @@ class InlineEdit extends Component<AsProps> {
   }
 
   handlerKeyDownEdit = (event: React.KeyboardEvent) => {
-    if (event.code === 'Enter' || event.code === 'Escape') {
+    if (this.viewRef.current && (event.code === 'Enter' || event.code === 'Escape')) {
       event.preventDefault();
       this.viewRef.current?.focus();
     }
@@ -125,9 +125,9 @@ const View: React.FC<AsProps> = (props) => {
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent) => {
       if (!visible) return;
-      if (event.code === 'Enter' || event.code === 'Space') {
+      if (props.onEdit && (event.code === 'Enter' || event.code === 'Space')) {
         event.preventDefault();
-        props.onEdit?.();
+        props.onEdit();
       }
     },
     [visible, props.onEdit],

--- a/semcore/inline-edit/src/InlineEdit.tsx
+++ b/semcore/inline-edit/src/InlineEdit.tsx
@@ -71,7 +71,8 @@ class InlineEdit extends Component<AsProps> {
   }
 
   handlerKeyDownEdit = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter' || event.key === 'Escape') {
+    if (event.code === 'Enter' || event.code === 'Escape') {
+      event.preventDefault();
       this.viewRef.current?.focus();
     }
   };
@@ -124,7 +125,7 @@ const View: React.FC<AsProps> = (props) => {
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent) => {
       if (!visible) return;
-      if (event.key === 'Enter' || event.key === 'Space') {
+      if (event.code === 'Enter' || event.code === 'Space') {
         event.preventDefault();
         props.onEdit?.();
       }

--- a/semcore/inline-input/CHANGELOG.md
+++ b/semcore/inline-input/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.25.0] - 2024-02-13
+
+### Fixed
+
+- Confirm and cancel controls were ignoring `Space` click.
+
 ## [4.24.2] - 2024-02-09
 
 ### Changed

--- a/semcore/inline-input/src/InlineInput.tsx
+++ b/semcore/inline-input/src/InlineInput.tsx
@@ -247,11 +247,11 @@ class InlineInputBase extends Component<RootAsProps> {
 
   handleKeyDown = (event: React.KeyboardEvent) => {
     const { onConfirm, onCancel } = this.asProps;
-    if (event.key === 'Enter') {
+    if (event.code === 'Enter') {
       onConfirm?.(this.inputRef.current?.value ?? '', event);
       this.lastHandledKeyboardEvent = Date.now();
     }
-    if (event.key === 'Escape') {
+    if (event.code === 'Escape') {
       onCancel?.(this.initValue, event);
       this.lastHandledKeyboardEvent = Date.now();
     }
@@ -320,7 +320,7 @@ const ConfirmControl: React.FC<ConfirmControlAsProps> = (props) => {
 
   const handleKeydown = React.useCallback(
     (event: React.KeyboardEvent) => {
-      if (event.key === 'Enter' || event.key === 'Space') {
+      if (event.code === 'Enter' || event.code === 'Space') {
         event.preventDefault();
         event.stopPropagation();
         handleConfirm(event);
@@ -372,7 +372,7 @@ const CancelControl: React.FC<CancelControlAsProps> = (props) => {
 
   const handleKeydown = React.useCallback(
     (event: React.KeyboardEvent) => {
-      if (event.key === 'Enter' || event.key === 'Space') {
+      if (event.code === 'Enter' || event.code === 'Space') {
         event.preventDefault();
         event.stopPropagation();
         handleCancel(event);

--- a/semcore/input-tags/CHANGELOG.md
+++ b/semcore/input-tags/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.22.0] - 2024-02-13
+
+### Changed
+
+- Tags are clickable by `Space` now (along with `Enter` as before).
+
 ## [4.21.2] - 2024-02-09
 
 ### Changed

--- a/semcore/input-tags/src/InputTags.tsx
+++ b/semcore/input-tags/src/InputTags.tsx
@@ -255,9 +255,9 @@ function InputTag(props: any) {
   const STag = Root;
 
   const onKeyDown = (event: React.KeyboardEvent) => {
-    if (event.code === 'Enter' || event.code === 'Space') {
+    if (props.onClick && (event.code === 'Enter' || event.code === 'Space')) {
       event.preventDefault();
-      props.onClick?.(event);
+      props.onClick(event);
 
       return false;
     }

--- a/semcore/input-tags/src/InputTags.tsx
+++ b/semcore/input-tags/src/InputTags.tsx
@@ -255,7 +255,8 @@ function InputTag(props: any) {
   const STag = Root;
 
   const onKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter') {
+    if (event.code === 'Enter' || event.code === 'Space') {
+      event.preventDefault();
       props.onClick?.(event);
 
       return false;

--- a/semcore/pills/CHANGELOG.md
+++ b/semcore/pills/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.20.0] - 2024-02-13
+
+### Changed
+
+- Pills are clickable by `Space` now (along with `Enter` as before).
+
 ## [5.19.2] - 2024-02-09
 
 ### Changed

--- a/semcore/pills/src/Pills.jsx
+++ b/semcore/pills/src/Pills.jsx
@@ -58,7 +58,8 @@ class RootPills extends Component {
   };
 
   bindHandleKeyDown = (value) => (event) => {
-    if (event.key === 'Enter' || event.key === 'Space') {
+    if (event.code === 'Enter' || event.code === 'Space') {
+      event.preventDefault();
       this.handlers.value(value, event);
     }
   };

--- a/semcore/switch/CHANGELOG.md
+++ b/semcore/switch/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.19.0] - 2024-02-13
+
+### Changed
+
+- Switches are clickable by `Space` now (along with `Enter` as before).
+
 ## [5.18.2] - 2024-02-09
 
 ### Changed

--- a/semcore/switch/__tests__/index.test.tsx
+++ b/semcore/switch/__tests__/index.test.tsx
@@ -184,7 +184,7 @@ describe('Switch', () => {
       </Switch>,
     );
 
-    fireEvent.keyDown(getByTestId('value'), { key: 'Enter', keyCode: 13 });
+    fireEvent.keyDown(getByTestId('value'), { code: 'Enter', keyCode: 13 });
     expect(spy).lastCalledWith(true, expect.any(Object));
   });
 

--- a/semcore/switch/src/Switch.jsx
+++ b/semcore/switch/src/Switch.jsx
@@ -121,8 +121,11 @@ class Value extends Component {
     clearTimeout(this.timer);
   }
 
-  handleKeyDown = (e) => {
-    if (e.key === 'Enter') this.handlers.checked(!this.asProps.checked, e);
+  handleKeyDown = (event) => {
+    if (event.code === 'Enter' || event.code === 'Space') {
+      event.preventDefault();
+      this.handlers.checked(!this.asProps.checked, event);
+    }
   };
 
   // because clicking on label causes a click on input

--- a/semcore/tab-panel/CHANGELOG.md
+++ b/semcore/tab-panel/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.20.0] - 2024-02-13
+
+### Changed
+
+- Tabs are clickable by `Space` now (along with `Enter` as before).
+
 ## [4.19.2] - 2024-02-09
 
 ### Changed

--- a/semcore/tab-panel/src/TabPanel.jsx
+++ b/semcore/tab-panel/src/TabPanel.jsx
@@ -39,7 +39,8 @@ class TabPanelRoot extends Component {
   };
 
   handleKeyDown = (value) => (event) => {
-    if (event.key === 'Enter' || event.key === 'Space') {
+    if (event.code === 'Enter' || event.code === 'Space') {
+      event.preventDefault();
       this.handlers.value(value, event);
     }
   };

--- a/semcore/tag/CHANGELOG.md
+++ b/semcore/tag/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.26.0] - 2024-02-13
+
+### Changed
+
+- Tags are clickable by `Space` now (along with `Enter` as before).
+
 ## [5.25.2] - 2024-02-09
 
 ### Changed

--- a/semcore/tag/__tests__/index.test.tsx
+++ b/semcore/tag/__tests__/index.test.tsx
@@ -163,7 +163,7 @@ describe('Tag', () => {
       </Tag>,
     );
 
-    fireEvent.keyDown(getByTestId('close'), { key: 'Enter' });
+    fireEvent.keyDown(getByTestId('close'), { code: 'Enter' });
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
@@ -177,7 +177,7 @@ describe('Tag', () => {
       </Tag>,
     );
 
-    fireEvent.keyDown(getByTestId('close'), { key: 'Enter' });
+    fireEvent.keyDown(getByTestId('close'), { code: 'Enter' });
     expect(onClick).toHaveBeenCalledTimes(0);
   });
 

--- a/semcore/tag/src/Tag.jsx
+++ b/semcore/tag/src/Tag.jsx
@@ -120,9 +120,9 @@ function Close(props) {
       return props.onKeyDown(event);
     }
 
-    if (event.code === 'Enter' || event.code === 'Space') {
+    if (props.onClick && (event.code === 'Enter' || event.code === 'Space')) {
       event.preventDefault();
-      props.onClick?.(event);
+      props.onClick(event);
     }
   }
 

--- a/semcore/tag/src/Tag.jsx
+++ b/semcore/tag/src/Tag.jsx
@@ -64,6 +64,7 @@ class RootTag extends Component {
     switch (e.key) {
       case ' ':
       case 'Enter':
+        e.preventDefault();
         this.asProps.onClick?.(e);
         break;
     }
@@ -119,7 +120,8 @@ function Close(props) {
       return props.onKeyDown(event);
     }
 
-    if (event.key === 'Enter') {
+    if (event.code === 'Enter' || event.code === 'Space') {
+      event.preventDefault();
       props.onClick?.(event);
     }
   }

--- a/semcore/wizard/CHANGELOG.md
+++ b/semcore/wizard/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.28.0] - 2024-02-13
+
+### Changed
+
+- Wizard steps are clickable by `Space` now (along with `Enter` as before).
+
 ## [2.27.2] - 2024-02-09
 
 ### Changed

--- a/semcore/wizard/__tests__/index.test.tsx
+++ b/semcore/wizard/__tests__/index.test.tsx
@@ -142,7 +142,7 @@ describe('Wizard', () => {
       </Wizard>,
     );
 
-    fireEvent.keyDown(getByTestId('second-step'), { key: 'Enter', keyCode: 13 });
+    fireEvent.keyDown(getByTestId('second-step'), { code: 'Enter', keyCode: 13 });
     expect(spy).lastCalledWith(2, expect.any(Object));
   });
 

--- a/semcore/wizard/src/Wizard.jsx
+++ b/semcore/wizard/src/Wizard.jsx
@@ -113,7 +113,8 @@ function Stepper(props) {
 
   const handlerKeyDown = React.useCallback(
     (e) => {
-      if (onActive && e.key === 'Enter') {
+      if (onActive && (e.code === 'Enter' || e.code === 'Space')) {
+        e.preventDefault();
         onActive(step, e);
       }
     },


### PR DESCRIPTION
## Motivation and Context

We have a lot of interactive elements that listen to Enter keydown and call the click handlers. It's also expected for them to react on Space keydowns. 

I've checked out all placed in code where keydown

## How has this been tested?

I've manually tested every updated component. Nothing seems to be risky or require additional unit tests (over existing ones for Enter key).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
