### PR TITLE
[86bx4vya5] alternative dropdown-menu a11y improvemnt 

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1030,9 +1030,15 @@ importers:
       '@playwright/test':
         specifier: 1.25.1
         version: 1.25.1
+      '@semcore/base-trigger':
+        specifier: 4.26.1
+        version: link:../base-trigger
       '@semcore/button':
         specifier: workspace:*
         version: link:../button
+      '@semcore/icon':
+        specifier: 4.26.0
+        version: link:../icon
       '@semcore/testing-utils':
         specifier: 1.0.0
         version: link:../../tools/testing-utils

--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -6,323 +6,323 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Fixed
 
-* Assistive technologies were not announcing the selected item if dropdown contained focusable elements.
+- Assistive technologies were not announcing the selected item if dropdown contained focusable elements.
 
 ### Changed
 
-* When dropdown menu item has focusable elements inside, pressing tab locks focus inside the item. Closing or navigating inside the dropdown menu unlocks the focus.
-* If dropdown menu poppers placed to the left or right side of trigger, user needs to press `ArrowLeft` or `ArrowRight` to open the popper (`ArrowUp` or `ArrowDown` was opening popper with any placement before the change).
+- When dropdown menu item has focusable elements inside, pressing tab locks focus inside the item. Closing or navigating inside the dropdown menu unlocks the focus.
+- If dropdown menu poppers placed to the left or right side of trigger, user needs to press `ArrowLeft` or `ArrowRight` to open the popper (`ArrowUp` or `ArrowDown` was opening popper with any placement before the change).
 
 ## [4.20.4] - 2024-02-19
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.19.3 ~> 4.19.4]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.19.3 ~> 4.19.4]).
 
 ## [4.20.3] - 2024-02-16
 
 ### Fixed
 
-* Removed deprecation messages about `interaction` property (that were added by mistake).
+- Removed deprecation messages about `interaction` property (that were added by mistake).
 
 ## [4.20.2] - 2024-02-09
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.19.1 ~> 4.19.2], `@semcore/utils` [4.20.1 ~> 4.20.2], `@semcore/core` [2.17.1 ~> 2.17.2]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.19.1 ~> 4.19.2], `@semcore/utils` [4.20.1 ~> 4.20.2], `@semcore/core` [2.17.1 ~> 2.17.2]).
 
 ## [4.20.1] - 2024-02-06
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.19.0 ~> 4.19.1], `@semcore/flex-box` [5.18.0 ~> 5.19.0], `@semcore/utils` [4.20.0 ~> 4.20.1], `@semcore/core` [2.17.0 ~> 2.17.1]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.19.0 ~> 4.19.1], `@semcore/flex-box` [5.18.0 ~> 5.19.0], `@semcore/utils` [4.20.0 ~> 4.20.1], `@semcore/core` [2.17.0 ~> 2.17.1]).
 
 ## [4.20.0] - 2024-02-01
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.18.1 ~> 4.19.0], `@semcore/utils` [4.19.1 ~> 4.20.0], `@semcore/core` [2.16.1 ~> 2.17.0]).
+- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.18.1 ~> 4.19.0], `@semcore/utils` [4.19.1 ~> 4.20.0], `@semcore/core` [2.16.1 ~> 2.17.0]).
 
 ## [4.19.1] - 2024-02-01
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.18.0 ~> 4.18.1], `@semcore/utils` [4.19.0 ~> 4.19.1], `@semcore/core` [2.16.0 ~> 2.16.1]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.18.0 ~> 4.18.1], `@semcore/utils` [4.19.0 ~> 4.19.1], `@semcore/core` [2.16.0 ~> 2.16.1]).
 
 ## [4.19.0] - 2024-01-31
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.17.0 ~> 4.18.0], `@semcore/utils` [4.18.0 ~> 4.19.0], `@semcore/core` [2.15.0 ~> 2.16.0]).
+- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.17.0 ~> 4.18.0], `@semcore/utils` [4.18.0 ~> 4.19.0], `@semcore/core` [2.15.0 ~> 2.16.0]).
 
 ## [4.18.0] - 2024-01-19
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.16.0 ~> 4.17.0], `@semcore/utils` [4.17.0 ~> 4.18.0], `@semcore/core` [2.14.0 ~> 2.15.0]).
+- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.16.0 ~> 4.17.0], `@semcore/utils` [4.17.0 ~> 4.18.0], `@semcore/core` [2.14.0 ~> 2.15.0]).
 
 ## [4.17.0] - 2024-01-19
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.15.0 ~> 4.16.0], `@semcore/core` [2.13.1 ~> 2.14.0]).
+- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.15.0 ~> 4.16.0], `@semcore/core` [2.13.1 ~> 2.14.0]).
 
 ## [4.16.3] - 2024-01-10
 
 ### Fixed
 
-* Pressing `ArrowUp`/`ArrowDown` on closed `DropdownMenu` trigger was causing error in console.
+- Pressing `ArrowUp`/`ArrowDown` on closed `DropdownMenu` trigger was causing error in console.
 
 ## [4.16.2] - 2024-01-10
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.14.1 ~> 4.14.2], `@semcore/utils` [4.16.0 ~> 4.16.2], `@semcore/core` [2.13.0 ~> 2.13.1]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.14.1 ~> 4.14.2], `@semcore/utils` [4.16.0 ~> 4.16.2], `@semcore/core` [2.13.0 ~> 2.13.1]).
 
 ## [4.16.1] - 2024-01-04
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.14.0 ~> 4.14.1]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.14.0 ~> 4.14.1]).
 
 ## [4.16.0] - 2023-12-22
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.13.2 ~> 4.14.0], `@semcore/utils` [4.15.1 ~> 4.16.0], `@semcore/core` [2.12.1 ~> 2.13.0]).
+- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.13.2 ~> 4.14.0], `@semcore/utils` [4.15.1 ~> 4.16.0], `@semcore/core` [2.12.1 ~> 2.13.0]).
 
 ## [4.15.2] - 2023-12-19
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.13.1 ~> 4.13.2], `@semcore/utils` [4.15.0 ~> 4.15.1], `@semcore/core` [2.12.0 ~> 2.12.1]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.13.1 ~> 4.13.2], `@semcore/utils` [4.15.0 ~> 4.15.1], `@semcore/core` [2.12.0 ~> 2.12.1]).
 
 ## [4.15.1] - 2023-12-12
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.13.0 ~> 4.13.1]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.13.0 ~> 4.13.1]).
 
 ## [4.15.0] - 2023-12-05
 
 ### Changed
 
-* Deprecated some values of `interaction` property.
+- Deprecated some values of `interaction` property.
 
 ### Removed
 
-* unnecessary style for focused `Popper`.
+- unnecessary style for focused `Popper`.
 
 ## [4.14.0] - 2023-12-04
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.11.0 ~> 4.12.0], `@semcore/utils` [4.13.0 ~> 4.14.0], `@semcore/core` [2.10.0 ~> 2.11.0]).
+- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.11.0 ~> 4.12.0], `@semcore/utils` [4.13.0 ~> 4.14.0], `@semcore/core` [2.10.0 ~> 2.11.0]).
 
 ## [4.13.0] - 2023-11-23
 
 ### Added
 
-* Support for both non-focusable and focusable items in DropdownMenu.
+- Support for both non-focusable and focusable items in DropdownMenu.
 
 ## [4.12.6] - 2023-11-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.10.2 ~> 4.10.3], `@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/core` [2.9.1 ~> 2.9.2]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.10.2 ~> 4.10.3], `@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/core` [2.9.1 ~> 2.9.2]).
 
 ## [4.12.5] - 2023-11-10
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.10.1 ~> 4.10.2]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.10.1 ~> 4.10.2]).
 
 ## [4.12.4] - 2023-11-10
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/scroll-area` [5.12.1 ~> 5.12.2]).
+- Version prepatch update due to children dependencies update (`@semcore/scroll-area` [5.12.1 ~> 5.12.2]).
 
 ## [4.12.3] - 2023-11-09
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.10.0 ~> 4.10.1], `@semcore/utils` [4.10.1 ~> 4.10.2], `@semcore/core` [2.9.0 ~> 2.9.1]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.10.0 ~> 4.10.1], `@semcore/utils` [4.10.1 ~> 4.10.2], `@semcore/core` [2.9.0 ~> 2.9.1]).
 
 ## [4.12.2] - 2023-11-07
 
 ### Changed
 
-* Deprecated `notInteractive` prop.
+- Deprecated `notInteractive` prop.
 
 ## [4.12.0] - 2023-11-06
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.9.0 ~> 4.10.0], `@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/core` [2.8.0 ~> 2.9.0]).
+- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.9.0 ~> 4.10.0], `@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/core` [2.8.0 ~> 2.9.0]).
 
 ## [4.11.0] - 2023-10-27
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.8.3 ~> 4.9.0], `@semcore/utils` [4.8.4 ~> 4.9.0], `@semcore/core` [2.7.7 ~> 2.8.0]).
+- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.8.3 ~> 4.9.0], `@semcore/utils` [4.8.4 ~> 4.9.0], `@semcore/core` [2.7.7 ~> 2.8.0]).
 
 ## [4.10.3] - 2023-10-24
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.8.2 ~> 4.8.3], `@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/core` [2.7.6 ~> 2.7.7]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.8.2 ~> 4.8.3], `@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/core` [2.7.6 ~> 2.7.7]).
 
 ## [4.10.2] - 2023-10-16
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.8.1 ~> 4.8.2], `@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/core` [2.7.5 ~> 2.7.6]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.8.1 ~> 4.8.2], `@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/core` [2.7.5 ~> 2.7.6]).
 
 ## [4.10.1] - 2023-10-10
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.8.0 ~> 4.8.1], `@semcore/flex-box` [5.7.5 ~> 5.8.0]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.8.0 ~> 4.8.1], `@semcore/flex-box` [5.7.5 ~> 5.8.0]).
 
 ## [4.10.0] - 2023-10-09
 
 ### Added
 
-* `nl` locale support.
+- `nl` locale support.
 
 ## [4.9.5] - 2023-10-06
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.4 ~> 4.7.5], `@semcore/scroll-area` [5.9.4 ~> 5.9.5], `@semcore/utils` [4.8.1 ~> 4.8.2], `@semcore/core` [2.7.4 ~> 2.7.5]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.4 ~> 4.7.5], `@semcore/scroll-area` [5.9.4 ~> 5.9.5], `@semcore/utils` [4.8.1 ~> 4.8.2], `@semcore/core` [2.7.4 ~> 2.7.5]).
 
 ## [4.9.4] - 2023-10-03
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.3 ~> 4.7.4], `@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/core` [2.7.3 ~> 2.7.4]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.3 ~> 4.7.4], `@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/core` [2.7.3 ~> 2.7.4]).
 
 ## [4.9.3] - 2023-10-02
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.2 ~> 4.7.3], `@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/core` [2.7.2 ~> 2.7.3]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.2 ~> 4.7.3], `@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/core` [2.7.2 ~> 2.7.3]).
 
 ## [4.9.2] - 2023-09-20
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.1 ~> 4.7.2], `@semcore/core` [2.7.1 ~> 2.7.2]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.1 ~> 4.7.2], `@semcore/core` [2.7.1 ~> 2.7.2]).
 
 ## [4.9.1] - 2023-09-20
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.0 ~> 4.7.1], `@semcore/utils` [4.7.0 ~> 4.7.1], `@semcore/core` [2.7.0 ~> 2.7.1]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.0 ~> 4.7.1], `@semcore/utils` [4.7.0 ~> 4.7.1], `@semcore/core` [2.7.0 ~> 2.7.1]).
 
 ## [4.9.0] - 2023-09-13
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.6.3 ~> 4.7.0], `@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
+- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.6.3 ~> 4.7.0], `@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
 
 ## [4.8.3] - 2023-09-12
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.6.2 ~> 4.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.6.2 ~> 4.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
 
 ## [4.8.2] - 2023-09-08
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.6.1 ~> 4.6.2], `@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.6.1 ~> 4.6.2], `@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
 
 ## [4.8.1] - 2023-09-05
 
 ### Fixed
 
-* Both highlighted and selected menu items were not visually distinguishable from selected items.
-* `highlightedIndex` prop was added to `DropdownMenu.Menu` context type.
+- Both highlighted and selected menu items were not visually distinguishable from selected items.
+- `highlightedIndex` prop was added to `DropdownMenu.Menu` context type.
 
 ## [4.8.0] - 2023-09-04
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.5.0 ~> 4.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
+- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.5.0 ~> 4.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
 
 ## [4.7.0] - 2023-08-28
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.4.1 ~> 4.5.0], `@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
+- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.4.1 ~> 4.5.0], `@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
 
 ## [4.6.1] - 2023-08-24
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.4.0 ~> 4.4.1], `@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.4.0 ~> 4.4.1], `@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
 
 ## [4.6.0] - 2023-08-23
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/scroll-area` [5.5.0 ~> 5.6.0]).
+- Version preminor update due to children dependencies update (`@semcore/scroll-area` [5.5.0 ~> 5.6.0]).
 
 ## [4.5.0] - 2023-08-23
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.3.1 ~> 4.4.0], `@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
+- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.3.1 ~> 4.4.0], `@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
 
 ## [4.4.1] - 2023-08-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.3.0 ~> 4.3.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.3.0 ~> 4.3.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
 
 ## [4.4.0] - 2023-08-18
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.2.1 ~> 4.3.0], `@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
+- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.2.1 ~> 4.3.0], `@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
 
 ## [4.3.0] - 2023-08-17
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/scroll-area` [5.2.1 ~> 5.3.0]).
+- Version preminor update due to children dependencies update (`@semcore/scroll-area` [5.2.1 ~> 5.3.0]).
 
 ## [4.2.1] - 2023-08-16
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.2.0 ~> 4.2.1], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/core` [2.2.0 ~> 2.2.1]).
+- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.2.0 ~> 4.2.1], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/core` [2.2.0 ~> 2.2.1]).
 
 ## [4.2.0] - 2023-08-07
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/dropdown` [4.1.0 ~> 4.2.0], `@semcore/utils` [4.0.0 ~> 4.1.0]).
+- Version minor update due to children dependencies update (`@semcore/dropdown` [4.1.0 ~> 4.2.0], `@semcore/utils` [4.0.0 ~> 4.1.0]).
 
 ## [4.1.0] - 2023-08-01
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/dropdown` [4.0.1 ~> 4.1.0], `@semcore/flex-box` [5.0.0 ~> 5.1.0]).
+- Version minor update due to children dependencies update (`@semcore/dropdown` [4.0.1 ~> 4.1.0], `@semcore/flex-box` [5.0.0 ~> 5.1.0]).
 
 ## [4.0.1] - 2023-07-18
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [4.0.0 ~> 4.0.1]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [4.0.0 ~> 4.0.1]).
 
 ## [4.0.0] - 2023-07-17
 
 ### Break
 
-* Strict, backward incompatible typings.
+- Strict, backward incompatible typings.
 
 ## [3.9.7] - 2023-06-30
 
@@ -330,7 +330,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.6.2 ~> 3.6.3], `@semcore/utils` [3.53.4 ~> 3.54.0]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.6.2 ~> 3.6.3], `@semcore/utils` [3.53.4 ~> 3.54.0]).
 
 ## [3.9.5] - 2023-06-22
 
@@ -338,7 +338,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.13 ~> 4.4.0]).
+- Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.13 ~> 4.4.0]).
 
 ## [3.9.3] - 2023-06-15
 
@@ -346,149 +346,149 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.6.0 ~> 3.6.1], `@semcore/utils` [3.53.3 ~> 3.53.4]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.6.0 ~> 3.6.1], `@semcore/utils` [3.53.3 ~> 3.53.4]).
 
 ## [3.9.1] - 2023-06-13
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.10 ~> 4.3.11]).
+- Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.10 ~> 4.3.11]).
 
 ## [3.9.0] - 2023-06-12
 
 ### Added
 
-* Swedish (`sv`) locale support.
+- Swedish (`sv`) locale support.
 
 ## [3.8.2] - 2023-06-12
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.5.1 ~> 3.5.2], `@semcore/utils` [3.53.2 ~> 3.53.3]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.5.1 ~> 3.5.2], `@semcore/utils` [3.53.2 ~> 3.53.3]).
 
 ## [3.8.1] - 2023-06-09
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.5.0 ~> 3.5.1], `@semcore/utils` [3.53.1 ~> 3.53.2]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.5.0 ~> 3.5.1], `@semcore/utils` [3.53.1 ~> 3.53.2]).
 
 ## [3.8.0] - 2023-06-09
 
 ### Added
 
-* Polish (`pl`) locale support.
+- Polish (`pl`) locale support.
 
 ## [3.7.4] - 2023-06-07
 
 ### Fixed
 
-* Improved `<Popper />` integration.
-* Fixed `aria-activedescendant` value.
-* Fixed double focus inside of popper.
+- Improved `<Popper />` integration.
+- Fixed `aria-activedescendant` value.
+- Fixed double focus inside of popper.
 
 ## [3.7.3] - 2023-05-31
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.33 ~> 3.4.34], `@semcore/utils` [3.52.0 ~> 3.53.0]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.33 ~> 3.4.34], `@semcore/utils` [3.52.0 ~> 3.53.0]).
 
 ## [3.7.2] - 2023-05-25
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.32 ~> 3.4.33], `@semcore/utils` [3.51.1 ~> 3.52.0]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.32 ~> 3.4.33], `@semcore/utils` [3.51.1 ~> 3.52.0]).
 
 ## [3.7.1] - 2023-05-24
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.31 ~> 3.4.32], `@semcore/utils` [3.51.0 ~> 3.51.1]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.31 ~> 3.4.32], `@semcore/utils` [3.51.0 ~> 3.51.1]).
 
 ## [3.7.0] - 2023-05-22
 
 ### Changed
 
-* Added visual cue to the `selected` DropdownMenu. Item.
+- Added visual cue to the `selected` DropdownMenu. Item.
 
 ## [3.6.36] - 2023-05-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.29 ~> 3.4.30]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.29 ~> 3.4.30]).
 
 ## [3.6.35] - 2023-05-11
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.28 ~> 3.4.29], `@semcore/utils` [3.50.6 ~> 3.50.7]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.28 ~> 3.4.29], `@semcore/utils` [3.50.6 ~> 3.50.7]).
 
 ## [3.6.34] - 2023-05-04
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.27 ~> 3.4.28], `@semcore/utils` [3.50.5 ~> 3.50.6]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.27 ~> 3.4.28], `@semcore/utils` [3.50.5 ~> 3.50.6]).
 
 ## [3.6.30] - 2023-05-02
 
 ### Changed
 
-* Removed `aria-flowto` because it has bad screen readers support and often confuse users in supporting screen readers.
+- Removed `aria-flowto` because it has bad screen readers support and often confuse users in supporting screen readers.
 
 ## [3.6.29] - 2023-04-24
 
 ### Fixed
 
-* Remove role for Title and Hint
+- Remove role for Title and Hint
 
 ## [3.6.27] - 2023-04-17
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.22 ~> 3.4.23], `@semcore/utils` [3.50.0 ~> 3.50.3]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.22 ~> 3.4.23], `@semcore/utils` [3.50.0 ~> 3.50.3]).
 
 ## [3.6.25] - 2023-03-28
 
 ### Added
 
-* Added default color (`--intergalactic-text-primary`) to the component.
+- Added default color (`--intergalactic-text-primary`) to the component.
 
 ## [3.6.24] - 2023-03-28
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.19 ~> 3.4.20], `@semcore/utils` [3.49.1 ~> 3.50.0]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.19 ~> 3.4.20], `@semcore/utils` [3.49.1 ~> 3.50.0]).
 
 ## [3.6.20] - 2023-03-23
 
 ### Added
 
-* Added `z-index: 0` to `DropdownMenu.List` so that it doesn't overlap the focus border of neighboring elements.
+- Added `z-index: 0` to `DropdownMenu.List` so that it doesn't overlap the focus border of neighboring elements.
 
 ## [3.6.19] - 2023-03-23
 
 ### Fixed
 
-* `aria-controls` and `aria-expanded` html attributes wasn't applied on closed dropdown.
-* Navigating options with keyboard now doesn't trigger browser focus.
-* `aria-activedescendant` now is properly updated on keyboard navigation.
+- `aria-controls` and `aria-expanded` html attributes wasn't applied on closed dropdown.
+- Navigating options with keyboard now doesn't trigger browser focus.
+- `aria-activedescendant` now is properly updated on keyboard navigation.
 
 ## [3.6.18] - 2023-03-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.14 ~> 3.4.15], `@semcore/utils` [3.47.3 ~> 3.47.4]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.14 ~> 3.4.15], `@semcore/utils` [3.47.3 ~> 3.47.4]).
 
 ## [3.6.15] - 2023-03-06
 
 ### Fixed
 
-* Fixed the ability to move text to the next line with the Enter key in `Textarea`.
+- Fixed the ability to move text to the next line with the Enter key in `Textarea`.
 
 ## [3.6.14] - 2023-03-01
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.10 ~> 3.4.11]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.10 ~> 3.4.11]).
 
 ## [3.6.13] - 2023-02-22
 
@@ -496,394 +496,394 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.8 ~> 3.4.9], `@semcore/utils` [3.47.0 ~> 3.47.1]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.8 ~> 3.4.9], `@semcore/utils` [3.47.0 ~> 3.47.1]).
 
 ## [3.6.10] - 2023-02-09
 
 ### Changed
 
-* Renamed rounding design token (`--intergalactic-rounded-medium` -> `--intergalactic-control-rounded`).
+- Renamed rounding design token (`--intergalactic-rounded-medium` -> `--intergalactic-control-rounded`).
 
 ## [3.6.9] - 2023-01-20
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.5 ~> 3.4.6], `@semcore/utils` [3.45.0 ~> 3.46.0]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.5 ~> 3.4.6], `@semcore/utils` [3.45.0 ~> 3.46.0]).
 
 ## [3.6.6] - 2023-01-10
 
 ### Fixed
 
-* Fixed error loading styles in correct order for `mini-css-extract-plugin`.
+- Fixed error loading styles in correct order for `mini-css-extract-plugin`.
 
 ## [3.6.5] - 2023-01-10
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.1 ~> 3.4.2], `@semcore/utils` [3.44.1 ~> 3.44.2]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.1 ~> 3.4.2], `@semcore/utils` [3.44.1 ~> 3.44.2]).
 
 ## [3.6.3] - 2022-12-27
 
 ### Changed
 
-* `DropdownMenu.Popper` closes when the `Enter` button is pressed.
+- `DropdownMenu.Popper` closes when the `Enter` button is pressed.
 
 ## [3.6.2] - 2022-12-27
 
 ### Added
 
-* Added `box-sizing` for correct offset display.
+- Added `box-sizing` for correct offset display.
 
 ## [3.6.1] - 2022-12-19
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.0 ~> 3.4.1], `@semcore/utils` [3.44.0 ~> 3.44.1]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.0 ~> 3.4.1], `@semcore/utils` [3.44.0 ~> 3.44.1]).
 
 ## [3.6.0] - 2022-12-14
 
 ### Added
 
-* Added internationalization of aria attributes.
+- Added internationalization of aria attributes.
 
 ## [3.5.2] - 2022-12-13
 
 ### Fixed
 
-* Fix tabulation and moving highlighted items
+- Fix tabulation and moving highlighted items
 
 ## [3.5.1] - 2022-12-13
 
 ### Changed
 
-* Added `react-dom` to peer dependencies.
+- Added `react-dom` to peer dependencies.
 
 ## [3.5.0] - 2022-12-12
 
 ### Added
 
-* Design tokens based theming.
+- Design tokens based theming.
 
 ## [3.4.2] - 2022-12-01
 
 ### Changed
 
-* Changed size of shadow in `DropdownMenu.List` from `9px` to `16px`.
+- Changed size of shadow in `DropdownMenu.List` from `9px` to `16px`.
 
 ## [3.4.1] - 2022-11-30
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.2.5 ~> 3.2.6], `@semcore/flex-box` [4.6.4 ~> 4.6.5], `@semcore/utils` [3.41.0 ~> 3.42.0]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.2.5 ~> 3.2.6], `@semcore/flex-box` [4.6.4 ~> 4.6.5], `@semcore/utils` [3.41.0 ~> 3.42.0]).
 
 ## [3.4.0] - 2022-11-30
 
 ### Changed
 
-* Due to the effect of cutting off the last line, it was decided to add a shadow to the container (`DropdownMenu.List`) when scrolling.
-* Changed `margin` to `padding` to make the scrollbar look better.
+- Due to the effect of cutting off the last line, it was decided to add a shadow to the container (`DropdownMenu.List`) when scrolling.
+- Changed `margin` to `padding` to make the scrollbar look better.
 
 ## [3.3.4] - 2022-11-28
 
 ### Changed
 
-* Now highlighted tabs are also browser focused.
+- Now highlighted tabs are also browser focused.
 
 ## [3.3.3] - 2022-11-03
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.2.3 ~> 3.2.4]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.2.3 ~> 3.2.4]).
 
 ## [3.3.0] - 2022-10-17
 
 ### Fixed
 
-* Fixed wrong setting of `type=button` attribute for every `DropdownMenu.Trigger` based component.
+- Fixed wrong setting of `type=button` attribute for every `DropdownMenu.Trigger` based component.
 
 ## [3.2.1] - 2022-10-17
 
 ### Changed
 
-* Version patch update due to children dependencies update.
+- Version patch update due to children dependencies update.
 
 ## [3.2.0] - 2022-10-10
 
 ### Changed
 
-* Added support for React 18 🔥
+- Added support for React 18 🔥
 
 ## [3.1.2] - 2022-10-10
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/dropdown` [3.1.1 ~> 3.1.2]).
+- Version patch update due to children dependencies update (`@semcore/dropdown` [3.1.1 ~> 3.1.2]).
 
 ## [3.1.0] - 2022-09-07
 
 ### Added
 
-* Screen readers support.
+- Screen readers support.
 
 ## [3.0.12] - 2022-08-30
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.37.0 ~> 3.37.1], `@semcore/dropdown` [3.0.10 ~> 3.0.11]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.37.0 ~> 3.37.1], `@semcore/dropdown` [3.0.10 ~> 3.0.11]).
 
 ## [3.0.6] - 2022-07-12
 
 ### Fixed
 
-* Remove deprecated size (`xl`) type.
+- Remove deprecated size (`xl`) type.
 
 ## [3.0.5] - 2022-07-07
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.33.0 ~> 3.34.0], `@semcore/dropdown` [3.0.4 ~> 3.0.5]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.33.0 ~> 3.34.0], `@semcore/dropdown` [3.0.4 ~> 3.0.5]).
 
 ## [3.0.0] - 2022-05-17
 
 ### BREAK
 
-* Updated styles according to the library redesign policy.
-* Removed deprecated props `onSelect, optionCount, triggerType`.
-* Removed value "xl" for "size".
+- Updated styles according to the library redesign policy.
+- Removed deprecated props `onSelect, optionCount, triggerType`.
+- Removed value "xl" for "size".
 
 ## [2.3.12] - 2022-04-25
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/scroll-area` [3.7.0 ~> 3.7.1]).
+- Version patch update due to children dependencies update (`@semcore/scroll-area` [3.7.0 ~> 3.7.1]).
 
 ## [2.3.9] - 2022-03-09
 
 ### Fixed
 
-* Fixed enter space in input trigger for `DropdownMenu.Trigger`.
+- Fixed enter space in input trigger for `DropdownMenu.Trigger`.
 
 ## [2.3.8] - 2022-02-24
 
 ### Added
 
-* Added repository field to package.json file.
+- Added repository field to package.json file.
 
 ## [2.3.7] - 2021-8-26
 
 ### Changed
 
-* Add 'sideEffect=false' for more optimal build via webpack
+- Add 'sideEffect=false' for more optimal build via webpack
 
 ## [2.3.6] - 2021-08-18
 
 ### Fixed
 
-* Fixed typo in class names.
+- Fixed typo in class names.
 
 ## [2.3.5] - 2021-07-06
 
 ### Changed
 
-* Changed `tabIndex` to `0` and styles for `DropdowmMenu.Popper`.
+- Changed `tabIndex` to `0` and styles for `DropdowmMenu.Popper`.
 
 ## [2.3.4] - 2021-06-10
 
 ### Changed
 
-* Moved logic for checking interactive trigger to `Dropdown`.
+- Moved logic for checking interactive trigger to `Dropdown`.
 
 ## [2.3.3] - 2021-06-08
 
 ### Fixed
 
-* Fix TS type
+- Fix TS type
 
 ## [2.3.2] - 2021-05-17
 
 ### Changed
 
-* Version of dependence `@semcore/core` has been changed to `1.11`.
-* Improved performance. Removed one component wrapper.
+- Version of dependence `@semcore/core` has been changed to `1.11`.
+- Improved performance. Removed one component wrapper.
 
 ## [2.2.0] - 2020-12-17
 
 ### Added
 
-* Added supported react@17.
+- Added supported react@17.
 
 ## [2.1.2] - 2020-10-29
 
 ### Fixed
 
-* Added the placeholder for ID style tag to improve collision protection.
+- Added the placeholder for ID style tag to improve collision protection.
 
 ## [2.1.1] - 2020-10-14
 
 ### Fixed
 
-* fixed wrong path for ES6 build
+- fixed wrong path for ES6 build
 
 ## [2.1.0] - 2020-09-30
 
 ### Fixed
 
-* Fixed possible styles collisions between components with different versions, but same styles
+- Fixed possible styles collisions between components with different versions, but same styles
 
 ### Changed
 
-* Update @semcore/core version to ^1.8
+- Update @semcore/core version to ^1.8
 
 ## [2.0.5] - 2020-09-08
 
 ### Fixed
 
-* Fixed possible styles collisions between components with different versions, but same styles
+- Fixed possible styles collisions between components with different versions, but same styles
 
 ## [2.0.4] - 2020-07-14
 
 ### Changed
 
-* Улучшена производительность. Теперь внутренние компоненты не перерендриваються из-за создания новых функций-хендлеров.
+- Улучшена производительность. Теперь внутренние компоненты не перерендриваються из-за создания новых функций-хендлеров.
 
 ## [2.0.3] - 2020-06-10
 
 ### Fixed
 
-* Исправлены TS типы
+- Исправлены TS типы
 
 ## [2.0.1] - 2020-06-08
 
 ### Fixed
 
-* Исправлена типизация дочерних компонентов
-* Исправлена типизация `IDropdownMenuContext`
+- Исправлена типизация дочерних компонентов
+- Исправлена типизация `IDropdownMenuContext`
 
 ## [2.0.0] - 2020-06-01
 
 ### BREAK
 
-* Изменения описаны в [migration guide](/internal/migration-guide)
+- Изменения описаны в [migration guide](/internal/migration-guide)
 
 ## [1.4.0] - 2020-01-16
 
 ### Added
 
-* Добавлен компонент `DropdownMenu.ItemHint` и `DropdownMenu.ItemTitle` для отображениия подсказок и заголовков
+- Добавлен компонент `DropdownMenu.ItemHint` и `DropdownMenu.ItemTitle` для отображениия подсказок и заголовков
 
 ## [1.3.0] - 2019-12-12
 
 ### Added
 
-* Появилась возможность добавления различных стилистических тем через css переменные
-* Появилась возможность оптицонально подключать адаптивноссть
-* Появилась возможность изолировать стили даже в пределах одной страницы
+- Появилась возможность добавления различных стилистических тем через css переменные
+- Появилась возможность оптицонально подключать адаптивноссть
+- Появилась возможность изолировать стили даже в пределах одной страницы
 
 ### Changed
 
-* Изменен алгоритм вставки стилей в head
+- Изменен алгоритм вставки стилей в head
 
 ### Removed
 
-* Убраны относительные единицы измерения(rem), которые использовались для адаптивности
+- Убраны относительные единицы измерения(rem), которые использовались для адаптивности
 
 ## [1.2.10] - 2019-10-23
 
 ### Fixed
 
-* При нажатии на пробел в Input не происходит выбор подсвеченого элемента
+- При нажатии на пробел в Input не происходит выбор подсвеченого элемента
 
 ## [1.2.8] - 2019-09-30
 
 ### Changed
 
-* Нужные зависимости перенесены в `utils`, размер должен стать меньше
+- Нужные зависимости перенесены в `utils`, размер должен стать меньше
 
 ## [1.2.6] - 2019-09-13
 
 ### Fixed
 
-* События клавиатуры для открытия всплывающего окна (для button - "enter", "arrowDown", input - "arrowDown")
+- События клавиатуры для открытия всплывающего окна (для button - "enter", "arrowDown", input - "arrowDown")
 
 ## [1.2.5] - 2019-09-05
 
 ### Fixed
 
-* Исправлены ошибки типизации `DropdownMenu` & `Trigger`
+- Исправлены ошибки типизации `DropdownMenu` & `Trigger`
 
 ## [1.2.4] - 2019-08-02
 
 ### Changed
 
-* Обновлены зависимости
-* Добавлен `Item.Addon` от `MenuList.Item.Addon`
+- Обновлены зависимости
+- Добавлен `Item.Addon` от `MenuList.Item.Addon`
 
 ## [1.2.3] - 2019-08-01
 
 ### Fixed
 
-* Удалено поле `"": function(){}`, возвращаемое ф-цией `getTriggerProps` при `triggerType="input"`
+- Удалено поле `"": function(){}`, возвращаемое ф-цией `getTriggerProps` при `triggerType="input"`
 
 ## [1.2.2] - 2019-06-25
 
 ### Added
 
-* Добавлен `size="xl"`
+- Добавлен `size="xl"`
 
 ## [1.2.1] - 2019-05-13
 
 ### Changed
 
-* Обновлена зависимость @semcore/scroll-area
+- Обновлена зависимость @semcore/scroll-area
 
 ## [1.2.0] - 2019-05-13
 
 ### Added
 
-* Добавлена функция `getTriggerProps` для инпутов(например для фильтрации)
+- Добавлена функция `getTriggerProps` для инпутов(например для фильтрации)
 
 ### Changed
 
-* Контекст DropdownMenu и Popper смерджен
+- Контекст DropdownMenu и Popper смерджен
 
 ## [1.1.0] - 2019-04-09
 
 ### Added
 
-* Добавлена абстракция `DropdownMenu.Popper`
-* Добавлена абстракция `DropdownMenu.Menu`
-* В `DropdownMenu.Menu` добавлен компонент `@semcore/scroll-area`
+- Добавлена абстракция `DropdownMenu.Popper`
+- Добавлена абстракция `DropdownMenu.Menu`
+- В `DropdownMenu.Menu` добавлен компонент `@semcore/scroll-area`
 
 ## [1.0.4] - 2019-03-28
 
 ### Added
 
-* `IDropdowMenuCtx` расширен св-вом `multiselect`
+- `IDropdowMenuCtx` расширен св-вом `multiselect`
 
 ## [1.0.3] - 2019-03-18
 
 ### Added
 
-* новое свойство `triggerType`
+- новое свойство `triggerType`
 
 ### Changed
 
-* `DropdownMenu.List` теперь принимает в children не только jsx, но и ф-цию
+- `DropdownMenu.List` теперь принимает в children не только jsx, но и ф-цию
 
 ## [1.0.2] - 2018-02-26
 
 ### Fixed
 
-* Добавлены пропущенные типы для TS
+- Добавлены пропущенные типы для TS
 
 ## [1.0.1] - 2018-01-02
 
 ### Changed
 
-* Экспорт `PortalProvider`
+- Экспорт `PortalProvider`
 
 ## [1.0.0] - 2019-01-25
 
 ### Added
 
-* Initial release
+- Initial release

--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -13,6 +13,10 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 - When dropdown menu item has focusable elements inside, pressing tab locks focus inside the item. Closing or navigating inside the dropdown menu unlocks the focus.
 - If dropdown menu poppers placed to the left or right side of trigger, user needs to press `ArrowLeft` or `ArrowRight` to open the popper (`ArrowUp` or `ArrowDown` was opening popper with any placement before the change).
 
+### Added
+
+- `DropdownMenu.Nesting` component to support accessible nested dropdowns.
+
 ## [4.20.4] - 2024-02-19
 
 ### Changed

--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -2,316 +2,327 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.21.0] - 2024-02-15
+
+### Fixed
+
+* Assistive technologies were not announcing the selected item if dropdown contained focusable elements.
+
+### Changed
+
+* When dropdown menu item has focusable elements inside, pressing tab locks focus inside the item. Closing or navigating inside the dropdown menu unlocks the focus.
+* If dropdown menu poppers placed to the left or right side of trigger, user needs to press `ArrowLeft` or `ArrowRight` to open the popper (`ArrowUp` or `ArrowDown` was opening popper with any placement before the change).
+
 ## [4.20.4] - 2024-02-19
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.19.3 ~> 4.19.4]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.19.3 ~> 4.19.4]).
 
 ## [4.20.3] - 2024-02-16
 
 ### Fixed
 
-- Removed deprecation messages about `interaction` property (that were added by mistake).
+* Removed deprecation messages about `interaction` property (that were added by mistake).
 
 ## [4.20.2] - 2024-02-09
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.19.1 ~> 4.19.2], `@semcore/utils` [4.20.1 ~> 4.20.2], `@semcore/core` [2.17.1 ~> 2.17.2]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.19.1 ~> 4.19.2], `@semcore/utils` [4.20.1 ~> 4.20.2], `@semcore/core` [2.17.1 ~> 2.17.2]).
 
 ## [4.20.1] - 2024-02-06
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.19.0 ~> 4.19.1], `@semcore/flex-box` [5.18.0 ~> 5.19.0], `@semcore/utils` [4.20.0 ~> 4.20.1], `@semcore/core` [2.17.0 ~> 2.17.1]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.19.0 ~> 4.19.1], `@semcore/flex-box` [5.18.0 ~> 5.19.0], `@semcore/utils` [4.20.0 ~> 4.20.1], `@semcore/core` [2.17.0 ~> 2.17.1]).
 
 ## [4.20.0] - 2024-02-01
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.18.1 ~> 4.19.0], `@semcore/utils` [4.19.1 ~> 4.20.0], `@semcore/core` [2.16.1 ~> 2.17.0]).
+* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.18.1 ~> 4.19.0], `@semcore/utils` [4.19.1 ~> 4.20.0], `@semcore/core` [2.16.1 ~> 2.17.0]).
 
 ## [4.19.1] - 2024-02-01
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.18.0 ~> 4.18.1], `@semcore/utils` [4.19.0 ~> 4.19.1], `@semcore/core` [2.16.0 ~> 2.16.1]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.18.0 ~> 4.18.1], `@semcore/utils` [4.19.0 ~> 4.19.1], `@semcore/core` [2.16.0 ~> 2.16.1]).
 
 ## [4.19.0] - 2024-01-31
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.17.0 ~> 4.18.0], `@semcore/utils` [4.18.0 ~> 4.19.0], `@semcore/core` [2.15.0 ~> 2.16.0]).
+* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.17.0 ~> 4.18.0], `@semcore/utils` [4.18.0 ~> 4.19.0], `@semcore/core` [2.15.0 ~> 2.16.0]).
 
 ## [4.18.0] - 2024-01-19
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.16.0 ~> 4.17.0], `@semcore/utils` [4.17.0 ~> 4.18.0], `@semcore/core` [2.14.0 ~> 2.15.0]).
+* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.16.0 ~> 4.17.0], `@semcore/utils` [4.17.0 ~> 4.18.0], `@semcore/core` [2.14.0 ~> 2.15.0]).
 
 ## [4.17.0] - 2024-01-19
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.15.0 ~> 4.16.0], `@semcore/core` [2.13.1 ~> 2.14.0]).
+* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.15.0 ~> 4.16.0], `@semcore/core` [2.13.1 ~> 2.14.0]).
 
 ## [4.16.3] - 2024-01-10
 
 ### Fixed
 
-- Pressing `ArrowUp`/`ArrowDown` on closed `DropdownMenu` trigger was causing error in console.
+* Pressing `ArrowUp`/`ArrowDown` on closed `DropdownMenu` trigger was causing error in console.
 
 ## [4.16.2] - 2024-01-10
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.14.1 ~> 4.14.2], `@semcore/utils` [4.16.0 ~> 4.16.2], `@semcore/core` [2.13.0 ~> 2.13.1]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.14.1 ~> 4.14.2], `@semcore/utils` [4.16.0 ~> 4.16.2], `@semcore/core` [2.13.0 ~> 2.13.1]).
 
 ## [4.16.1] - 2024-01-04
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.14.0 ~> 4.14.1]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.14.0 ~> 4.14.1]).
 
 ## [4.16.0] - 2023-12-22
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.13.2 ~> 4.14.0], `@semcore/utils` [4.15.1 ~> 4.16.0], `@semcore/core` [2.12.1 ~> 2.13.0]).
+* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.13.2 ~> 4.14.0], `@semcore/utils` [4.15.1 ~> 4.16.0], `@semcore/core` [2.12.1 ~> 2.13.0]).
 
 ## [4.15.2] - 2023-12-19
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.13.1 ~> 4.13.2], `@semcore/utils` [4.15.0 ~> 4.15.1], `@semcore/core` [2.12.0 ~> 2.12.1]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.13.1 ~> 4.13.2], `@semcore/utils` [4.15.0 ~> 4.15.1], `@semcore/core` [2.12.0 ~> 2.12.1]).
 
 ## [4.15.1] - 2023-12-12
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.13.0 ~> 4.13.1]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.13.0 ~> 4.13.1]).
 
 ## [4.15.0] - 2023-12-05
 
 ### Changed
 
-- Deprecated some values of `interaction` property.
+* Deprecated some values of `interaction` property.
 
 ### Removed
 
-- unnecessary style for focused `Popper`.
+* unnecessary style for focused `Popper`.
 
 ## [4.14.0] - 2023-12-04
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.11.0 ~> 4.12.0], `@semcore/utils` [4.13.0 ~> 4.14.0], `@semcore/core` [2.10.0 ~> 2.11.0]).
+* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.11.0 ~> 4.12.0], `@semcore/utils` [4.13.0 ~> 4.14.0], `@semcore/core` [2.10.0 ~> 2.11.0]).
 
 ## [4.13.0] - 2023-11-23
 
 ### Added
 
-- Support for both non-focusable and focusable items in DropdownMenu.
+* Support for both non-focusable and focusable items in DropdownMenu.
 
 ## [4.12.6] - 2023-11-21
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.10.2 ~> 4.10.3], `@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/core` [2.9.1 ~> 2.9.2]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.10.2 ~> 4.10.3], `@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/core` [2.9.1 ~> 2.9.2]).
 
 ## [4.12.5] - 2023-11-10
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.10.1 ~> 4.10.2]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.10.1 ~> 4.10.2]).
 
 ## [4.12.4] - 2023-11-10
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/scroll-area` [5.12.1 ~> 5.12.2]).
+* Version prepatch update due to children dependencies update (`@semcore/scroll-area` [5.12.1 ~> 5.12.2]).
 
 ## [4.12.3] - 2023-11-09
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.10.0 ~> 4.10.1], `@semcore/utils` [4.10.1 ~> 4.10.2], `@semcore/core` [2.9.0 ~> 2.9.1]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.10.0 ~> 4.10.1], `@semcore/utils` [4.10.1 ~> 4.10.2], `@semcore/core` [2.9.0 ~> 2.9.1]).
 
 ## [4.12.2] - 2023-11-07
 
 ### Changed
 
-- Deprecated `notInteractive` prop.
+* Deprecated `notInteractive` prop.
 
 ## [4.12.0] - 2023-11-06
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.9.0 ~> 4.10.0], `@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/core` [2.8.0 ~> 2.9.0]).
+* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.9.0 ~> 4.10.0], `@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/core` [2.8.0 ~> 2.9.0]).
 
 ## [4.11.0] - 2023-10-27
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.8.3 ~> 4.9.0], `@semcore/utils` [4.8.4 ~> 4.9.0], `@semcore/core` [2.7.7 ~> 2.8.0]).
+* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.8.3 ~> 4.9.0], `@semcore/utils` [4.8.4 ~> 4.9.0], `@semcore/core` [2.7.7 ~> 2.8.0]).
 
 ## [4.10.3] - 2023-10-24
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.8.2 ~> 4.8.3], `@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/core` [2.7.6 ~> 2.7.7]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.8.2 ~> 4.8.3], `@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/core` [2.7.6 ~> 2.7.7]).
 
 ## [4.10.2] - 2023-10-16
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.8.1 ~> 4.8.2], `@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/core` [2.7.5 ~> 2.7.6]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.8.1 ~> 4.8.2], `@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/core` [2.7.5 ~> 2.7.6]).
 
 ## [4.10.1] - 2023-10-10
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.8.0 ~> 4.8.1], `@semcore/flex-box` [5.7.5 ~> 5.8.0]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.8.0 ~> 4.8.1], `@semcore/flex-box` [5.7.5 ~> 5.8.0]).
 
 ## [4.10.0] - 2023-10-09
 
 ### Added
 
-- `nl` locale support.
+* `nl` locale support.
 
 ## [4.9.5] - 2023-10-06
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.4 ~> 4.7.5], `@semcore/scroll-area` [5.9.4 ~> 5.9.5], `@semcore/utils` [4.8.1 ~> 4.8.2], `@semcore/core` [2.7.4 ~> 2.7.5]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.4 ~> 4.7.5], `@semcore/scroll-area` [5.9.4 ~> 5.9.5], `@semcore/utils` [4.8.1 ~> 4.8.2], `@semcore/core` [2.7.4 ~> 2.7.5]).
 
 ## [4.9.4] - 2023-10-03
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.3 ~> 4.7.4], `@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/core` [2.7.3 ~> 2.7.4]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.3 ~> 4.7.4], `@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/core` [2.7.3 ~> 2.7.4]).
 
 ## [4.9.3] - 2023-10-02
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.2 ~> 4.7.3], `@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/core` [2.7.2 ~> 2.7.3]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.2 ~> 4.7.3], `@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/core` [2.7.2 ~> 2.7.3]).
 
 ## [4.9.2] - 2023-09-20
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.1 ~> 4.7.2], `@semcore/core` [2.7.1 ~> 2.7.2]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.1 ~> 4.7.2], `@semcore/core` [2.7.1 ~> 2.7.2]).
 
 ## [4.9.1] - 2023-09-20
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.0 ~> 4.7.1], `@semcore/utils` [4.7.0 ~> 4.7.1], `@semcore/core` [2.7.0 ~> 2.7.1]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.7.0 ~> 4.7.1], `@semcore/utils` [4.7.0 ~> 4.7.1], `@semcore/core` [2.7.0 ~> 2.7.1]).
 
 ## [4.9.0] - 2023-09-13
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.6.3 ~> 4.7.0], `@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
+* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.6.3 ~> 4.7.0], `@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
 
 ## [4.8.3] - 2023-09-12
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.6.2 ~> 4.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.6.2 ~> 4.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
 
 ## [4.8.2] - 2023-09-08
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.6.1 ~> 4.6.2], `@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.6.1 ~> 4.6.2], `@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
 
 ## [4.8.1] - 2023-09-05
 
 ### Fixed
 
-- Both highlighted and selected menu items were not visually distinguishable from selected items.
-- `highlightedIndex` prop was added to `DropdownMenu.Menu` context type.
+* Both highlighted and selected menu items were not visually distinguishable from selected items.
+* `highlightedIndex` prop was added to `DropdownMenu.Menu` context type.
 
 ## [4.8.0] - 2023-09-04
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.5.0 ~> 4.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
+* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.5.0 ~> 4.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
 
 ## [4.7.0] - 2023-08-28
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.4.1 ~> 4.5.0], `@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
+* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.4.1 ~> 4.5.0], `@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
 
 ## [4.6.1] - 2023-08-24
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.4.0 ~> 4.4.1], `@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.4.0 ~> 4.4.1], `@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
 
 ## [4.6.0] - 2023-08-23
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/scroll-area` [5.5.0 ~> 5.6.0]).
+* Version preminor update due to children dependencies update (`@semcore/scroll-area` [5.5.0 ~> 5.6.0]).
 
 ## [4.5.0] - 2023-08-23
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.3.1 ~> 4.4.0], `@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
+* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.3.1 ~> 4.4.0], `@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
 
 ## [4.4.1] - 2023-08-21
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.3.0 ~> 4.3.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.3.0 ~> 4.3.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
 
 ## [4.4.0] - 2023-08-18
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/dropdown` [4.2.1 ~> 4.3.0], `@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
+* Version preminor update due to children dependencies update (`@semcore/dropdown` [4.2.1 ~> 4.3.0], `@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
 
 ## [4.3.0] - 2023-08-17
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/scroll-area` [5.2.1 ~> 5.3.0]).
+* Version preminor update due to children dependencies update (`@semcore/scroll-area` [5.2.1 ~> 5.3.0]).
 
 ## [4.2.1] - 2023-08-16
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.2.0 ~> 4.2.1], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/core` [2.2.0 ~> 2.2.1]).
+* Version prepatch update due to children dependencies update (`@semcore/dropdown` [4.2.0 ~> 4.2.1], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/core` [2.2.0 ~> 2.2.1]).
 
 ## [4.2.0] - 2023-08-07
 
 ### Changed
 
-- Version minor update due to children dependencies update (`@semcore/dropdown` [4.1.0 ~> 4.2.0], `@semcore/utils` [4.0.0 ~> 4.1.0]).
+* Version minor update due to children dependencies update (`@semcore/dropdown` [4.1.0 ~> 4.2.0], `@semcore/utils` [4.0.0 ~> 4.1.0]).
 
 ## [4.1.0] - 2023-08-01
 
 ### Changed
 
-- Version minor update due to children dependencies update (`@semcore/dropdown` [4.0.1 ~> 4.1.0], `@semcore/flex-box` [5.0.0 ~> 5.1.0]).
+* Version minor update due to children dependencies update (`@semcore/dropdown` [4.0.1 ~> 4.1.0], `@semcore/flex-box` [5.0.0 ~> 5.1.0]).
 
 ## [4.0.1] - 2023-07-18
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [4.0.0 ~> 4.0.1]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [4.0.0 ~> 4.0.1]).
 
 ## [4.0.0] - 2023-07-17
 
 ### Break
 
-- Strict, backward incompatible typings.
+* Strict, backward incompatible typings.
 
 ## [3.9.7] - 2023-06-30
 
@@ -319,7 +330,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.6.2 ~> 3.6.3], `@semcore/utils` [3.53.4 ~> 3.54.0]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.6.2 ~> 3.6.3], `@semcore/utils` [3.53.4 ~> 3.54.0]).
 
 ## [3.9.5] - 2023-06-22
 
@@ -327,7 +338,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.13 ~> 4.4.0]).
+* Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.13 ~> 4.4.0]).
 
 ## [3.9.3] - 2023-06-15
 
@@ -335,149 +346,149 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.6.0 ~> 3.6.1], `@semcore/utils` [3.53.3 ~> 3.53.4]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.6.0 ~> 3.6.1], `@semcore/utils` [3.53.3 ~> 3.53.4]).
 
 ## [3.9.1] - 2023-06-13
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.10 ~> 4.3.11]).
+* Version patch update due to children dependencies update (`@semcore/scroll-area` [4.3.10 ~> 4.3.11]).
 
 ## [3.9.0] - 2023-06-12
 
 ### Added
 
-- Swedish (`sv`) locale support.
+* Swedish (`sv`) locale support.
 
 ## [3.8.2] - 2023-06-12
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.5.1 ~> 3.5.2], `@semcore/utils` [3.53.2 ~> 3.53.3]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.5.1 ~> 3.5.2], `@semcore/utils` [3.53.2 ~> 3.53.3]).
 
 ## [3.8.1] - 2023-06-09
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.5.0 ~> 3.5.1], `@semcore/utils` [3.53.1 ~> 3.53.2]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.5.0 ~> 3.5.1], `@semcore/utils` [3.53.1 ~> 3.53.2]).
 
 ## [3.8.0] - 2023-06-09
 
 ### Added
 
-- Polish (`pl`) locale support.
+* Polish (`pl`) locale support.
 
 ## [3.7.4] - 2023-06-07
 
 ### Fixed
 
-- Improved `<Popper />` integration.
-- Fixed `aria-activedescendant` value.
-- Fixed double focus inside of popper.
+* Improved `<Popper />` integration.
+* Fixed `aria-activedescendant` value.
+* Fixed double focus inside of popper.
 
 ## [3.7.3] - 2023-05-31
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.33 ~> 3.4.34], `@semcore/utils` [3.52.0 ~> 3.53.0]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.33 ~> 3.4.34], `@semcore/utils` [3.52.0 ~> 3.53.0]).
 
 ## [3.7.2] - 2023-05-25
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.32 ~> 3.4.33], `@semcore/utils` [3.51.1 ~> 3.52.0]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.32 ~> 3.4.33], `@semcore/utils` [3.51.1 ~> 3.52.0]).
 
 ## [3.7.1] - 2023-05-24
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.31 ~> 3.4.32], `@semcore/utils` [3.51.0 ~> 3.51.1]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.31 ~> 3.4.32], `@semcore/utils` [3.51.0 ~> 3.51.1]).
 
 ## [3.7.0] - 2023-05-22
 
 ### Changed
 
-- Added visual cue to the `selected` DropdownMenu. Item.
+* Added visual cue to the `selected` DropdownMenu. Item.
 
 ## [3.6.36] - 2023-05-22
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.29 ~> 3.4.30]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.29 ~> 3.4.30]).
 
 ## [3.6.35] - 2023-05-11
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.28 ~> 3.4.29], `@semcore/utils` [3.50.6 ~> 3.50.7]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.28 ~> 3.4.29], `@semcore/utils` [3.50.6 ~> 3.50.7]).
 
 ## [3.6.34] - 2023-05-04
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.27 ~> 3.4.28], `@semcore/utils` [3.50.5 ~> 3.50.6]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.27 ~> 3.4.28], `@semcore/utils` [3.50.5 ~> 3.50.6]).
 
 ## [3.6.30] - 2023-05-02
 
 ### Changed
 
-- Removed `aria-flowto` because it has bad screen readers support and often confuse users in supporting screen readers.
+* Removed `aria-flowto` because it has bad screen readers support and often confuse users in supporting screen readers.
 
 ## [3.6.29] - 2023-04-24
 
 ### Fixed
 
-- Remove role for Title and Hint
+* Remove role for Title and Hint
 
 ## [3.6.27] - 2023-04-17
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.22 ~> 3.4.23], `@semcore/utils` [3.50.0 ~> 3.50.3]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.22 ~> 3.4.23], `@semcore/utils` [3.50.0 ~> 3.50.3]).
 
 ## [3.6.25] - 2023-03-28
 
 ### Added
 
-- Added default color (`--intergalactic-text-primary`) to the component.
+* Added default color (`--intergalactic-text-primary`) to the component.
 
 ## [3.6.24] - 2023-03-28
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.19 ~> 3.4.20], `@semcore/utils` [3.49.1 ~> 3.50.0]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.19 ~> 3.4.20], `@semcore/utils` [3.49.1 ~> 3.50.0]).
 
 ## [3.6.20] - 2023-03-23
 
 ### Added
 
-- Added `z-index: 0` to `DropdownMenu.List` so that it doesn't overlap the focus border of neighboring elements.
+* Added `z-index: 0` to `DropdownMenu.List` so that it doesn't overlap the focus border of neighboring elements.
 
 ## [3.6.19] - 2023-03-23
 
 ### Fixed
 
-- `aria-controls` and `aria-expanded` html attributes wasn't applied on closed dropdown.
-- Navigating options with keyboard now doesn't trigger browser focus.
-- `aria-activedescendant` now is properly updated on keyboard navigation.
+* `aria-controls` and `aria-expanded` html attributes wasn't applied on closed dropdown.
+* Navigating options with keyboard now doesn't trigger browser focus.
+* `aria-activedescendant` now is properly updated on keyboard navigation.
 
 ## [3.6.18] - 2023-03-22
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.14 ~> 3.4.15], `@semcore/utils` [3.47.3 ~> 3.47.4]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.14 ~> 3.4.15], `@semcore/utils` [3.47.3 ~> 3.47.4]).
 
 ## [3.6.15] - 2023-03-06
 
 ### Fixed
 
-- Fixed the ability to move text to the next line with the Enter key in `Textarea`.
+* Fixed the ability to move text to the next line with the Enter key in `Textarea`.
 
 ## [3.6.14] - 2023-03-01
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.10 ~> 3.4.11]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.10 ~> 3.4.11]).
 
 ## [3.6.13] - 2023-02-22
 
@@ -485,394 +496,394 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.8 ~> 3.4.9], `@semcore/utils` [3.47.0 ~> 3.47.1]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.8 ~> 3.4.9], `@semcore/utils` [3.47.0 ~> 3.47.1]).
 
 ## [3.6.10] - 2023-02-09
 
 ### Changed
 
-- Renamed rounding design token (`--intergalactic-rounded-medium` -> `--intergalactic-control-rounded`).
+* Renamed rounding design token (`--intergalactic-rounded-medium` -> `--intergalactic-control-rounded`).
 
 ## [3.6.9] - 2023-01-20
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.5 ~> 3.4.6], `@semcore/utils` [3.45.0 ~> 3.46.0]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.5 ~> 3.4.6], `@semcore/utils` [3.45.0 ~> 3.46.0]).
 
 ## [3.6.6] - 2023-01-10
 
 ### Fixed
 
-- Fixed error loading styles in correct order for `mini-css-extract-plugin`.
+* Fixed error loading styles in correct order for `mini-css-extract-plugin`.
 
 ## [3.6.5] - 2023-01-10
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.1 ~> 3.4.2], `@semcore/utils` [3.44.1 ~> 3.44.2]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.1 ~> 3.4.2], `@semcore/utils` [3.44.1 ~> 3.44.2]).
 
 ## [3.6.3] - 2022-12-27
 
 ### Changed
 
-- `DropdownMenu.Popper` closes when the `Enter` button is pressed.
+* `DropdownMenu.Popper` closes when the `Enter` button is pressed.
 
 ## [3.6.2] - 2022-12-27
 
 ### Added
 
-- Added `box-sizing` for correct offset display.
+* Added `box-sizing` for correct offset display.
 
 ## [3.6.1] - 2022-12-19
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.0 ~> 3.4.1], `@semcore/utils` [3.44.0 ~> 3.44.1]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.4.0 ~> 3.4.1], `@semcore/utils` [3.44.0 ~> 3.44.1]).
 
 ## [3.6.0] - 2022-12-14
 
 ### Added
 
-- Added internationalization of aria attributes.
+* Added internationalization of aria attributes.
 
 ## [3.5.2] - 2022-12-13
 
 ### Fixed
 
-- Fix tabulation and moving highlighted items
+* Fix tabulation and moving highlighted items
 
 ## [3.5.1] - 2022-12-13
 
 ### Changed
 
-- Added `react-dom` to peer dependencies.
+* Added `react-dom` to peer dependencies.
 
 ## [3.5.0] - 2022-12-12
 
 ### Added
 
-- Design tokens based theming.
+* Design tokens based theming.
 
 ## [3.4.2] - 2022-12-01
 
 ### Changed
 
-- Changed size of shadow in `DropdownMenu.List` from `9px` to `16px`.
+* Changed size of shadow in `DropdownMenu.List` from `9px` to `16px`.
 
 ## [3.4.1] - 2022-11-30
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.2.5 ~> 3.2.6], `@semcore/flex-box` [4.6.4 ~> 4.6.5], `@semcore/utils` [3.41.0 ~> 3.42.0]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.2.5 ~> 3.2.6], `@semcore/flex-box` [4.6.4 ~> 4.6.5], `@semcore/utils` [3.41.0 ~> 3.42.0]).
 
 ## [3.4.0] - 2022-11-30
 
 ### Changed
 
-- Due to the effect of cutting off the last line, it was decided to add a shadow to the container (`DropdownMenu.List`) when scrolling.
-- Changed `margin` to `padding` to make the scrollbar look better.
+* Due to the effect of cutting off the last line, it was decided to add a shadow to the container (`DropdownMenu.List`) when scrolling.
+* Changed `margin` to `padding` to make the scrollbar look better.
 
 ## [3.3.4] - 2022-11-28
 
 ### Changed
 
-- Now highlighted tabs are also browser focused.
+* Now highlighted tabs are also browser focused.
 
 ## [3.3.3] - 2022-11-03
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.2.3 ~> 3.2.4]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.2.3 ~> 3.2.4]).
 
 ## [3.3.0] - 2022-10-17
 
 ### Fixed
 
-- Fixed wrong setting of `type=button` attribute for every `DropdownMenu.Trigger` based component.
+* Fixed wrong setting of `type=button` attribute for every `DropdownMenu.Trigger` based component.
 
 ## [3.2.1] - 2022-10-17
 
 ### Changed
 
-- Version patch update due to children dependencies update.
+* Version patch update due to children dependencies update.
 
 ## [3.2.0] - 2022-10-10
 
 ### Changed
 
-- Added support for React 18 🔥
+* Added support for React 18 🔥
 
 ## [3.1.2] - 2022-10-10
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/dropdown` [3.1.1 ~> 3.1.2]).
+* Version patch update due to children dependencies update (`@semcore/dropdown` [3.1.1 ~> 3.1.2]).
 
 ## [3.1.0] - 2022-09-07
 
 ### Added
 
-- Screen readers support.
+* Screen readers support.
 
 ## [3.0.12] - 2022-08-30
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.37.0 ~> 3.37.1], `@semcore/dropdown` [3.0.10 ~> 3.0.11]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.37.0 ~> 3.37.1], `@semcore/dropdown` [3.0.10 ~> 3.0.11]).
 
 ## [3.0.6] - 2022-07-12
 
 ### Fixed
 
-- Remove deprecated size (`xl`) type.
+* Remove deprecated size (`xl`) type.
 
 ## [3.0.5] - 2022-07-07
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.33.0 ~> 3.34.0], `@semcore/dropdown` [3.0.4 ~> 3.0.5]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.33.0 ~> 3.34.0], `@semcore/dropdown` [3.0.4 ~> 3.0.5]).
 
 ## [3.0.0] - 2022-05-17
 
 ### BREAK
 
-- Updated styles according to the library redesign policy.
-- Removed deprecated props `onSelect, optionCount, triggerType`.
-- Removed value "xl" for "size".
+* Updated styles according to the library redesign policy.
+* Removed deprecated props `onSelect, optionCount, triggerType`.
+* Removed value "xl" for "size".
 
 ## [2.3.12] - 2022-04-25
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/scroll-area` [3.7.0 ~> 3.7.1]).
+* Version patch update due to children dependencies update (`@semcore/scroll-area` [3.7.0 ~> 3.7.1]).
 
 ## [2.3.9] - 2022-03-09
 
 ### Fixed
 
-- Fixed enter space in input trigger for `DropdownMenu.Trigger`.
+* Fixed enter space in input trigger for `DropdownMenu.Trigger`.
 
 ## [2.3.8] - 2022-02-24
 
 ### Added
 
-- Added repository field to package.json file.
+* Added repository field to package.json file.
 
 ## [2.3.7] - 2021-8-26
 
 ### Changed
 
-- Add 'sideEffect=false' for more optimal build via webpack
+* Add 'sideEffect=false' for more optimal build via webpack
 
 ## [2.3.6] - 2021-08-18
 
 ### Fixed
 
-- Fixed typo in class names.
+* Fixed typo in class names.
 
 ## [2.3.5] - 2021-07-06
 
 ### Changed
 
-- Changed `tabIndex` to `0` and styles for `DropdowmMenu.Popper`.
+* Changed `tabIndex` to `0` and styles for `DropdowmMenu.Popper`.
 
 ## [2.3.4] - 2021-06-10
 
 ### Changed
 
-- Moved logic for checking interactive trigger to `Dropdown`.
+* Moved logic for checking interactive trigger to `Dropdown`.
 
 ## [2.3.3] - 2021-06-08
 
 ### Fixed
 
-- Fix TS type
+* Fix TS type
 
 ## [2.3.2] - 2021-05-17
 
 ### Changed
 
-- Version of dependence `@semcore/core` has been changed to `1.11`.
-- Improved performance. Removed one component wrapper.
+* Version of dependence `@semcore/core` has been changed to `1.11`.
+* Improved performance. Removed one component wrapper.
 
 ## [2.2.0] - 2020-12-17
 
 ### Added
 
-- Added supported react@17.
+* Added supported react@17.
 
 ## [2.1.2] - 2020-10-29
 
 ### Fixed
 
-- Added the placeholder for ID style tag to improve collision protection.
+* Added the placeholder for ID style tag to improve collision protection.
 
 ## [2.1.1] - 2020-10-14
 
 ### Fixed
 
-- fixed wrong path for ES6 build
+* fixed wrong path for ES6 build
 
 ## [2.1.0] - 2020-09-30
 
 ### Fixed
 
-- Fixed possible styles collisions between components with different versions, but same styles
+* Fixed possible styles collisions between components with different versions, but same styles
 
 ### Changed
 
-- Update @semcore/core version to ^1.8
+* Update @semcore/core version to ^1.8
 
 ## [2.0.5] - 2020-09-08
 
 ### Fixed
 
-- Fixed possible styles collisions between components with different versions, but same styles
+* Fixed possible styles collisions between components with different versions, but same styles
 
 ## [2.0.4] - 2020-07-14
 
 ### Changed
 
-- Улучшена производительность. Теперь внутренние компоненты не перерендриваються из-за создания новых функций-хендлеров.
+* Улучшена производительность. Теперь внутренние компоненты не перерендриваються из-за создания новых функций-хендлеров.
 
 ## [2.0.3] - 2020-06-10
 
 ### Fixed
 
-- Исправлены TS типы
+* Исправлены TS типы
 
 ## [2.0.1] - 2020-06-08
 
 ### Fixed
 
-- Исправлена типизация дочерних компонентов
-- Исправлена типизация `IDropdownMenuContext`
+* Исправлена типизация дочерних компонентов
+* Исправлена типизация `IDropdownMenuContext`
 
 ## [2.0.0] - 2020-06-01
 
 ### BREAK
 
-- Изменения описаны в [migration guide](/internal/migration-guide)
+* Изменения описаны в [migration guide](/internal/migration-guide)
 
 ## [1.4.0] - 2020-01-16
 
 ### Added
 
-- Добавлен компонент `DropdownMenu.ItemHint` и `DropdownMenu.ItemTitle` для отображениия подсказок и заголовков
+* Добавлен компонент `DropdownMenu.ItemHint` и `DropdownMenu.ItemTitle` для отображениия подсказок и заголовков
 
 ## [1.3.0] - 2019-12-12
 
 ### Added
 
-- Появилась возможность добавления различных стилистических тем через css переменные
-- Появилась возможность оптицонально подключать адаптивноссть
-- Появилась возможность изолировать стили даже в пределах одной страницы
+* Появилась возможность добавления различных стилистических тем через css переменные
+* Появилась возможность оптицонально подключать адаптивноссть
+* Появилась возможность изолировать стили даже в пределах одной страницы
 
 ### Changed
 
-- Изменен алгоритм вставки стилей в head
+* Изменен алгоритм вставки стилей в head
 
 ### Removed
 
-- Убраны относительные единицы измерения(rem), которые использовались для адаптивности
+* Убраны относительные единицы измерения(rem), которые использовались для адаптивности
 
 ## [1.2.10] - 2019-10-23
 
 ### Fixed
 
-- При нажатии на пробел в Input не происходит выбор подсвеченого элемента
+* При нажатии на пробел в Input не происходит выбор подсвеченого элемента
 
 ## [1.2.8] - 2019-09-30
 
 ### Changed
 
-- Нужные зависимости перенесены в `utils`, размер должен стать меньше
+* Нужные зависимости перенесены в `utils`, размер должен стать меньше
 
 ## [1.2.6] - 2019-09-13
 
 ### Fixed
 
-- События клавиатуры для открытия всплывающего окна (для button - "enter", "arrowDown", input - "arrowDown")
+* События клавиатуры для открытия всплывающего окна (для button - "enter", "arrowDown", input - "arrowDown")
 
 ## [1.2.5] - 2019-09-05
 
 ### Fixed
 
-- Исправлены ошибки типизации `DropdownMenu` & `Trigger`
+* Исправлены ошибки типизации `DropdownMenu` & `Trigger`
 
 ## [1.2.4] - 2019-08-02
 
 ### Changed
 
-- Обновлены зависимости
-- Добавлен `Item.Addon` от `MenuList.Item.Addon`
+* Обновлены зависимости
+* Добавлен `Item.Addon` от `MenuList.Item.Addon`
 
 ## [1.2.3] - 2019-08-01
 
 ### Fixed
 
-- Удалено поле `"": function(){}`, возвращаемое ф-цией `getTriggerProps` при `triggerType="input"`
+* Удалено поле `"": function(){}`, возвращаемое ф-цией `getTriggerProps` при `triggerType="input"`
 
 ## [1.2.2] - 2019-06-25
 
 ### Added
 
-- Добавлен `size="xl"`
+* Добавлен `size="xl"`
 
 ## [1.2.1] - 2019-05-13
 
 ### Changed
 
-- Обновлена зависимость @semcore/scroll-area
+* Обновлена зависимость @semcore/scroll-area
 
 ## [1.2.0] - 2019-05-13
 
 ### Added
 
-- Добавлена функция `getTriggerProps` для инпутов(например для фильтрации)
+* Добавлена функция `getTriggerProps` для инпутов(например для фильтрации)
 
 ### Changed
 
-- Контекст DropdownMenu и Popper смерджен
+* Контекст DropdownMenu и Popper смерджен
 
 ## [1.1.0] - 2019-04-09
 
 ### Added
 
-- Добавлена абстракция `DropdownMenu.Popper`
-- Добавлена абстракция `DropdownMenu.Menu`
-- В `DropdownMenu.Menu` добавлен компонент `@semcore/scroll-area`
+* Добавлена абстракция `DropdownMenu.Popper`
+* Добавлена абстракция `DropdownMenu.Menu`
+* В `DropdownMenu.Menu` добавлен компонент `@semcore/scroll-area`
 
 ## [1.0.4] - 2019-03-28
 
 ### Added
 
-- `IDropdowMenuCtx` расширен св-вом `multiselect`
+* `IDropdowMenuCtx` расширен св-вом `multiselect`
 
 ## [1.0.3] - 2019-03-18
 
 ### Added
 
-- новое свойство `triggerType`
+* новое свойство `triggerType`
 
 ### Changed
 
-- `DropdownMenu.List` теперь принимает в children не только jsx, но и ф-цию
+* `DropdownMenu.List` теперь принимает в children не только jsx, но и ф-цию
 
 ## [1.0.2] - 2018-02-26
 
 ### Fixed
 
-- Добавлены пропущенные типы для TS
+* Добавлены пропущенные типы для TS
 
 ## [1.0.1] - 2018-01-02
 
 ### Changed
 
-- Экспорт `PortalProvider`
+* Экспорт `PortalProvider`
 
 ## [1.0.0] - 2019-01-25
 
 ### Added
 
-- Initial release
+* Initial release

--- a/semcore/dropdown-menu/__tests__/index.test.tsx
+++ b/semcore/dropdown-menu/__tests__/index.test.tsx
@@ -174,11 +174,12 @@ describe('DropdownMenu', () => {
     await expect(await snapshot(component)).toMatchImageSnapshot(task);
   });
 
-  test('support items and focusable elements at the same time', async ({ expect }) => {
+  test.only('support items and focusable elements at the same time', async ({ expect }) => {
     const spy = vi.fn();
     const buttonSpy = vi.fn();
     const { getByTestId } = render(
       <DropdownMenu visible>
+        <DropdownMenu.Trigger tag='button'>trigger</DropdownMenu.Trigger>
         <DropdownMenu.Menu>
           <DropdownMenu.Item onClick={spy}>Item 1</DropdownMenu.Item>
           <DropdownMenu.Item>Item 2</DropdownMenu.Item>
@@ -198,6 +199,7 @@ describe('DropdownMenu', () => {
     await userEvent.keyboard('[Enter]');
     expect(spy).toHaveBeenCalled();
 
+    await userEvent.keyboard('[Tab]');
     await userEvent.keyboard('[Tab]');
     expect(acceptButton).toHaveFocus();
 

--- a/semcore/dropdown-menu/__tests__/index.test.tsx
+++ b/semcore/dropdown-menu/__tests__/index.test.tsx
@@ -174,7 +174,7 @@ describe('DropdownMenu', () => {
     await expect(await snapshot(component)).toMatchImageSnapshot(task);
   });
 
-  test.concurrent('support items and focusable elements at the same time', async ({ expect }) => {
+  test('support items and focusable elements at the same time', async ({ expect }) => {
     const spy = vi.fn();
     const buttonSpy = vi.fn();
     const { getByTestId } = render(
@@ -206,9 +206,48 @@ describe('DropdownMenu', () => {
     expect(spy).toHaveBeenCalledTimes(1);
 
     await userEvent.keyboard('[ArrowDown]');
+    await userEvent.keyboard('[ArrowDown]');
     await userEvent.keyboard('[Enter]');
     expect(spy).toHaveBeenCalledTimes(2);
     expect(buttonSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('support focusable element in Dropdown item', async ({ expect }) => {
+    const spy = vi.fn();
+    const buttonSpy = vi.fn();
+    const { getByTestId } = render(
+      <DropdownMenu visible>
+        <DropdownMenu.Menu>
+          <DropdownMenu.Item onClick={spy}>Item 1</DropdownMenu.Item>
+          <DropdownMenu.Item>
+            Item 2
+            <Button data-testid={'testButton'} onClick={buttonSpy}>
+              Test Button
+            </Button>
+          </DropdownMenu.Item>
+        </DropdownMenu.Menu>
+      </DropdownMenu>,
+    );
+
+    const testButton = getByTestId('testButton');
+
+    await userEvent.keyboard('[Tab]');
+    await userEvent.keyboard('[Tab]');
+
+    await userEvent.keyboard('[ArrowDown]');
+    await userEvent.keyboard('[Enter]');
+    expect(spy).toHaveBeenCalled();
+
+    await userEvent.keyboard('[ArrowDown]');
+    await userEvent.keyboard('[Tab]');
+    expect(testButton).toHaveFocus();
+
+    await userEvent.keyboard('[Enter]');
+    expect(buttonSpy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    await userEvent.keyboard('[Tab]');
+    expect(testButton).toHaveFocus();
   });
 
   test('a11y', async () => {

--- a/semcore/dropdown-menu/package.json
+++ b/semcore/dropdown-menu/package.json
@@ -34,6 +34,8 @@
     "@guidepup/playwright": "0.6.1",
     "@playwright/test": "1.25.1",
     "@semcore/testing-utils": "1.0.0",
+    "@semcore/base-trigger": "4.26.1",
+    "@semcore/icon": "4.26.0",
     "@semcore/button": "workspace:*"
   }
 }

--- a/semcore/dropdown-menu/src/index.d.ts
+++ b/semcore/dropdown-menu/src/index.d.ts
@@ -146,6 +146,15 @@ declare const DropdownMenu: Intergalactic.Component<
   };
   ItemTitle: Intergalactic.Component<'div', DropdownMenuItemTitleProps>;
   ItemHint: Intergalactic.Component<'div', DropdownMenuItemHintProps>;
+  Nesting: Intergalactic.Component<
+    'div',
+    DropdownMenuItemProps,
+    DropdownMenuContext,
+    [handlers: DropdownMenuHandlers]
+  > & {
+    Trigger: Intergalactic.Component<'div', DropdownMenuItemProps>;
+    Addon: typeof Box;
+  };
 };
 
 export default DropdownMenu;

--- a/semcore/dropdown-menu/src/style/dropdown-menu.shadow.css
+++ b/semcore/dropdown-menu/src/style/dropdown-menu.shadow.css
@@ -40,7 +40,7 @@ SDropdownMenuItem[selected] {
   }
 }
 
-SDropdownMenuItem[highlighted] {
+SDropdownMenuItem[highlighted]:not(:focus-within) {
   z-index: 1;
   box-shadow: var(--intergalactic-keyboard-focus, 0px 0px 0px 3px rgba(0, 143, 248, 0.5)) inset;
 }

--- a/semcore/dropdown-menu/src/style/dropdown-menu.shadow.css
+++ b/semcore/dropdown-menu/src/style/dropdown-menu.shadow.css
@@ -91,6 +91,14 @@ SDropdownMenuItem[variant='title'] {
   }
 }
 
+SDropdownMenuItem[visible] {
+  background-color: var(--intergalactic-dropdown-menu-item-hover, #f4f5f9);
+}
+
+SDropdownMenuItem[nesting-trigger] {
+  justify-content: space-between;
+}
+
 SDropdownMenuItemAddon {
   display: inline-flex;
   margin-left: var(--intergalactic-spacing-2x, 8px);
@@ -103,4 +111,15 @@ SDropdownMenuItemAddon {
   &:last-child {
     margin-right: 0;
   }
+}
+
+SDropdownMenuNesting,
+SDropdownMenuNesting[size='l'],
+SDropdownMenuNesting[size='m'] {
+  padding: 0;
+}
+
+SDropdownMenuNesting[highlighted] {
+  z-index: 1;
+  box-shadow: var(--intergalactic-keyboard-focus, 0px 0px 0px 3px rgba(0, 143, 248, 0.5)) inset;
 }

--- a/semcore/utils/src/use/useFocusLock.ts
+++ b/semcore/utils/src/use/useFocusLock.ts
@@ -122,6 +122,12 @@ const useFocusLockHook = (
           ? [trapRef.current]
           : [trapRef.current, ...focusLockAllTraps];
         if (isFocusInside(trapNodes, focusMovedTo)) return;
+        if (
+          typeof returnFocusTo === 'object' &&
+          returnFocusTo?.current &&
+          isFocusInside(returnFocusTo.current)
+        )
+          return;
 
         if (focusCameFrom) {
           setFocus(trapRef.current, focusCameFrom, focusMovedTo);
@@ -165,6 +171,10 @@ const useFocusLockHook = (
     if (disabled) return;
     if (!canUseDOM()) return;
     if (!trapRef.current) return;
+    const focusableChildren = Array.from(trapRef.current.children).flatMap((node) =>
+      getFocusableIn(node as HTMLElement),
+    );
+    if (focusableChildren.length === 0) return;
 
     if (focusMaster) {
       focusMastersStack.push(trapRef.current);

--- a/website/docs/components/dropdown-menu/examples/nested.tsx
+++ b/website/docs/components/dropdown-menu/examples/nested.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import DropdownMenu from '@semcore/ui/dropdown-menu';
 import { ButtonTrigger } from '@semcore/ui/base-trigger';
-import ChevronRight from '@semcore/ui/icon/ChevronRight/m';
+import ChevronRightIcon from '@semcore/ui/icon/ChevronRight/m';
 
 const Demo = () => {
   return (
@@ -9,26 +9,58 @@ const Demo = () => {
       <DropdownMenu.Trigger tag={ButtonTrigger}>Click me</DropdownMenu.Trigger>
       <DropdownMenu.Menu>
         <DropdownMenu.Item>Item 1</DropdownMenu.Item>
-        <DropdownMenu placement='right' interaction='hover' timeout={[0, 300]}>
-          <DropdownMenu.Trigger tag={DropdownMenu.Item}>
-            Item 2 <ChevronRight ml='auto' color='icon-primary-neutral' />
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Menu w={120}>
-            <DropdownMenu.Item>Item 1</DropdownMenu.Item>
-            <DropdownMenu.Item>Item 2</DropdownMenu.Item>
-            <DropdownMenu placement='right' interaction='hover' timeout={[0, 300]}>
-              <DropdownMenu.Trigger tag={DropdownMenu.Item}>
-                Item 3 <ChevronRight ml='auto' color='icon-primary-neutral' />
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Menu w={120}>
-                <DropdownMenu.Item>Item 1</DropdownMenu.Item>
-                <DropdownMenu.Item>Item 2</DropdownMenu.Item>
-                <DropdownMenu.Item>Item 3</DropdownMenu.Item>
-              </DropdownMenu.Menu>
-            </DropdownMenu>
-          </DropdownMenu.Menu>
-        </DropdownMenu>
+        <DropdownMenu.Item>Item 2</DropdownMenu.Item>
         <DropdownMenu.Item>Item 3</DropdownMenu.Item>
+        <DropdownMenu.Nesting>
+          <DropdownMenu placement='right' interaction='hover' timeout={[0, 300]}>
+            <DropdownMenu.Trigger tag={DropdownMenu.Nesting.Trigger}>
+              Item 4
+              <DropdownMenu.Nesting.Addon tag={ChevronRightIcon} />
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Menu w={120}>
+              <DropdownMenu.Nesting>
+                <DropdownMenu placement='right' interaction='hover' timeout={[0, 300]}>
+                  <DropdownMenu.Trigger tag={DropdownMenu.Nesting.Trigger}>
+                    Item 4.1
+                    <DropdownMenu.Nesting.Addon tag={ChevronRightIcon} />
+                  </DropdownMenu.Trigger>
+                  <DropdownMenu.Menu w={120}>
+                    <DropdownMenu.Item>Item 4.1.1</DropdownMenu.Item>
+                    <DropdownMenu.Item>Item 4.1.2</DropdownMenu.Item>
+                    <DropdownMenu.Item>Item 4.1.3</DropdownMenu.Item>
+                  </DropdownMenu.Menu>
+                </DropdownMenu>
+              </DropdownMenu.Nesting>
+              <DropdownMenu.Nesting>
+                <DropdownMenu placement='right' interaction='hover' timeout={[0, 300]}>
+                  <DropdownMenu.Trigger tag={DropdownMenu.Nesting.Trigger}>
+                    Item 4.2
+                    <DropdownMenu.Nesting.Addon tag={ChevronRightIcon} />
+                  </DropdownMenu.Trigger>
+                  <DropdownMenu.Menu w={120}>
+                    <DropdownMenu.Nesting>
+                      <DropdownMenu placement='right' interaction='hover' timeout={[0, 300]}>
+                        <DropdownMenu.Trigger tag={DropdownMenu.Nesting.Trigger}>
+                          Item 4.2.1
+                          <DropdownMenu.Nesting.Addon tag={ChevronRightIcon} />
+                        </DropdownMenu.Trigger>
+                        <DropdownMenu.Menu w={120}>
+                          <DropdownMenu.Item>Item 4.2.1.1</DropdownMenu.Item>
+                          <DropdownMenu.Item>Item 4.2.1.2</DropdownMenu.Item>
+                          <DropdownMenu.Item>Item 4.2.1.3</DropdownMenu.Item>
+                        </DropdownMenu.Menu>
+                      </DropdownMenu>
+                    </DropdownMenu.Nesting>
+                    <DropdownMenu.Item>Item 4.2.2</DropdownMenu.Item>
+                    <DropdownMenu.Item>Item 4.2.3</DropdownMenu.Item>
+                  </DropdownMenu.Menu>
+                </DropdownMenu>
+              </DropdownMenu.Nesting>
+              <DropdownMenu.Item>Item 4.3</DropdownMenu.Item>
+            </DropdownMenu.Menu>
+          </DropdownMenu>
+        </DropdownMenu.Nesting>
+        <DropdownMenu.Item>Item 5</DropdownMenu.Item>
       </DropdownMenu.Menu>
     </DropdownMenu>
   );


### PR DESCRIPTION
## Motivation and Context

This PR is based on #1100 and provides alternative approach to fix dropdown menu a11y.

Key differences:
1. Changes in this PR doesn't include moving `aria-activedescendant` from trigger to popper as it breaks combobox pattern support.
2. Changes in this PR includes little fixes in focus lock that crucial for correct focus lock in Dropdown Menu items.
3. Instead of creating an independent focus management system, a common focus lock is used.
4. PR also includes fixes applied to keydowns handling that are important for nested dropdowns.


## How has this been tested?

Unit tests & manual testing. Also I was testing it with nested dropdowns.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [x] I have added new unit tests on added of fixed functionality.
