### PR TITLE
[86bxce63v][popper, tooltip] improved tooltip singleton example

### DIFF
--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.20.1] - 2024-02-16
+
+### Fixed
+
+- Focusing trigger right after popper had been closed by mouse leave was not opening popper again.
+
 ## [5.20.0] - 2024-02-06
 
 ### Added

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -281,7 +281,7 @@ class Popper extends Component {
       }, 0);
     });
     const ignoringDuration = 2000;
-    if (!visible) {
+    if (!visible && ['onClick', 'onBlur'].includes(action)) {
       this.setState({
         ignoreTriggerFocusUntil: now + ignoringDuration,
       });

--- a/website/docs/components/tooltip/examples/singleton.tsx
+++ b/website/docs/components/tooltip/examples/singleton.tsx
@@ -6,20 +6,49 @@ const options = Array(50)
   .fill('')
   .map((_, index) => `Option ${index}`);
 
-const Demo = () => (
-  <Select>
-    <Select.Trigger placeholder='Select option' />
-    <Select.Menu>
-      <Tooltip timeout={[0, 50]} placement='right'>
-        {options.map((option, index) => (
-          <Select.Option value={option} key={index} tag={Tooltip.Trigger}>
-            {option}
-          </Select.Option>
-        ))}
-        <Tooltip.Popper w={86}>Hey there!</Tooltip.Popper>
-      </Tooltip>
-    </Select.Menu>
-  </Select>
+const tooltipIndexContext = React.createContext(0);
+
+const TooltipContent = () => {
+  const tooltipIndex = React.useContext(tooltipIndexContext);
+  return <>Option {tooltipIndex} description</>;
+};
+
+const SelectWithTooltip = React.memo(
+  ({ setTooltipIndex }: { setTooltipIndex: (number) => void }) => {
+    return (
+      <Select onHighlightedIndexChange={setTooltipIndex}>
+        <Select.Trigger placeholder='Select option' />
+        <Select.Menu>
+          <Tooltip timeout={[0, 50]} placement='right'>
+            {options.map((option, index) => (
+              <Select.Option
+                onMouseEnter={() => setTooltipIndex(index)}
+                value={option}
+                key={index}
+                tag={Tooltip.Trigger}
+              >
+                {option}
+              </Select.Option>
+            ))}
+            <Tooltip.Popper w={200}>
+              <TooltipContent />
+            </Tooltip.Popper>
+          </Tooltip>
+        </Select.Menu>
+      </Select>
+    );
+  },
+  () => true,
 );
+
+const Demo = () => {
+  const [tooltipIndex, setTooltipIndex] = React.useState(0);
+
+  return (
+    <tooltipIndexContext.Provider value={tooltipIndex}>
+      <SelectWithTooltip setTooltipIndex={setTooltipIndex} />
+    </tooltipIndexContext.Provider>
+  );
+};
 
 export default Demo;

--- a/website/docs/components/tooltip/tooltip-code.md
+++ b/website/docs/components/tooltip/tooltip-code.md
@@ -55,7 +55,7 @@ To make use of Tooltip accessible for assistive tocologies, the `aria-describedb
 
 ## Singleton
 
-You can use a single tooltip for multiple reference elements. This allows you to "group" tooltips with a shared timer to improve the user experience.
+You can use a single tooltip for multiple reference elements. This allows you to "group" tooltips with a shared timer to improve the user experience. This example uses React context and memo to bypass select component rerendering and much improve performance during quick navigation.
 
 ::: sandbox
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Our tooltip singleton example was almost useless because it contained same tooltip content for every option.
I have update example to deal with it.

Also I found a bug in hour popper prevents infinite popper reopens on trigger focus.

Also I made singleton example weird a bit  after finding out that added state rerenders whole example with select and makes all example unusable.


## How has this been tested?

Manual testing only.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
