### PR TITLE
[86bxht8wd][base-trigger] fixed pressing enter in forms was triggering `FilterTrigger` to open

### DIFF
--- a/semcore/base-trigger/CHANGELOG.md
+++ b/semcore/base-trigger/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.26.1] - 2024-02-19
+
+### Fixed
+
+- Pressing enter in forms was triggering `FilterTrigger` to open.
+
 ## [4.26.0] - 2024-02-14
 
 ### Changed

--- a/semcore/base-trigger/src/FilterTrigger.jsx
+++ b/semcore/base-trigger/src/FilterTrigger.jsx
@@ -86,6 +86,7 @@ class RootFilterTrigger extends Component {
         <NeighborLocation>
           <SFilterTrigger
             tag='button'
+            type='button'
             w='100%'
             size={size}
             placeholder={placeholder}
@@ -108,6 +109,7 @@ class RootFilterTrigger extends Component {
           {!empty && (
             <SFilterTrigger
               tag='button'
+              type='button'
               size={size}
               empty={empty}
               selected


### PR DESCRIPTION
## Motivation and Context

When `button` tags was added to FilterTrigger, `type="button"` was forgotten to be added. So, in forms FilterTriggers was always considered (by browsers) as submit buttons. It was causing them to open on form submit instead of real form submitting.

## How has this been tested?

Too stupid fix. Manual testing was enough.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
