### PR TITLE
[d3-chart, docs] fixed types

### DIFF
--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.28.1] - 2024-02-19
+
+### Fixed
+
+- `patterns` prop was missing in multiple chart types.
+
 ## [2.28.0] - 2024-02-13
 
 ### Changed

--- a/semcore/d3-chart/src/types/Area.d.ts
+++ b/semcore/d3-chart/src/types/Area.d.ts
@@ -2,6 +2,7 @@ import { UnknownProperties } from '@semcore/core';
 import { Context } from './context';
 import { CurveFactory } from 'd3-shape';
 import { IntergalacticD3Component } from './Plot';
+import { PatternsConfig } from './Pattern';
 
 /** @deprecated */
 export interface IAreaProps extends AreaProps, UnknownProperties {}
@@ -22,6 +23,8 @@ export type AreaProps = Context & {
   duration?: number;
   /** Enables element transparency */
   transparent?: boolean;
+  /** Enables charts patterns that enhances charts accessability */
+  patterns?: PatternsConfig;
 };
 
 /** @deprecated */

--- a/semcore/d3-chart/src/types/Bar.d.ts
+++ b/semcore/d3-chart/src/types/Bar.d.ts
@@ -2,6 +2,7 @@ import { UnknownProperties } from '@semcore/core';
 import { Context } from './context';
 import { IntergalacticD3Component } from './Plot';
 import { ScaleBand, ScaleLinear } from 'd3-scale';
+import { PatternsConfig } from './Pattern';
 
 /** @deprecated */
 export interface IBarProps extends BarProps, UnknownProperties {}
@@ -36,6 +37,8 @@ export type BarProps = Context & {
    * The maximum width of each Bar
    */
   maxBarSize?: number;
+  /** Enables charts patterns that enhances charts accessability */
+  patterns?: PatternsConfig;
 };
 
 /** @deprecated */

--- a/semcore/d3-chart/src/types/Bubble.d.ts
+++ b/semcore/d3-chart/src/types/Bubble.d.ts
@@ -2,6 +2,7 @@ import { Intergalactic, UnknownProperties } from '@semcore/core';
 import { Context } from './context';
 import { TooltipType } from './Tooltip';
 import { IntergalacticD3Component } from './Plot';
+import { PatternsConfig } from './Pattern';
 
 /** @deprecated */
 export interface IBubbleProps extends BubbleProps, UnknownProperties {}
@@ -26,6 +27,8 @@ export type BubbleProps = Context & {
   duration?: number;
   /** Enables element transparency */
   transparent?: boolean;
+  /** Enables charts patterns that enhances charts accessability */
+  patterns?: PatternsConfig;
 };
 
 /** @deprecated */

--- a/semcore/d3-chart/src/types/Donut.d.ts
+++ b/semcore/d3-chart/src/types/Donut.d.ts
@@ -2,6 +2,7 @@ import { UnknownProperties } from '@semcore/core';
 import { Context } from './context';
 import { TooltipType } from './Tooltip';
 import { IntergalacticD3Component } from './Plot';
+import { PatternsConfig } from './Pattern';
 
 /** @deprecated */
 export interface IDonutProps extends DonutProps, UnknownProperties {}
@@ -24,6 +25,8 @@ export type DonutProps = Context & {
    * @default 0
    */
   paddingAngle?: number;
+  /** Enables charts patterns that enhances charts accessability */
+  patterns?: PatternsConfig;
 };
 
 /** @deprecated */

--- a/semcore/d3-chart/src/types/GroupBar.d.ts
+++ b/semcore/d3-chart/src/types/GroupBar.d.ts
@@ -3,6 +3,7 @@ import { BarContext, BarProps } from './Bar';
 import { HorizontalBarProps } from './HorizontalBar';
 import { Context } from './context';
 import { IntergalacticD3Component } from './Plot';
+import { PatternsConfig } from './Pattern';
 
 /** @deprecated */
 export interface IGroupBarProps extends GroupBarProps, UnknownProperties {}
@@ -14,7 +15,6 @@ export type GroupBarProps = Context & {
   /** Scale for group bars */
   /** @deprecated */
   scaleGroup?: any;
-
   /**
    * The maximum width of each Bar
    */

--- a/semcore/d3-chart/src/types/HorizontalBar.d.ts
+++ b/semcore/d3-chart/src/types/HorizontalBar.d.ts
@@ -2,6 +2,7 @@ import { UnknownProperties } from '@semcore/core';
 import { Context } from './context';
 import { BarContext, BackgroundProps } from './Bar';
 import { IntergalacticD3Component } from './Plot';
+import { PatternsConfig } from './Pattern';
 
 /** @deprecated */
 export interface IHorizontalBarProps extends HorizontalBarProps, UnknownProperties {}
@@ -26,6 +27,8 @@ export type HorizontalBarProps = Context & {
    * The maximum width of each Bar
    */
   maxBarSize?: number;
+  /** Enables charts patterns that enhances charts accessability */
+  patterns?: PatternsConfig;
 };
 
 declare const HorizontalBar: IntergalacticD3Component<'path', HorizontalBarProps, BarContext> & {

--- a/semcore/d3-chart/src/types/Line.d.ts
+++ b/semcore/d3-chart/src/types/Line.d.ts
@@ -3,6 +3,7 @@ import { Context } from './context';
 import { curveCardinal, CurveFactory } from 'd3-shape';
 import { FadeInOutProps } from '@semcore/animation';
 import { IntergalacticD3Component } from './Plot';
+import { PatternsConfig } from './Pattern';
 
 /** @deprecated */
 export interface ILineProps extends LineProps, UnknownProperties {}
@@ -23,6 +24,8 @@ export type LineProps = Context & {
   duration?: number;
   /** Enables element transparency */
   transparent?: boolean;
+  /** Enables charts patterns that enhances charts accessability */
+  patterns?: PatternsConfig;
 };
 
 /** @deprecated */

--- a/semcore/d3-chart/src/types/Plot.d.ts
+++ b/semcore/d3-chart/src/types/Plot.d.ts
@@ -2,7 +2,7 @@ import { BoxProps } from '@semcore/flex-box';
 import { UnknownProperties, Intergalactic } from '@semcore/core';
 import { Context } from './context';
 import { DataStructureHints } from './a11y/hints';
-import { PatternsConfig } from '../Pattern';
+import { PatternsConfig } from './Pattern';
 
 /** @deprecated */
 export interface IPlotProps extends PlotProps, UnknownProperties {}

--- a/semcore/d3-chart/src/types/Radar.d.ts
+++ b/semcore/d3-chart/src/types/Radar.d.ts
@@ -4,6 +4,7 @@ import { CurveFactory } from 'd3-shape';
 import { TooltipType } from './Tooltip';
 import { IntergalacticD3Component } from './Plot';
 import { BoxProps } from '@semcore/flex-box';
+import { PatternsConfig } from './Pattern';
 
 /** @deprecated */
 export interface IRadarProps extends RadarProps, UnknownProperties {}
@@ -35,6 +36,8 @@ export type RadarProps = Context & {
    * @example Math.PI/3
    * */
   angleOffset?: number;
+  /** Enables charts patterns that enhances charts accessability */
+  patterns?: PatternsConfig;
 };
 
 /** @deprecated */

--- a/semcore/d3-chart/src/types/ScatterPlot.d.ts
+++ b/semcore/d3-chart/src/types/ScatterPlot.d.ts
@@ -2,6 +2,7 @@ import { UnknownProperties } from '@semcore/core';
 import { Context } from './context';
 import { TooltipType } from './Tooltip';
 import { IntergalacticD3Component } from './Plot';
+import { PatternsConfig } from './Pattern';
 
 /** @deprecated */
 export interface IScatterPlotProps extends ScatterPlotProps, UnknownProperties {}
@@ -26,6 +27,8 @@ export type ScatterPlotProps = Context & {
   r?: number;
   /** Enables element transparency */
   transparent?: boolean;
+  /** Enables charts patterns that enhances charts accessability */
+  patterns?: PatternsConfig;
 };
 
 declare const ScatterPlot: IntergalacticD3Component<'g', ScatterPlotProps, Context> & {

--- a/semcore/d3-chart/src/types/StackBar.d.ts
+++ b/semcore/d3-chart/src/types/StackBar.d.ts
@@ -3,6 +3,7 @@ import { Context } from './context';
 import { BarContext, BarProps } from './Bar';
 import { HorizontalBarProps } from './HorizontalBar';
 import { IntergalacticD3Component } from './Plot';
+import { PatternsConfig } from './Pattern';
 
 /** @deprecated */
 export interface IStackBarProps extends StackBarProps, UnknownProperties {}
@@ -19,6 +20,9 @@ export type StackBarProps = Context & {
    * The maximum width of each Bar
    */
   maxBarSize?: number;
+
+  /** Enables charts patterns that enhances charts accessability */
+  patterns?: PatternsConfig;
 };
 
 /** @deprecated */

--- a/semcore/d3-chart/src/types/StackedArea.d.ts
+++ b/semcore/d3-chart/src/types/StackedArea.d.ts
@@ -2,6 +2,7 @@ import { UnknownProperties } from '@semcore/core';
 import { Context } from './context';
 import Area from './Area';
 import { IntergalacticD3Component } from './Plot';
+import { PatternsConfig } from './Pattern';
 
 /** @deprecated */
 export interface IStackedAreaProps extends StackedAreaProps, UnknownProperties {}
@@ -14,6 +15,9 @@ export type StackedAreaProps = Context & {
    * @default d3.stack() */
   /** @deprecated */
   stack?: any;
+
+  /** Enables charts patterns that enhances charts accessability */
+  patterns?: PatternsConfig;
 };
 
 /** @deprecated */

--- a/semcore/d3-chart/src/types/Venn.d.ts
+++ b/semcore/d3-chart/src/types/Venn.d.ts
@@ -3,6 +3,7 @@ import { Context } from './context';
 import { FadeInOutProps } from '@semcore/animation';
 import { TooltipType } from './Tooltip';
 import { IntergalacticD3Component } from './Plot';
+import { PatternsConfig } from './Pattern';
 
 /** @deprecated */
 export interface IVennProps extends VennProps, UnknownProperties {}
@@ -18,6 +19,8 @@ export type VennProps = Context &
      * @default (circle1, circle2) => circle2.radius - circle1.radius
      */
     orientationOrder?: (c1: number, c2: number) => number;
+    /** Enables charts patterns that enhances charts accessability */
+    patterns?: PatternsConfig;
   };
 
 /** @deprecated */

--- a/website/docs/core-principles/writing-code/examples/making-wrappers.tsx
+++ b/website/docs/core-principles/writing-code/examples/making-wrappers.tsx
@@ -5,7 +5,7 @@ import Button from '@semcore/ui/button';
 const AlertButton = wrapIntergalacticComponent<
   typeof Button,
   {
-    handle: ['click', 'hover'];
+    handle: ('click' | 'hover')[];
     message: string;
   }
 >(({ handle, message, ...restProps }) => {

--- a/website/docs/data-display/d3-chart/d3-chart-code.md
+++ b/website/docs/data-display/d3-chart/d3-chart-code.md
@@ -14,13 +14,13 @@ Charts are a complex component that cannot be applied in a single line. That's w
 
 ## Concept
 
-* We want to provide you with a convenient way to use the imperative d3 style with React's declarative approach.
-* All charts are based on [d3-scale](https://github.com/d3/d3-scale), which you transfer to our charts in a customized form.
-* We try to provide access to each SVG node, so you could modify it if needed.
+- We want to provide you with a convenient way to use the imperative d3 style with React's declarative approach.
+- All charts are based on [d3-scale](https://github.com/d3/d3-scale), which you transfer to our charts in a customized form.
+- We try to provide access to each SVG node, so you could modify it if needed.
 
-Each element that you place on the chart is based on a real SVG element or a group of elements. For example, when you render `<Line/>` , you will get an SVG ( `<line d = {...}>` ). All properties you pass to `<Line/>` will go to the native SVG `<line d = {...}>` tag.
+Each element that you place on the chart is based on a real SVG element or a group of elements. For example, when you render `<Line/>`, you will get an SVG (`<line d = {...}>`). All properties you pass to `<Line/>` will go to the native SVG `<line d = {...}>` tag.
 
-When you render `<Line.Dots/>` (dots on a line plot), you get a set of `<circle cx = {...} cy = {...}/>` . So all properties you pass to <Line. Dots/> will also go to the native SVG `<circle cx = {...} cy = {...}/>` tag.
+When you render `<Line.Dots/>` (dots on a line plot), you get a set of `<circle cx = {...} cy = {...}/>`. So all properties you pass to <Line.Dots/> will also go to the native SVG `<circle cx = {...} cy = {...}/>` tag.
 
 For a point change in the properties of each specific dot, you need to pass a function that will be called at each dot with the calculated properties of this dot:
 
@@ -38,7 +38,7 @@ For a point change in the properties of each specific dot, you need to pass a fu
 You also can put functions into single elements if your properties are calculated dynamically.
 :::
 
-Since many SVG elements don't support nesting, they are rendered sequentially. For example, this code example doesn't nest `<circle/>` in `<line/>` , but draws them one after another:
+Since many SVG elements don't support nesting, they are rendered sequentially. For example, this code example doesn't nest `<circle/>` in `<line/>`, but draws them one after another:
 
 ```jsx
 <Line>
@@ -52,7 +52,7 @@ CSS is responsible for all the chart styles. See [Themes](/style/design-tokens/d
 
 Any SVG container must have absolute values for its size.
 
-See [d3-scale docs on GitHub](https://github.com/d3/d3-scale) for more information about the types of `scale` , as well as their `range` and `domain` .
+See [d3-scale docs on GitHub](https://github.com/d3/d3-scale) for more information about the types of `scale`, as well as their `range` and `domain`.
 
 ::: tip
 The `range` of the horizontal `scale` is inverted, so that the axes origin is at the bottom left corner.
@@ -61,7 +61,7 @@ The `range` of the horizontal `scale` is inverted, so that the axes origin is at
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/base.tsx'; 
+  export Demo from './examples/base.tsx';
 </script>
 
 :::
@@ -75,7 +75,7 @@ That's why values in `scale.range ()` are set with a shift.
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/paddings-&-margins.tsx'; 
+  export Demo from './examples/paddings-&-margins.tsx';
 </script>
 
 :::
@@ -84,21 +84,21 @@ That's why values in `scale.range ()` are set with a shift.
 
 When you pass `scale` to the root component it also sets the coordinate axes. However, you still need to specify them for them to render.
 
-* `XAxis/YAxis` are the axis lines.
-* `ticks` are the values on the axis.
+- `XAxis/YAxis` are the axis lines.
+- `ticks` are the values on the axis.
 
 It is also possible to have multiple axes with different positions.
 
 You can get the number of ticks from the `scale.ticks` or `scale.domain` method. To calculate an approximate number of ticks, divide the chart size by the size of a one tick.
 
 ::: tip
-According to the design guide, `YAxis` is hidden by default `(hide = true)` .
+According to the design guide, `YAxis` is hidden by default `(hide = true)`.
 :::
 
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/axes.tsx'; 
+  export Demo from './examples/axes.tsx';
 </script>
 
 :::
@@ -107,7 +107,7 @@ According to the design guide, `YAxis` is hidden by default `(hide = true)` .
 
 You can change the values and properties on the axis by passing a function.
 
-The default tag is `<text/>` , but you can change it by defining the `tag` property. For example, you can change it to `foreignObject` for inserting `html` components.
+The default tag is `<text/>`, but you can change it by defining the `tag` property. For example, you can change it to `foreignObject` for inserting `html` components.
 
 ::: tip
 The function arguments contain calculated XY coordinates that you can use to shift the object as needed.
@@ -116,7 +116,7 @@ The function arguments contain calculated XY coordinates that you can use to shi
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/axis-values.tsx'; 
+  export Demo from './examples/axis-values.tsx';
 </script>
 
 :::
@@ -126,13 +126,13 @@ The function arguments contain calculated XY coordinates that you can use to shi
 Additional lines are formed in the same way as ticks.
 
 ::: tip
-To make things easier, ticks can be specified on the `Axis` component itself, and it will be automatically passed to `<Axis.Ticks/>` and `<Axis.Grid/>` .
+To make things easier, ticks can be specified on the `Axis` component itself, and it will be automatically passed to `<Axis.Ticks/>` and `<Axis.Grid/>`.
 :::
 
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/additional-lines.tsx'; 
+  export Demo from './examples/additional-lines.tsx';
 </script>
 
 :::
@@ -142,26 +142,26 @@ To make things easier, ticks can be specified on the `Axis` component itself, an
 Axis titles are formed in the same way as ticks and additional lines.
 
 ::: tip
-By default, the title is set to the right for the Oy axis, and at the top for the Ox axis. However, you can change this condition by passing the desired location to `position` : `right` , `top` , `left` , or `bottom` .
+By default, the title is set to the right for the Oy axis, and at the top for the Ox axis. However, you can change this condition by passing the desired location to `position`: `right`, `top`, `left`, or `bottom`.
 :::
 
 ::: sandbox
 
 <script lang="tsx">
-import { Bar, XAxis, Plot, YAxis } from '@semcore/ui/d3-chart'; 
-  export Demo from './examples/axes-titles.tsx'; 
+import { Bar, XAxis, Plot, YAxis } from '@semcore/ui/d3-chart';
+  export Demo from './examples/axes-titles.tsx';
 </script>
 
 :::
 
 ## Tooltip
 
-You can add a tooltip to the chart, for which you can set `Title` and `Footer` .
+You can add a tooltip to the chart, for which you can set `Title` and `Footer`.
 
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/tooltip.tsx'; 
+  export Demo from './examples/tooltip.tsx';
 </script>
 
 :::
@@ -181,7 +181,7 @@ For SVG charts to display correctly on responsive layouts, you need to dynamical
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/adaptive-chart.tsx'; 
+  export Demo from './examples/adaptive-chart.tsx';
 </script>
 
 :::
@@ -193,7 +193,7 @@ Refer to [Chart legend](/data-display/chart-legend/chart-legend), for a guide on
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/chart-legend.tsx'; 
+  export Demo from './examples/chart-legend.tsx';
 </script>
 
 :::
@@ -203,7 +203,7 @@ Refer to [Chart legend](/data-display/chart-legend/chart-legend), for a guide on
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/reference-line.tsx'; 
+  export Demo from './examples/reference-line.tsx';
 </script>
 
 :::
@@ -219,7 +219,7 @@ Be careful when choosing the `scale` for the axis, since it's common across diff
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/synchronous-charts.tsx'; 
+  export Demo from './examples/synchronous-charts.tsx';
 </script>
 
 :::
@@ -229,7 +229,7 @@ Be careful when choosing the `scale` for the axis, since it's common across diff
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/export-to-image.tsx'; 
+  export Demo from './examples/export-to-image-(png,-jpeg,-webp).tsx';
 </script>
 
 :::
@@ -247,7 +247,7 @@ To enable visual patterns on chart, simply add `pattern` prop to the chart compo
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/pattern-fill.tsx'; 
+  export Demo from './examples/pattern-fill.tsx';
 </script>
 
 :::
@@ -284,7 +284,7 @@ You can enforce use of build-in patterns by using it's names. The list of availa
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/enforcing-patterns.tsx'; 
+  export Demo from './examples/enforcing-patterns.tsx';
 </script>
 
 :::
@@ -298,22 +298,19 @@ The fill data is used for rendering charts like an `Area` while symbol data is n
 ::: sandbox 
 
 <script  lang="tsx">
-import React from 'react'; 
-import { Chart, Pattern } from '@semcore/ui/d3-chart'; 
+import React from 'react';
+import { Chart, Pattern } from '@semcore/ui/d3-chart';
 
 const customPattern: Pattern = {
   fill: {
-
     viewBox: '0 0 21 20',
     children: (
       <>
         <path d='M9.17 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 0 0 .951.69h3.461c.969 0 1.372 1.24.588 1.81l-2.8 2.034a1 1 0 0 0-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.539 1.118l-2.8-2.034a1 1 0 0 0-1.175 0l-2.8 2.034c-.784.57-1.839-.197-1.54-1.118l1.07-3.292a1 1 0 0 0-.363-1.118L3.1 8.72c-.784-.57-.381-1.81.587-1.81H7.15a1 1 0 0 0 .95-.69l1.07-3.292Z' />
       </>
     ),
-
-  }, 
+  },
   symbol: {
-
     viewBox: '0 0 33 32',
     size: [16.41, 15.66],
     children: (
@@ -321,13 +318,11 @@ const customPattern: Pattern = {
         <path d='M15.049.927c.3-.921 1.603-.921 1.902 0l2.866 8.82a1 1 0 0 0 .95.69h9.274c.97 0 1.372 1.24.588 1.81l-7.502 5.45a1 1 0 0 0-.364 1.119l2.866 8.82c.3.92-.755 1.687-1.539 1.117l-7.502-5.45a1 1 0 0 0-1.176 0l-7.502 5.45c-.784.57-1.838-.196-1.54-1.118l2.867-8.82a1 1 0 0 0-.364-1.117l-7.502-5.451c-.784-.57-.381-1.81.588-1.81h9.273a1 1 0 0 0 .951-.69L15.05.927Z' />
       </>
     ),
-
-  }, 
+  },
 }
 
 const Demo = () => {
   return (
-
     <Chart.Line
       data={data}
       plotWidth={500}
@@ -338,18 +333,15 @@ const Demo = () => {
       showDots
       showTooltip
     />
-
-  ); 
-}; 
+  );
+};
 
 const data = Array(20)
   .fill({})
   .map((d, i) => ({
-
     x: i,
     y1: Math.random() * 10,
-
-  })); 
+  }));
 </script>
 
 :::
@@ -359,7 +351,7 @@ You can also provide a list of patterns.
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/custom-patterns.tsx'; 
+  export Demo from './examples/custom-patterns.tsx';
 </script>
 
 :::
@@ -375,7 +367,8 @@ You can access `PatternFill` and `PatternSymbol` components for low level use.
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/low-level-components-use.tsx'; 
+  export Demo from './examples/low-level-components-use.tsx';
 </script>
 
 :::
+

--- a/website/docs/data-display/d3-chart/d3-chart-code.md
+++ b/website/docs/data-display/d3-chart/d3-chart-code.md
@@ -14,13 +14,13 @@ Charts are a complex component that cannot be applied in a single line. That's w
 
 ## Concept
 
-- We want to provide you with a convenient way to use the imperative d3 style with React's declarative approach.
-- All charts are based on [d3-scale](https://github.com/d3/d3-scale), which you transfer to our charts in a customized form.
-- We try to provide access to each SVG node, so you could modify it if needed.
+* We want to provide you with a convenient way to use the imperative d3 style with React's declarative approach.
+* All charts are based on [d3-scale](https://github.com/d3/d3-scale), which you transfer to our charts in a customized form.
+* We try to provide access to each SVG node, so you could modify it if needed.
 
-Each element that you place on the chart is based on a real SVG element or a group of elements. For example, when you render `<Line/>`, you will get an SVG (`<line d = {...}>`). All properties you pass to `<Line/>` will go to the native SVG `<line d = {...}>` tag.
+Each element that you place on the chart is based on a real SVG element or a group of elements. For example, when you render `<Line/>` , you will get an SVG ( `<line d = {...}>` ). All properties you pass to `<Line/>` will go to the native SVG `<line d = {...}>` tag.
 
-When you render `<Line.Dots/>` (dots on a line plot), you get a set of `<circle cx = {...} cy = {...}/>`. So all properties you pass to <Line.Dots/> will also go to the native SVG `<circle cx = {...} cy = {...}/>` tag.
+When you render `<Line.Dots/>` (dots on a line plot), you get a set of `<circle cx = {...} cy = {...}/>` . So all properties you pass to <Line. Dots/> will also go to the native SVG `<circle cx = {...} cy = {...}/>` tag.
 
 For a point change in the properties of each specific dot, you need to pass a function that will be called at each dot with the calculated properties of this dot:
 
@@ -38,7 +38,7 @@ For a point change in the properties of each specific dot, you need to pass a fu
 You also can put functions into single elements if your properties are calculated dynamically.
 :::
 
-Since many SVG elements don't support nesting, they are rendered sequentially. For example, this code example doesn't nest `<circle/>` in `<line/>`, but draws them one after another:
+Since many SVG elements don't support nesting, they are rendered sequentially. For example, this code example doesn't nest `<circle/>` in `<line/>` , but draws them one after another:
 
 ```jsx
 <Line>
@@ -52,7 +52,7 @@ CSS is responsible for all the chart styles. See [Themes](/style/design-tokens/d
 
 Any SVG container must have absolute values for its size.
 
-See [d3-scale docs on GitHub](https://github.com/d3/d3-scale) for more information about the types of `scale`, as well as their `range` and `domain`.
+See [d3-scale docs on GitHub](https://github.com/d3/d3-scale) for more information about the types of `scale` , as well as their `range` and `domain` .
 
 ::: tip
 The `range` of the horizontal `scale` is inverted, so that the axes origin is at the bottom left corner.
@@ -61,7 +61,7 @@ The `range` of the horizontal `scale` is inverted, so that the axes origin is at
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/base.tsx';
+  export Demo from './examples/base.tsx'; 
 </script>
 
 :::
@@ -75,7 +75,7 @@ That's why values in `scale.range ()` are set with a shift.
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/paddings-&-margins.tsx';
+  export Demo from './examples/paddings-&-margins.tsx'; 
 </script>
 
 :::
@@ -84,21 +84,21 @@ That's why values in `scale.range ()` are set with a shift.
 
 When you pass `scale` to the root component it also sets the coordinate axes. However, you still need to specify them for them to render.
 
-- `XAxis/YAxis` are the axis lines.
-- `ticks` are the values on the axis.
+* `XAxis/YAxis` are the axis lines.
+* `ticks` are the values on the axis.
 
 It is also possible to have multiple axes with different positions.
 
 You can get the number of ticks from the `scale.ticks` or `scale.domain` method. To calculate an approximate number of ticks, divide the chart size by the size of a one tick.
 
 ::: tip
-According to the design guide, `YAxis` is hidden by default `(hide = true)`.
+According to the design guide, `YAxis` is hidden by default `(hide = true)` .
 :::
 
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/axes.tsx';
+  export Demo from './examples/axes.tsx'; 
 </script>
 
 :::
@@ -107,7 +107,7 @@ According to the design guide, `YAxis` is hidden by default `(hide = true)`.
 
 You can change the values and properties on the axis by passing a function.
 
-The default tag is `<text/>`, but you can change it by defining the `tag` property. For example, you can change it to `foreignObject` for inserting `html` components.
+The default tag is `<text/>` , but you can change it by defining the `tag` property. For example, you can change it to `foreignObject` for inserting `html` components.
 
 ::: tip
 The function arguments contain calculated XY coordinates that you can use to shift the object as needed.
@@ -116,7 +116,7 @@ The function arguments contain calculated XY coordinates that you can use to shi
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/axis-values.tsx';
+  export Demo from './examples/axis-values.tsx'; 
 </script>
 
 :::
@@ -126,13 +126,13 @@ The function arguments contain calculated XY coordinates that you can use to shi
 Additional lines are formed in the same way as ticks.
 
 ::: tip
-To make things easier, ticks can be specified on the `Axis` component itself, and it will be automatically passed to `<Axis.Ticks/>` and `<Axis.Grid/>`.
+To make things easier, ticks can be specified on the `Axis` component itself, and it will be automatically passed to `<Axis.Ticks/>` and `<Axis.Grid/>` .
 :::
 
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/additional-lines.tsx';
+  export Demo from './examples/additional-lines.tsx'; 
 </script>
 
 :::
@@ -142,26 +142,26 @@ To make things easier, ticks can be specified on the `Axis` component itself, an
 Axis titles are formed in the same way as ticks and additional lines.
 
 ::: tip
-By default, the title is set to the right for the Oy axis, and at the top for the Ox axis. However, you can change this condition by passing the desired location to `position`: `right`, `top`, `left`, or `bottom`.
+By default, the title is set to the right for the Oy axis, and at the top for the Ox axis. However, you can change this condition by passing the desired location to `position` : `right` , `top` , `left` , or `bottom` .
 :::
 
 ::: sandbox
 
 <script lang="tsx">
-import { Bar, XAxis, Plot, YAxis } from '@semcore/ui/d3-chart';
-  export Demo from './examples/axes-titles.tsx';
+import { Bar, XAxis, Plot, YAxis } from '@semcore/ui/d3-chart'; 
+  export Demo from './examples/axes-titles.tsx'; 
 </script>
 
 :::
 
 ## Tooltip
 
-You can add a tooltip to the chart, for which you can set `Title` and `Footer`.
+You can add a tooltip to the chart, for which you can set `Title` and `Footer` .
 
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/tooltip.tsx';
+  export Demo from './examples/tooltip.tsx'; 
 </script>
 
 :::
@@ -181,7 +181,7 @@ For SVG charts to display correctly on responsive layouts, you need to dynamical
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/adaptive-chart.tsx';
+  export Demo from './examples/adaptive-chart.tsx'; 
 </script>
 
 :::
@@ -193,7 +193,7 @@ Refer to [Chart legend](/data-display/chart-legend/chart-legend), for a guide on
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/chart-legend.tsx';
+  export Demo from './examples/chart-legend.tsx'; 
 </script>
 
 :::
@@ -203,7 +203,7 @@ Refer to [Chart legend](/data-display/chart-legend/chart-legend), for a guide on
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/reference-line.tsx';
+  export Demo from './examples/reference-line.tsx'; 
 </script>
 
 :::
@@ -219,7 +219,7 @@ Be careful when choosing the `scale` for the axis, since it's common across diff
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/synchronous-charts.tsx';
+  export Demo from './examples/synchronous-charts.tsx'; 
 </script>
 
 :::
@@ -229,7 +229,7 @@ Be careful when choosing the `scale` for the axis, since it's common across diff
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/export-to-image-(png,-jpeg,-webp).tsx';
+  export Demo from './examples/export-to-image.tsx'; 
 </script>
 
 :::
@@ -247,7 +247,7 @@ To enable visual patterns on chart, simply add `pattern` prop to the chart compo
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/pattern-fill.tsx';
+  export Demo from './examples/pattern-fill.tsx'; 
 </script>
 
 :::
@@ -284,7 +284,7 @@ You can enforce use of build-in patterns by using it's names. The list of availa
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/enforcing-patterns.tsx';
+  export Demo from './examples/enforcing-patterns.tsx'; 
 </script>
 
 :::
@@ -298,19 +298,22 @@ The fill data is used for rendering charts like an `Area` while symbol data is n
 ::: sandbox 
 
 <script  lang="tsx">
-import React from 'react';
-import { Chart, Pattern } from '@semcore/ui/d3-chart';
+import React from 'react'; 
+import { Chart, Pattern } from '@semcore/ui/d3-chart'; 
 
 const customPattern: Pattern = {
   fill: {
+
     viewBox: '0 0 21 20',
     children: (
       <>
         <path d='M9.17 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 0 0 .951.69h3.461c.969 0 1.372 1.24.588 1.81l-2.8 2.034a1 1 0 0 0-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.539 1.118l-2.8-2.034a1 1 0 0 0-1.175 0l-2.8 2.034c-.784.57-1.839-.197-1.54-1.118l1.07-3.292a1 1 0 0 0-.363-1.118L3.1 8.72c-.784-.57-.381-1.81.587-1.81H7.15a1 1 0 0 0 .95-.69l1.07-3.292Z' />
       </>
     ),
-  },
+
+  }, 
   symbol: {
+
     viewBox: '0 0 33 32',
     size: [16.41, 15.66],
     children: (
@@ -318,11 +321,13 @@ const customPattern: Pattern = {
         <path d='M15.049.927c.3-.921 1.603-.921 1.902 0l2.866 8.82a1 1 0 0 0 .95.69h9.274c.97 0 1.372 1.24.588 1.81l-7.502 5.45a1 1 0 0 0-.364 1.119l2.866 8.82c.3.92-.755 1.687-1.539 1.117l-7.502-5.45a1 1 0 0 0-1.176 0l-7.502 5.45c-.784.57-1.838-.196-1.54-1.118l2.867-8.82a1 1 0 0 0-.364-1.117l-7.502-5.451c-.784-.57-.381-1.81.588-1.81h9.273a1 1 0 0 0 .951-.69L15.05.927Z' />
       </>
     ),
-  },
+
+  }, 
 }
 
 const Demo = () => {
   return (
+
     <Chart.Line
       data={data}
       plotWidth={500}
@@ -333,15 +338,18 @@ const Demo = () => {
       showDots
       showTooltip
     />
-  );
-};
+
+  ); 
+}; 
 
 const data = Array(20)
   .fill({})
   .map((d, i) => ({
+
     x: i,
     y1: Math.random() * 10,
-  }));
+
+  })); 
 </script>
 
 :::
@@ -351,7 +359,7 @@ You can also provide a list of patterns.
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/custom-patterns.tsx';
+  export Demo from './examples/custom-patterns.tsx'; 
 </script>
 
 :::
@@ -367,8 +375,7 @@ You can access `PatternFill` and `PatternSymbol` components for low level use.
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/low-level-components-use.tsx';
+  export Demo from './examples/low-level-components-use.tsx'; 
 </script>
 
 :::
-

--- a/website/docs/data-display/d3-chart/examples/axes-titles.tsx
+++ b/website/docs/data-display/d3-chart/examples/axes-titles.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { scaleBand, scaleLinear } from 'd3-scale';
+import { Plot, Bar, XAxis, YAxis } from '@semcore/ui/d3-chart';
 
 const Demo = () => {
   const MARGIN = 40;

--- a/website/docs/data-display/d3-chart/examples/custom-patterns.tsx
+++ b/website/docs/data-display/d3-chart/examples/custom-patterns.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Plot, Venn, colors } from '@semcore/ui/d3-chart';
-import { Text } from '@semcore/ui/typography';
+import { Pattern, Plot, Venn } from '@semcore/ui/d3-chart';
 
 const data = {
   G: 200,
@@ -13,7 +12,7 @@ const data = {
   'G/F/C': 100,
 };
 
-const patterns = [
+const patterns: Pattern[] = [
   {
     fill: {
       viewBox: '0 0 12 12',

--- a/website/docs/data-display/d3-chart/examples/export-to-image.tsx
+++ b/website/docs/data-display/d3-chart/examples/export-to-image.tsx
@@ -31,7 +31,7 @@ const Demo = () => {
 
   const downloadImage = React.useCallback(
     (extention: string) => async () => {
-      const svgElement = svgRef.current.cloneNode(true);
+      const svgElement = svgRef.current.cloneNode(true) as typeof svgRef.current;
       [...svgElement.querySelectorAll('animate')].forEach((animate) => animate.remove());
       let svgText = svgElementToSvgText(svgElement);
       svgText = svgText.replace(/(\w+)?:?xlink=/g, 'xmlns:xlink='); // Fix root xlink without namespace

--- a/website/docs/data-display/d3-chart/examples/low-level-components-use.tsx
+++ b/website/docs/data-display/d3-chart/examples/low-level-components-use.tsx
@@ -9,14 +9,7 @@ const Demo = () => {
   return (
     <svg height='100px' width='200px'>
       <PatternFill id='pattern-element' patternKey={patternKey} color='red' patterns={patterns} />
-      <rect
-        width='100px'
-        height='100px'
-        top='0'
-        left='0'
-        fill='url(#pattern-element)'
-        stroke='red'
-      />
+      <rect width='100px' height='100px' x='0' y='0' fill='url(#pattern-element)' stroke='red' />
       <PatternSymbol
         color='red'
         patternKey={patternKey}

--- a/website/docs/patterns/informer/examples/basic-usage.tsx
+++ b/website/docs/patterns/informer/examples/basic-usage.tsx
@@ -16,7 +16,6 @@ class Demo extends React.Component {
             tag={InfoL}
             ml='4px'
             color='gray-300'
-            cursor='help'
             interactive={true}
           />
         </div>
@@ -27,7 +26,6 @@ class Demo extends React.Component {
             tag={InfoL}
             ml='4px'
             color='gray-300'
-            cursor='help'
             interactive={true}
           />
         </div>
@@ -38,7 +36,6 @@ class Demo extends React.Component {
             tag={InfoM}
             ml='4px'
             color='gray-300'
-            cursor='help'
             interactive={true}
           />
         </div>
@@ -50,7 +47,6 @@ class Demo extends React.Component {
               tag={InfoM}
               ml='4px'
               color='gray-300'
-              cursor='help'
               interactive={true}
             />
           </div>
@@ -61,7 +57,6 @@ class Demo extends React.Component {
             tag={InfoM}
             ml='4px'
             color='gray-300'
-            cursor='help'
             interactive={true}
           />
         </div>
@@ -72,7 +67,6 @@ class Demo extends React.Component {
             tag={InfoM}
             ml='4px'
             color='gray-300'
-            cursor='help'
             interactive={true}
           />
         </div>
@@ -83,7 +77,6 @@ class Demo extends React.Component {
             tag={InfoM}
             ml='4px'
             color='gray-300'
-            cursor='help'
             interactive={true}
           />
         </div>

--- a/website/docs/style/typography/examples/formattext-nested-lists.tsx
+++ b/website/docs/style/typography/examples/formattext-nested-lists.tsx
@@ -3,7 +3,7 @@ import FormatText from '@semcore/ui/format-text';
 
 const Demo = () => (
   <FormatText>
-    <ol start='1'>
+    <ol start={1}>
       <li>List item one</li>
       <li>
         List item two with subitems:


### PR DESCRIPTION
## Motivation and Context

After enabling type checking for many docs examples many type issues was found. I've fixed many of them in docs. Also I found that forgot to add `patterns` prop type to many charts – it's not critical cause developers can set `patterns` on `Plot`, but prop also should exist on chart components itself.

## How has this been tested?

By ts type checking

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
