### PR TITLE
[86bxfdn8a] Dropdown menus nesting

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1030,9 +1030,15 @@ importers:
       '@playwright/test':
         specifier: 1.25.1
         version: 1.25.1
+      '@semcore/base-trigger':
+        specifier: 4.26.1
+        version: link:../base-trigger
       '@semcore/button':
         specifier: workspace:*
         version: link:../button
+      '@semcore/icon':
+        specifier: 4.26.0
+        version: link:../icon
       '@semcore/testing-utils':
         specifier: 1.0.0
         version: link:../../tools/testing-utils

--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -13,6 +13,10 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 - When dropdown menu item has focusable elements inside, pressing tab locks focus inside the item. Closing or navigating inside the dropdown menu unlocks the focus.
 - If dropdown menu poppers placed to the left or right side of trigger, user needs to press `ArrowLeft` or `ArrowRight` to open the popper (`ArrowUp` or `ArrowDown` was opening popper with any placement before the change).
 
+### Added
+
+- `DropdownMenu.Nesting` component to support accessible nested dropdowns.
+
 ## [4.20.4] - 2024-02-19
 
 ### Changed

--- a/semcore/dropdown-menu/package.json
+++ b/semcore/dropdown-menu/package.json
@@ -34,6 +34,8 @@
     "@guidepup/playwright": "0.6.1",
     "@playwright/test": "1.25.1",
     "@semcore/testing-utils": "1.0.0",
+    "@semcore/base-trigger": "4.26.1",
+    "@semcore/icon": "4.26.0",
     "@semcore/button": "workspace:*"
   }
 }

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -450,7 +450,7 @@ function Item({ styles, label, triggerRef, focusLock, disabled, highlighted }) {
 function Nesting({ styles }) {
   const SDropdownMenuNesting = Root;
 
-  return sstyled(styles)(<SDropdownMenuNesting render={DropdownMenu.Item} />);
+  return sstyled(styles)(<SDropdownMenuNesting aria-haspopup='true' render={DropdownMenu.Item} />);
 }
 
 function NestingTrigger({ styles, visible, onNestedVisibleChange }) {

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -14,7 +14,6 @@ import style from './style/dropdown-menu.shadow.css';
 import { setFocus } from '@semcore/utils/src/focus-lock/setFocus';
 import { isFocusInside } from '@semcore/utils/src/focus-lock/isFocusInside';
 import { getFocusableIn } from '@semcore/utils/src/focus-lock/getFocusableIn';
-import logger from '@semcore/utils/lib/logger';
 
 class DropdownMenuRoot extends Component {
   static displayName = 'DropdownMenu';
@@ -42,12 +41,20 @@ class DropdownMenuRoot extends Component {
 
   highlightedItemRef = React.createRef();
 
+  ignoreTriggerKeyboardFocusUntil = 0;
   prevHighlightedIndex = null;
 
   uncontrolledProps() {
     return {
       highlightedIndex: null,
-      visible: null,
+      visible: [
+        null,
+        (visible) => {
+          if (!visible) {
+            this.ignoreTriggerKeyboardFocusUntil = Date.now() + 100;
+          }
+        },
+      ],
     };
   }
 
@@ -93,8 +100,51 @@ class DropdownMenuRoot extends Component {
       this.handlers.visible(true);
     }
     if (['ArrowLeft', 'ArrowRight'].includes(e.key) && !verticalPlacement) {
-      e.preventDefault();
-      this.handlers.visible(true);
+      const show =
+        (e.key === 'ArrowRight' && placement.startsWith('right')) ||
+        (e.key === 'ArrowLeft' && placement.startsWith('left'));
+      const hide =
+        (e.key === 'ArrowLeft' && placement.startsWith('right')) ||
+        (e.key === 'ArrowRight' && placement.startsWith('left'));
+      const visibleChanged = (visible && hide) || (!visible && show);
+      if (show) {
+        this.handlers.visible(true);
+      } else if (hide) {
+        this.handlers.visible(false);
+      }
+      if (visibleChanged) {
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
+    }
+    if (['ArrowLeft', 'ArrowRight'].includes(e.key)) {
+      const item = highlightedIndex !== null && this.itemRefs[highlightedIndex];
+      const focusable = getFocusableIn(item);
+      if (focusable.length > 0 && item) {
+        const focusedIndex = focusable.indexOf(document.activeElement);
+        if (e.key === 'ArrowRight') {
+          if (focusedIndex === -1) {
+            this.setState({ focusLockItemIndex: highlightedIndex });
+          }
+          const nextFocused = focusable[focusedIndex + 1];
+          if (nextFocused) {
+            e.preventDefault();
+            e.stopPropagation();
+            nextFocused.focus();
+          }
+        } else if (e.key === 'ArrowLeft') {
+          if (focusedIndex === 0) {
+            this.setState({ focusLockItemIndex: null });
+          }
+          const prevFocused = focusable[focusedIndex - 1];
+          if (prevFocused) {
+            e.preventDefault();
+            e.stopPropagation();
+            prevFocused.focus();
+          }
+        }
+      }
     }
 
     switch (e.key) {
@@ -129,11 +179,16 @@ class DropdownMenuRoot extends Component {
         } else {
           if (place === 'trigger') {
             this.handlers.visible(false);
+
             e.preventDefault();
           }
         }
         break;
     }
+  };
+
+  handleTriggerKeyboardFocus = () => {
+    if (this.ignoreTriggerKeyboardFocusUntil > Date.now()) return false;
   };
 
   getTriggerProps() {
@@ -149,6 +204,7 @@ class DropdownMenuRoot extends Component {
         visible && highlightedIndex !== null ? `igc-${uid}-option-${highlightedIndex}` : undefined,
       onKeyDown: this.bindHandlerKeyDown('trigger'),
       ref: this.triggerRef,
+      onKeyboardFocus: this.handleTriggerKeyboardFocus,
     };
   }
 
@@ -196,8 +252,51 @@ class DropdownMenuRoot extends Component {
       focusLock: this.state.focusLockItemIndex === index,
       triggerRef: this.triggerRef,
       ref,
+      index,
     };
   }
+
+  handleNestingClick = (event) => {
+    const itemIndex = this.itemRefs.indexOf(event.currentTarget);
+    if (itemIndex === -1) return;
+    const focusable = getFocusableIn(event.currentTarget);
+    focusable[0]?.focus();
+    if (focusable[0] && this.state.focusLockItemIndex === null) {
+      this.setState({ focusLockItemIndex: null });
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+  handleNestingKeyDown = (event) => {
+    if (event.key === ' ') {
+      this.handleNestingClick(event);
+    }
+  };
+  getNestingProps = () => {
+    const { size } = this.asProps;
+    return {
+      size,
+      onClick: this.handleNestingClick,
+      onKeyDown: this.handleNestingKeyDown,
+    };
+  };
+  handleNestedVisibleChange = (lastUserInteraction) => {
+    if (
+      this.asProps.visible &&
+      this.asProps.highlightedIndex === null &&
+      lastUserInteraction === 'keyboard'
+    ) {
+      this.handlers.highlightedIndex(0);
+    }
+  };
+  getNestingTriggerProps = () => {
+    const { size, visible } = this.asProps;
+    return {
+      size,
+      visible,
+      onNestedVisibleChange: this.handleNestedVisibleChange,
+    };
+  };
 
   getItemHintProps() {
     const { size } = this.asProps;
@@ -266,7 +365,7 @@ class DropdownMenuRoot extends Component {
       this.handlers.highlightedIndex(null);
     }
     if (
-      this.state.focusLockItemIndex !== this.asProps.highlightedIndex &&
+      (this.state.focusLockItemIndex !== this.asProps.highlightedIndex || !this.asProps.visible) &&
       this.state.focusLockItemIndex !== null
     ) {
       setTimeout(() => {
@@ -276,13 +375,12 @@ class DropdownMenuRoot extends Component {
   }
 
   render() {
-    const { Children, interaction, 'data-ui-name': dataUiName } = this.asProps;
-    const props = {};
+    const { Children } = this.asProps;
 
     this.itemProps = [];
 
     return (
-      <Root render={Dropdown} {...props}>
+      <Root render={Dropdown}>
         <Children />
       </Root>
     );
@@ -349,6 +447,39 @@ function Item({ styles, label, triggerRef, focusLock, disabled, highlighted }) {
   );
 }
 
+function Nesting({ styles }) {
+  const SDropdownMenuNesting = Root;
+
+  return sstyled(styles)(<SDropdownMenuNesting render={DropdownMenu.Item} />);
+}
+
+function NestingTrigger({ styles, visible, onNestedVisibleChange }) {
+  const SDropdownMenuItem = Root;
+
+  const lastUserInteractionRef = React.useRef(undefined);
+  React.useEffect(() => {
+    onNestedVisibleChange(lastUserInteractionRef.current);
+  }, [visible]);
+
+  const handleMouseEvent = React.useCallback(() => {
+    lastUserInteractionRef.current = 'mouse';
+  }, []);
+  const handleKeyboardEvent = React.useCallback(() => {
+    lastUserInteractionRef.current = 'keyboard';
+  }, []);
+
+  React.useEffect(() => {
+    document.addEventListener('mouseover', handleMouseEvent, { capture: true });
+    document.addEventListener('keydown', handleKeyboardEvent, { capture: true });
+    return () => {
+      document.removeEventListener('mouseover', handleMouseEvent, { capture: true });
+      document.removeEventListener('keydown', handleKeyboardEvent, { capture: true });
+    };
+  }, []);
+
+  return sstyled(styles)(<SDropdownMenuItem nesting-trigger tabIndex={0} render={Flex} />);
+}
+
 function Addon(props) {
   const [SDropdownMenuItemAddon, { className, ...other }] = useBox(props, props.forwardRef);
   const styles = sstyled(props.styles);
@@ -382,6 +513,7 @@ const DropdownMenu = createComponent(
     List,
     Menu,
     Item: [Item, { Addon }],
+    Nesting: [Nesting, { Trigger: NestingTrigger, Addon }],
     ItemTitle: Title,
     ItemHint: Hint,
   },

--- a/semcore/dropdown-menu/src/index.d.ts
+++ b/semcore/dropdown-menu/src/index.d.ts
@@ -146,6 +146,15 @@ declare const DropdownMenu: Intergalactic.Component<
   };
   ItemTitle: Intergalactic.Component<'div', DropdownMenuItemTitleProps>;
   ItemHint: Intergalactic.Component<'div', DropdownMenuItemHintProps>;
+  Nesting: Intergalactic.Component<
+    'div',
+    DropdownMenuItemProps,
+    DropdownMenuContext,
+    [handlers: DropdownMenuHandlers]
+  > & {
+    Trigger: Intergalactic.Component<'div', DropdownMenuItemProps>;
+    Addon: typeof Box;
+  };
 };
 
 export default DropdownMenu;

--- a/semcore/dropdown-menu/src/style/dropdown-menu.shadow.css
+++ b/semcore/dropdown-menu/src/style/dropdown-menu.shadow.css
@@ -91,6 +91,14 @@ SDropdownMenuItem[variant='title'] {
   }
 }
 
+SDropdownMenuItem[visible] {
+  background-color: var(--intergalactic-dropdown-menu-item-hover, #f4f5f9);
+}
+
+SDropdownMenuItem[nesting-trigger] {
+  justify-content: space-between;
+}
+
 SDropdownMenuItemAddon {
   display: inline-flex;
   margin-left: var(--intergalactic-spacing-2x, 8px);
@@ -103,4 +111,15 @@ SDropdownMenuItemAddon {
   &:last-child {
     margin-right: 0;
   }
+}
+
+SDropdownMenuNesting,
+SDropdownMenuNesting[size='l'],
+SDropdownMenuNesting[size='m'] {
+  padding: 0;
+}
+
+SDropdownMenuNesting[highlighted] {
+  z-index: 1;
+  box-shadow: var(--intergalactic-keyboard-focus, 0px 0px 0px 3px rgba(0, 143, 248, 0.5)) inset;
 }

--- a/website/docs/components/dropdown-menu/examples/nested.tsx
+++ b/website/docs/components/dropdown-menu/examples/nested.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import DropdownMenu from '@semcore/ui/dropdown-menu';
 import { ButtonTrigger } from '@semcore/ui/base-trigger';
-import ChevronRight from '@semcore/ui/icon/ChevronRight/m';
+import ChevronRightIcon from '@semcore/ui/icon/ChevronRight/m';
 
 const Demo = () => {
   return (
@@ -9,26 +9,58 @@ const Demo = () => {
       <DropdownMenu.Trigger tag={ButtonTrigger}>Click me</DropdownMenu.Trigger>
       <DropdownMenu.Menu>
         <DropdownMenu.Item>Item 1</DropdownMenu.Item>
-        <DropdownMenu placement='right' interaction='hover' timeout={[0, 300]}>
-          <DropdownMenu.Trigger tag={DropdownMenu.Item}>
-            Item 2 <ChevronRight ml='auto' color='icon-primary-neutral' />
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Menu w={120}>
-            <DropdownMenu.Item>Item 1</DropdownMenu.Item>
-            <DropdownMenu.Item>Item 2</DropdownMenu.Item>
-            <DropdownMenu placement='right' interaction='hover' timeout={[0, 300]}>
-              <DropdownMenu.Trigger tag={DropdownMenu.Item}>
-                Item 3 <ChevronRight ml='auto' color='icon-primary-neutral' />
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Menu w={120}>
-                <DropdownMenu.Item>Item 1</DropdownMenu.Item>
-                <DropdownMenu.Item>Item 2</DropdownMenu.Item>
-                <DropdownMenu.Item>Item 3</DropdownMenu.Item>
-              </DropdownMenu.Menu>
-            </DropdownMenu>
-          </DropdownMenu.Menu>
-        </DropdownMenu>
+        <DropdownMenu.Item>Item 2</DropdownMenu.Item>
         <DropdownMenu.Item>Item 3</DropdownMenu.Item>
+        <DropdownMenu.Nesting>
+          <DropdownMenu placement='right' interaction='hover' timeout={[0, 300]}>
+            <DropdownMenu.Trigger tag={DropdownMenu.Nesting.Trigger}>
+              Item 4
+              <DropdownMenu.Nesting.Addon tag={ChevronRightIcon} />
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Menu w={120}>
+              <DropdownMenu.Nesting>
+                <DropdownMenu placement='right' interaction='hover' timeout={[0, 300]}>
+                  <DropdownMenu.Trigger tag={DropdownMenu.Nesting.Trigger}>
+                    Item 4.1
+                    <DropdownMenu.Nesting.Addon tag={ChevronRightIcon} />
+                  </DropdownMenu.Trigger>
+                  <DropdownMenu.Menu w={120}>
+                    <DropdownMenu.Item>Item 4.1.1</DropdownMenu.Item>
+                    <DropdownMenu.Item>Item 4.1.2</DropdownMenu.Item>
+                    <DropdownMenu.Item>Item 4.1.3</DropdownMenu.Item>
+                  </DropdownMenu.Menu>
+                </DropdownMenu>
+              </DropdownMenu.Nesting>
+              <DropdownMenu.Nesting>
+                <DropdownMenu placement='right' interaction='hover' timeout={[0, 300]}>
+                  <DropdownMenu.Trigger tag={DropdownMenu.Nesting.Trigger}>
+                    Item 4.2
+                    <DropdownMenu.Nesting.Addon tag={ChevronRightIcon} />
+                  </DropdownMenu.Trigger>
+                  <DropdownMenu.Menu w={120}>
+                    <DropdownMenu.Nesting>
+                      <DropdownMenu placement='right' interaction='hover' timeout={[0, 300]}>
+                        <DropdownMenu.Trigger tag={DropdownMenu.Nesting.Trigger}>
+                          Item 4.2.1
+                          <DropdownMenu.Nesting.Addon tag={ChevronRightIcon} />
+                        </DropdownMenu.Trigger>
+                        <DropdownMenu.Menu w={120}>
+                          <DropdownMenu.Item>Item 4.2.1.1</DropdownMenu.Item>
+                          <DropdownMenu.Item>Item 4.2.1.2</DropdownMenu.Item>
+                          <DropdownMenu.Item>Item 4.2.1.3</DropdownMenu.Item>
+                        </DropdownMenu.Menu>
+                      </DropdownMenu>
+                    </DropdownMenu.Nesting>
+                    <DropdownMenu.Item>Item 4.2.2</DropdownMenu.Item>
+                    <DropdownMenu.Item>Item 4.2.3</DropdownMenu.Item>
+                  </DropdownMenu.Menu>
+                </DropdownMenu>
+              </DropdownMenu.Nesting>
+              <DropdownMenu.Item>Item 4.3</DropdownMenu.Item>
+            </DropdownMenu.Menu>
+          </DropdownMenu>
+        </DropdownMenu.Nesting>
+        <DropdownMenu.Item>Item 5</DropdownMenu.Item>
       </DropdownMenu.Menu>
     </DropdownMenu>
   );


### PR DESCRIPTION
## Motivation and Context

Our dropdown menus are not accessible in case of building nested menus. Making #1102 unlocked the path to make it accessible. This PR adds special `DropdownMenu.Nesting` and `DropdownMenu.Nesting.Trigger` components that allows to build accessible nested menus.

## How has this been tested?

I have added new unit tests that cover testable cases. 

## Screenshots:

![image](https://github.com/semrush/intergalactic/assets/31261408/c97af808-5005-4380-85f2-8973887a7d5c)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [x] I have added new unit tests on added of fixed functionality.
