### PR TITLE
[select] removed `aria-owns` from the `Select.Trigger`

### DIFF
--- a/semcore/select/CHANGELOG.md
+++ b/semcore/select/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.32.0] - 2024-02-21
+
+### Changed
+
+- Removed `aria-owns` from the `Select.Trigger`. It was misleading assistive technologies and creating a "screen reader focus ring shift" effect. `aria-controls` is kept on the `Select.Trigger`.
+
 ## [4.31.0] - 2024-02-21
 
 ### Changed

--- a/semcore/select/src/Select.jsx
+++ b/semcore/select/src/Select.jsx
@@ -88,7 +88,6 @@ class RootSelect extends Component {
     return {
       id: `igc-${uid}-trigger`,
       'aria-controls': `igc-${uid}-list`,
-      'aria-owns': `igc-${uid}-list`,
       focusHint: visible && !disablePortal ? getI18nText('triggerHint') : undefined,
       'aria-haspopup': 'listbox',
       'aria-expanded': visible ? 'true' : 'false',


### PR DESCRIPTION
It was misleading assistive technologies and creating a "screen reader focus ring shift" effect, `aria-controls` is kept on the `Select.Trigger`.

## Motivation and Context

See screenshots.

## How has this been tested?

Not sure it's possible to test. And that tests are needed.

## Screenshots:

Before:

<img width="451" alt="Screenshot 2024-02-21 at 16 43 29" src="https://github.com/semrush/intergalactic/assets/31261408/2c8aa054-6b8b-44b4-9b85-7591c9943340">

After:

<img width="507" alt="Screenshot 2024-02-21 at 16 42 52" src="https://github.com/semrush/intergalactic/assets/31261408/2d5a6205-7c8d-4e6e-93c1-f9a9130a4c97">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
