### PR TITLE
[86bxkev49][base-trigger] fixed that filter trigger was setting aria attributes to wrapper instead of inner trigger

### DIFF
--- a/semcore/base-trigger/CHANGELOG.md
+++ b/semcore/base-trigger/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.26.3] - 2024-02-22
+
+### Fixed
+
+- Filter trigger options navigations were not announced by assistive technologies.
+
 ## [4.26.2] - 2024-02-21
 
 ### Changed

--- a/semcore/base-trigger/src/FilterTrigger.jsx
+++ b/semcore/base-trigger/src/FilterTrigger.jsx
@@ -18,6 +18,17 @@ import { setFocus } from '@semcore/utils/lib/use/useFocusLock';
 
 import style from './style/filter-trigger.shadow.css';
 
+const filterTriggerInputProps = [
+  ...inputProps,
+  'aria-controls',
+  'aria-haspopup',
+  'aria-expanded',
+  'aria-disabled',
+  'aria-activedescendant',
+  'aria-label',
+  'aria-labelledby',
+];
+
 class RootFilterTrigger extends Component {
   static displayName = 'FilterTrigger';
   static style = style;
@@ -36,7 +47,7 @@ class RootFilterTrigger extends Component {
     uniqueIDEnhancement(),
   ];
   static defaultProps = {
-    includeInputProps: inputProps,
+    includeInputProps: filterTriggerInputProps,
     i18n: localizedMessages,
     locale: 'en',
     triggerRef: React.createRef(),
@@ -82,6 +93,13 @@ class RootFilterTrigger extends Component {
         aria-label={getI18nText('filter')}
         __excludeProps={['id']}
         use:role={role}
+        use:aria-controls={undefined}
+        use:aria-haspopup={undefined}
+        use:aria-expanded={undefined}
+        use:aria-disabled={undefined}
+        use:aria-activedescendant={undefined}
+        use:aria-label={undefined}
+        use:aria-labelledby={undefined}
       >
         <NeighborLocation>
           <SFilterTrigger


### PR DESCRIPTION
## Motivation and Context

Our Filter trigger was found to not be accessible cause it was setting aria attributes on outer wrapper instead of inner trigger. I've fixed it. Solution is not perfect cause we need to add deep component customization but it's good enough just to make it accessible.

## How has this been tested?

Manual testing, soon I will enable a11y tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
