### PR TITLE
[86bxfj0xv][time-picker] fixed horizontal offset

### DIFF
--- a/semcore/time-picker/CHANGELOG.md
+++ b/semcore/time-picker/CHANGELOG.md
@@ -2,461 +2,473 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.32.0] - 2024-02-22
+
+### Fixed
+
+* TimePicker dropdowns had unexpected visual horizontal offset.
+
 ## [4.31.5] - 2024-02-27
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/select` [4.32.3 ~> 4.32.4]).
+* Version prepatch update due to children dependencies update (`@semcore/select` [4.32.3 ~> 4.32.4]).
 
 ## [4.31.4] - 2024-02-26
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/select` [4.32.2 ~> 4.32.3]).
+* Version prepatch update due to children dependencies update (`@semcore/select` [4.32.2 ~> 4.32.3]).
 
 ## [4.31.3] - 2024-02-22
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/select` [4.32.1 ~> 4.32.2]).
+* Version prepatch update due to children dependencies update (`@semcore/select` [4.32.1 ~> 4.32.2]).
+
+## [4.31.3-prerelease.1] - 2024-02-22
+
+### Changed
+
+* Version prepatch update due to children dependencies update (`@semcore/select` [4.32.1 ~> 4.32.2]).
 
 ## [4.31.2] - 2024-02-21
 
 ### Changed
 
-- Version prerelease update due to children dependencies update (`@semcore/button` [5.20.3-prerelease.10 ~> 5.20.3], `@semcore/flex-box` [5.19.2-prerelease.10 ~> 5.19.2], `@semcore/input` [4.20.3-prerelease.10 ~> 4.20.3], `@semcore/select` [4.32.0 ~> 4.32.1], `@semcore/core` [2.17.3-prerelease.10 ~> 2.17.3]).
+* Version prerelease update due to children dependencies update (`@semcore/button` [5.20.3-prerelease.10 ~> 5.20.3], `@semcore/flex-box` [5.19.2-prerelease.10 ~> 5.19.2], `@semcore/input` [4.20.3-prerelease.10 ~> 4.20.3], `@semcore/select` [4.32.0 ~> 4.32.1], `@semcore/core` [2.17.3-prerelease.10 ~> 2.17.3]).
 
 ## [4.31.1] - 2024-02-21
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.20.2 ~> 5.20.3], `@semcore/flex-box` [5.19.1 ~> 5.19.2], `@semcore/input` [4.20.2 ~> 4.20.3], `@semcore/select` [4.31.0 ~> 4.32.0], `@semcore/utils` [4.20.2 ~> 4.20.3], `@semcore/core` [2.17.2 ~> 2.17.3]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.20.2 ~> 5.20.3], `@semcore/flex-box` [5.19.1 ~> 5.19.2], `@semcore/input` [4.20.2 ~> 4.20.3], `@semcore/select` [4.31.0 ~> 4.32.0], `@semcore/utils` [4.20.2 ~> 4.20.3], `@semcore/core` [2.17.2 ~> 2.17.3]).
 
 ## [4.31.0] - 2024-02-21
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/select` [4.30.0 ~> 4.31.0]).
+* Version preminor update due to children dependencies update (`@semcore/select` [4.30.0 ~> 4.31.0]).
 
 ## [4.30.0] - 2024-02-21
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/select` [4.29.2 ~> 4.30.0]).
+* Version preminor update due to children dependencies update (`@semcore/select` [4.29.2 ~> 4.30.0]).
 
 ## [4.29.2] - 2024-02-19
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/select` [4.29.1 ~> 4.29.2]).
+* Version prepatch update due to children dependencies update (`@semcore/select` [4.29.1 ~> 4.29.2]).
 
 ## [4.29.1] - 2024-02-16
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/select` [4.29.0 ~> 4.29.1]).
+* Version prepatch update due to children dependencies update (`@semcore/select` [4.29.0 ~> 4.29.1]).
 
 ## [4.29.0] - 2024-02-14
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/select` [4.28.0 ~> 4.29.0]).
+* Version preminor update due to children dependencies update (`@semcore/select` [4.28.0 ~> 4.29.0]).
 
 ## [4.28.0] - 2024-02-13
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/select` [4.27.1 ~> 4.28.0]).
+* Version preminor update due to children dependencies update (`@semcore/select` [4.27.1 ~> 4.28.0]).
 
 ## [4.27.1] - 2024-02-09
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.20.1 ~> 5.20.2], `@semcore/flex-box` [5.19.0 ~> 5.19.1], `@semcore/input` [4.20.1 ~> 4.20.2], `@semcore/select` [4.27.0 ~> 4.27.1], `@semcore/utils` [4.20.1 ~> 4.20.2], `@semcore/core` [2.17.1 ~> 2.17.2]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.20.1 ~> 5.20.2], `@semcore/flex-box` [5.19.0 ~> 5.19.1], `@semcore/input` [4.20.1 ~> 4.20.2], `@semcore/select` [4.27.0 ~> 4.27.1], `@semcore/utils` [4.20.1 ~> 4.20.2], `@semcore/core` [2.17.1 ~> 2.17.2]).
 
 ## [4.27.0] - 2024-02-07
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/select` [4.26.1 ~> 4.27.0]).
+* Version preminor update due to children dependencies update (`@semcore/select` [4.26.1 ~> 4.27.0]).
 
 ## [4.26.1] - 2024-02-06
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.20.0 ~> 5.20.1], `@semcore/flex-box` [5.18.0 ~> 5.19.0], `@semcore/input` [4.20.0 ~> 4.20.1], `@semcore/select` [4.26.0 ~> 4.26.1], `@semcore/utils` [4.20.0 ~> 4.20.1], `@semcore/core` [2.17.0 ~> 2.17.1]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.20.0 ~> 5.20.1], `@semcore/flex-box` [5.18.0 ~> 5.19.0], `@semcore/input` [4.20.0 ~> 4.20.1], `@semcore/select` [4.26.0 ~> 4.26.1], `@semcore/utils` [4.20.0 ~> 4.20.1], `@semcore/core` [2.17.0 ~> 2.17.1]).
 
 ## [4.26.0] - 2024-02-01
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/button` [5.19.1 ~> 5.20.0], `@semcore/flex-box` [5.17.1 ~> 5.18.0], `@semcore/input` [4.19.1 ~> 4.20.0], `@semcore/select` [4.25.1 ~> 4.26.0], `@semcore/utils` [4.19.1 ~> 4.20.0], `@semcore/core` [2.16.1 ~> 2.17.0]).
+* Version preminor update due to children dependencies update (`@semcore/button` [5.19.1 ~> 5.20.0], `@semcore/flex-box` [5.17.1 ~> 5.18.0], `@semcore/input` [4.19.1 ~> 4.20.0], `@semcore/select` [4.25.1 ~> 4.26.0], `@semcore/utils` [4.19.1 ~> 4.20.0], `@semcore/core` [2.16.1 ~> 2.17.0]).
 
 ## [4.25.1] - 2024-02-01
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.19.0 ~> 5.19.1], `@semcore/flex-box` [5.17.0 ~> 5.17.1], `@semcore/input` [4.19.0 ~> 4.19.1], `@semcore/select` [4.25.0 ~> 4.25.1], `@semcore/utils` [4.19.0 ~> 4.19.1], `@semcore/core` [2.16.0 ~> 2.16.1]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.19.0 ~> 5.19.1], `@semcore/flex-box` [5.17.0 ~> 5.17.1], `@semcore/input` [4.19.0 ~> 4.19.1], `@semcore/select` [4.25.0 ~> 4.25.1], `@semcore/utils` [4.19.0 ~> 4.19.1], `@semcore/core` [2.16.0 ~> 2.16.1]).
 
 ## [4.25.0] - 2024-01-31
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/button` [5.18.0 ~> 5.19.0], `@semcore/flex-box` [5.16.0 ~> 5.17.0], `@semcore/input` [4.18.0 ~> 4.19.0], `@semcore/select` [4.24.1 ~> 4.25.0], `@semcore/utils` [4.18.0 ~> 4.19.0], `@semcore/core` [2.15.0 ~> 2.16.0]).
+* Version preminor update due to children dependencies update (`@semcore/button` [5.18.0 ~> 5.19.0], `@semcore/flex-box` [5.16.0 ~> 5.17.0], `@semcore/input` [4.18.0 ~> 4.19.0], `@semcore/select` [4.24.1 ~> 4.25.0], `@semcore/utils` [4.18.0 ~> 4.19.0], `@semcore/core` [2.15.0 ~> 2.16.0]).
 
 ## [4.24.1] - 2024-01-24
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/select` [4.24.0 ~> 4.24.1]).
+* Version prepatch update due to children dependencies update (`@semcore/select` [4.24.0 ~> 4.24.1]).
 
 ## [4.24.0] - 2024-01-19
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/button` [5.17.0 ~> 5.18.0], `@semcore/flex-box` [5.15.0 ~> 5.16.0], `@semcore/input` [4.17.0 ~> 4.18.0], `@semcore/select` [4.23.0 ~> 4.24.0], `@semcore/utils` [4.17.0 ~> 4.18.0], `@semcore/core` [2.14.0 ~> 2.15.0]).
+* Version preminor update due to children dependencies update (`@semcore/button` [5.17.0 ~> 5.18.0], `@semcore/flex-box` [5.15.0 ~> 5.16.0], `@semcore/input` [4.17.0 ~> 4.18.0], `@semcore/select` [4.23.0 ~> 4.24.0], `@semcore/utils` [4.17.0 ~> 4.18.0], `@semcore/core` [2.14.0 ~> 2.15.0]).
 
 ## [4.23.0] - 2024-01-19
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/button` [5.16.0 ~> 5.17.0], `@semcore/flex-box` [5.14.1 ~> 5.15.0], `@semcore/input` [4.16.1 ~> 4.17.0], `@semcore/select` [4.22.4 ~> 4.23.0], `@semcore/core` [2.13.1 ~> 2.14.0]).
+* Version preminor update due to children dependencies update (`@semcore/button` [5.16.0 ~> 5.17.0], `@semcore/flex-box` [5.14.1 ~> 5.15.0], `@semcore/input` [4.16.1 ~> 4.17.0], `@semcore/select` [4.22.4 ~> 4.23.0], `@semcore/core` [2.13.1 ~> 2.14.0]).
 
 ## [4.22.4] - 2024-01-15
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/select` [4.22.3 ~> 4.22.4]).
+* Version prepatch update due to children dependencies update (`@semcore/select` [4.22.3 ~> 4.22.4]).
 
 ## [4.22.3] - 2024-01-12
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/select` [4.22.2 ~> 4.22.3]).
+* Version prepatch update due to children dependencies update (`@semcore/select` [4.22.2 ~> 4.22.3]).
 
 ## [4.22.2] - 2024-01-10
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.15.0 ~> 5.16.0], `@semcore/flex-box` [5.14.0 ~> 5.14.1], `@semcore/input` [4.16.0 ~> 4.16.1], `@semcore/select` [4.22.1 ~> 4.22.2], `@semcore/utils` [4.16.0 ~> 4.16.2], `@semcore/core` [2.13.0 ~> 2.13.1]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.15.0 ~> 5.16.0], `@semcore/flex-box` [5.14.0 ~> 5.14.1], `@semcore/input` [4.16.0 ~> 4.16.1], `@semcore/select` [4.22.1 ~> 4.22.2], `@semcore/utils` [4.16.0 ~> 4.16.2], `@semcore/core` [2.13.0 ~> 2.13.1]).
 
 ## [4.22.1] - 2024-01-04
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/select` [4.22.0 ~> 4.22.1]).
+* Version prepatch update due to children dependencies update (`@semcore/select` [4.22.0 ~> 4.22.1]).
 
 ## [4.22.0] - 2023-12-22
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/button` [5.14.1 ~> 5.15.0], `@semcore/flex-box` [5.13.1 ~> 5.14.0], `@semcore/input` [4.15.1 ~> 4.16.0], `@semcore/select` [4.21.3 ~> 4.22.0], `@semcore/utils` [4.15.1 ~> 4.16.0], `@semcore/core` [2.12.1 ~> 2.13.0]).
+* Version preminor update due to children dependencies update (`@semcore/button` [5.14.1 ~> 5.15.0], `@semcore/flex-box` [5.13.1 ~> 5.14.0], `@semcore/input` [4.15.1 ~> 4.16.0], `@semcore/select` [4.21.3 ~> 4.22.0], `@semcore/utils` [4.15.1 ~> 4.16.0], `@semcore/core` [2.12.1 ~> 2.13.0]).
 
 ## [4.21.3] - 2023-12-19
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.14.0 ~> 5.14.1], `@semcore/flex-box` [5.13.0 ~> 5.13.1], `@semcore/input` [4.15.0 ~> 4.15.1], `@semcore/select` [4.21.2 ~> 4.21.3], `@semcore/utils` [4.15.0 ~> 4.15.1], `@semcore/core` [2.12.0 ~> 2.12.1]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.14.0 ~> 5.14.1], `@semcore/flex-box` [5.13.0 ~> 5.13.1], `@semcore/input` [4.15.0 ~> 4.15.1], `@semcore/select` [4.21.2 ~> 4.21.3], `@semcore/utils` [4.15.0 ~> 4.15.1], `@semcore/core` [2.12.0 ~> 2.12.1]).
 
 ## [4.21.2] - 2023-12-12
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/select` [4.21.1 ~> 4.21.2]).
+* Version prepatch update due to children dependencies update (`@semcore/select` [4.21.1 ~> 4.21.2]).
 
 ## [4.21.1] - 2023-12-07
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/select` [4.21.0 ~> 4.21.1]).
+* Version prepatch update due to children dependencies update (`@semcore/select` [4.21.0 ~> 4.21.1]).
 
 ## [4.21.0] - 2023-12-06
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/button` [5.13.0 ~> 5.14.0], `@semcore/flex-box` [5.12.0 ~> 5.13.0], `@semcore/input` [4.14.0 ~> 4.15.0], `@semcore/select` [4.20.0 ~> 4.21.0], `@semcore/core` [2.11.0 ~> 2.12.0]).
+* Version preminor update due to children dependencies update (`@semcore/button` [5.13.0 ~> 5.14.0], `@semcore/flex-box` [5.12.0 ~> 5.13.0], `@semcore/input` [4.14.0 ~> 4.15.0], `@semcore/select` [4.20.0 ~> 4.21.0], `@semcore/core` [2.11.0 ~> 2.12.0]).
 
 ## [4.20.0] - 2023-12-04
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/button` [5.12.0 ~> 5.13.0], `@semcore/flex-box` [5.11.0 ~> 5.12.0], `@semcore/input` [4.13.0 ~> 4.14.0], `@semcore/select` [4.19.0 ~> 4.20.0], `@semcore/utils` [4.13.0 ~> 4.14.0], `@semcore/core` [2.10.0 ~> 2.11.0]).
+* Version preminor update due to children dependencies update (`@semcore/button` [5.12.0 ~> 5.13.0], `@semcore/flex-box` [5.11.0 ~> 5.12.0], `@semcore/input` [4.13.0 ~> 4.14.0], `@semcore/select` [4.19.0 ~> 4.20.0], `@semcore/utils` [4.13.0 ~> 4.14.0], `@semcore/core` [2.10.0 ~> 2.11.0]).
 
 ## [4.19.0] - 2023-11-24
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/button` [5.11.3 ~> 5.12.0], `@semcore/flex-box` [5.10.2 ~> 5.11.0], `@semcore/input` [4.12.2 ~> 4.13.0], `@semcore/select` [4.18.1 ~> 4.19.0], `@semcore/utils` [4.10.3 ~> 4.13.0], `@semcore/core` [2.9.2 ~> 2.10.0]).
+* Version preminor update due to children dependencies update (`@semcore/button` [5.11.3 ~> 5.12.0], `@semcore/flex-box` [5.10.2 ~> 5.11.0], `@semcore/input` [4.12.2 ~> 4.13.0], `@semcore/select` [4.18.1 ~> 4.19.0], `@semcore/utils` [4.10.3 ~> 4.13.0], `@semcore/core` [2.9.2 ~> 2.10.0]).
 
 ## [4.18.2] - 2023-11-21
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.11.2 ~> 5.11.3], `@semcore/flex-box` [5.10.1 ~> 5.10.2], `@semcore/input` [4.12.1 ~> 4.12.2], `@semcore/select` [4.18.0 ~> 4.18.1], `@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/core` [2.9.1 ~> 2.9.2]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.11.2 ~> 5.11.3], `@semcore/flex-box` [5.10.1 ~> 5.10.2], `@semcore/input` [4.12.1 ~> 4.12.2], `@semcore/select` [4.18.0 ~> 4.18.1], `@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/core` [2.9.1 ~> 2.9.2]).
 
 ## [4.18.1] - 2023-11-14
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.11.1 ~> 5.11.2]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.11.1 ~> 5.11.2]).
 
 ## [4.18.0] - 2023-11-13
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/select` [4.17.5 ~> 4.18.0]).
+* Version preminor update due to children dependencies update (`@semcore/select` [4.17.5 ~> 4.18.0]).
 
 ## [4.17.5] - 2023-11-10
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/select` [4.17.4 ~> 4.17.5]).
+* Version prepatch update due to children dependencies update (`@semcore/select` [4.17.4 ~> 4.17.5]).
 
 ## [4.17.4] - 2023-11-10
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/select` [4.17.3 ~> 4.17.4]).
+* Version prepatch update due to children dependencies update (`@semcore/select` [4.17.3 ~> 4.17.4]).
 
 ## [4.17.3] - 2023-11-09
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.11.0 ~> 5.11.1], `@semcore/flex-box` [5.10.0 ~> 5.10.1], `@semcore/input` [4.12.0 ~> 4.12.1], `@semcore/select` [4.17.2 ~> 4.17.3], `@semcore/utils` [4.10.1 ~> 4.10.2], `@semcore/core` [2.9.0 ~> 2.9.1]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.11.0 ~> 5.11.1], `@semcore/flex-box` [5.10.0 ~> 5.10.1], `@semcore/input` [4.12.0 ~> 4.12.1], `@semcore/select` [4.17.2 ~> 4.17.3], `@semcore/utils` [4.10.1 ~> 4.10.2], `@semcore/core` [2.9.0 ~> 2.9.1]).
 
 ## [4.17.2] - 2023-11-07
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/select` [4.17.0 ~> 4.17.1]).
+* Version prepatch update due to children dependencies update (`@semcore/select` [4.17.0 ~> 4.17.1]).
 
 ## [4.17.0] - 2023-11-06
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/button` [5.10.0 ~> 5.11.0], `@semcore/flex-box` [5.9.0 ~> 5.10.0], `@semcore/input` [4.11.0 ~> 4.12.0], `@semcore/select` [4.16.0 ~> 4.17.0], `@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/core` [2.8.0 ~> 2.9.0]).
+* Version preminor update due to children dependencies update (`@semcore/button` [5.10.0 ~> 5.11.0], `@semcore/flex-box` [5.9.0 ~> 5.10.0], `@semcore/input` [4.11.0 ~> 4.12.0], `@semcore/select` [4.16.0 ~> 4.17.0], `@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/core` [2.8.0 ~> 2.9.0]).
 
 ## [4.16.0] - 2023-10-31
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/select` [4.15.0 ~> 4.16.0]).
+* Version preminor update due to children dependencies update (`@semcore/select` [4.15.0 ~> 4.16.0]).
 
 ## [4.15.0] - 2023-10-27
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/button` [5.9.3 ~> 5.10.0], `@semcore/flex-box` [5.8.2 ~> 5.9.0], `@semcore/input` [4.10.2 ~> 4.11.0], `@semcore/select` [4.14.0 ~> 4.15.0], `@semcore/utils` [4.8.4 ~> 4.9.0], `@semcore/core` [2.7.7 ~> 2.8.0]).
+* Version preminor update due to children dependencies update (`@semcore/button` [5.9.3 ~> 5.10.0], `@semcore/flex-box` [5.8.2 ~> 5.9.0], `@semcore/input` [4.10.2 ~> 4.11.0], `@semcore/select` [4.14.0 ~> 4.15.0], `@semcore/utils` [4.8.4 ~> 4.9.0], `@semcore/core` [2.7.7 ~> 2.8.0]).
 
 ## [4.14.0] - 2023-10-26
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/select` [4.13.3 ~> 4.14.0]).
+* Version preminor update due to children dependencies update (`@semcore/select` [4.13.3 ~> 4.14.0]).
 
 ## [4.13.4] - 2023-10-24
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.9.2 ~> 5.9.3], `@semcore/flex-box` [5.8.1 ~> 5.8.2], `@semcore/input` [4.10.1 ~> 4.10.2], `@semcore/select` [4.13.2 ~> 4.13.3], `@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/core` [2.7.6 ~> 2.7.7]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.9.2 ~> 5.9.3], `@semcore/flex-box` [5.8.1 ~> 5.8.2], `@semcore/input` [4.10.1 ~> 4.10.2], `@semcore/select` [4.13.2 ~> 4.13.3], `@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/core` [2.7.6 ~> 2.7.7]).
 
 ## [4.13.3] - 2023-10-16
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.9.1 ~> 5.9.2], `@semcore/flex-box` [5.8.0 ~> 5.8.1], `@semcore/input` [4.10.0 ~> 4.10.1], `@semcore/select` [4.13.1 ~> 4.13.2], `@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/core` [2.7.5 ~> 2.7.6]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.9.1 ~> 5.9.2], `@semcore/flex-box` [5.8.0 ~> 5.8.1], `@semcore/input` [4.10.0 ~> 4.10.1], `@semcore/select` [4.13.1 ~> 4.13.2], `@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/core` [2.7.5 ~> 2.7.6]).
 
 ## [4.13.2] - 2023-10-13
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.9.0 ~> 5.9.1]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.9.0 ~> 5.9.1]).
 
 ## [4.13.1] - 2023-10-10
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.8.5 ~> 5.9.0], `@semcore/flex-box` [5.7.5 ~> 5.8.0], `@semcore/input` [4.9.5 ~> 4.10.0], `@semcore/select` [4.13.0 ~> 4.13.1]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.8.5 ~> 5.9.0], `@semcore/flex-box` [5.7.5 ~> 5.8.0], `@semcore/input` [4.9.5 ~> 4.10.0], `@semcore/select` [4.13.0 ~> 4.13.1]).
 
 ## [4.13.0] - 2023-10-09
 
 ### Added
 
-- `nl` locale support.
+* `nl` locale support.
 
 ## [4.12.5] - 2023-10-06
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.8.4 ~> 5.8.5], `@semcore/flex-box` [5.7.4 ~> 5.7.5], `@semcore/input` [4.9.4 ~> 4.9.5], `@semcore/select` [4.12.4 ~> 4.12.5], `@semcore/utils` [4.8.1 ~> 4.8.2], `@semcore/core` [2.7.4 ~> 2.7.5]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.8.4 ~> 5.8.5], `@semcore/flex-box` [5.7.4 ~> 5.7.5], `@semcore/input` [4.9.4 ~> 4.9.5], `@semcore/select` [4.12.4 ~> 4.12.5], `@semcore/utils` [4.8.1 ~> 4.8.2], `@semcore/core` [2.7.4 ~> 2.7.5]).
 
 ## [4.12.4] - 2023-10-03
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.8.3 ~> 5.8.4], `@semcore/flex-box` [5.7.3 ~> 5.7.4], `@semcore/input` [4.9.3 ~> 4.9.4], `@semcore/select` [4.12.3 ~> 4.12.4], `@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/core` [2.7.3 ~> 2.7.4]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.8.3 ~> 5.8.4], `@semcore/flex-box` [5.7.3 ~> 5.7.4], `@semcore/input` [4.9.3 ~> 4.9.4], `@semcore/select` [4.12.3 ~> 4.12.4], `@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/core` [2.7.3 ~> 2.7.4]).
 
 ## [4.12.3] - 2023-10-02
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.8.2 ~> 5.8.3], `@semcore/flex-box` [5.7.2 ~> 5.7.3], `@semcore/input` [4.9.2 ~> 4.9.3], `@semcore/select` [4.12.2 ~> 4.12.3], `@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/core` [2.7.2 ~> 2.7.3]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.8.2 ~> 5.8.3], `@semcore/flex-box` [5.7.2 ~> 5.7.3], `@semcore/input` [4.9.2 ~> 4.9.3], `@semcore/select` [4.12.2 ~> 4.12.3], `@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/core` [2.7.2 ~> 2.7.3]).
 
 ## [4.12.2] - 2023-09-20
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.8.1 ~> 5.8.2], `@semcore/flex-box` [5.7.1 ~> 5.7.2], `@semcore/input` [4.9.1 ~> 4.9.2], `@semcore/select` [4.12.1 ~> 4.12.2], `@semcore/core` [2.7.1 ~> 2.7.2]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.8.1 ~> 5.8.2], `@semcore/flex-box` [5.7.1 ~> 5.7.2], `@semcore/input` [4.9.1 ~> 4.9.2], `@semcore/select` [4.12.1 ~> 4.12.2], `@semcore/core` [2.7.1 ~> 2.7.2]).
 
 ## [4.12.1] - 2023-09-20
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.8.0 ~> 5.8.1], `@semcore/flex-box` [5.7.0 ~> 5.7.1], `@semcore/input` [4.9.0 ~> 4.9.1], `@semcore/select` [4.12.0 ~> 4.12.1], `@semcore/utils` [4.7.0 ~> 4.7.1], `@semcore/core` [2.7.0 ~> 2.7.1]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.8.0 ~> 5.8.1], `@semcore/flex-box` [5.7.0 ~> 5.7.1], `@semcore/input` [4.9.0 ~> 4.9.1], `@semcore/select` [4.12.0 ~> 4.12.1], `@semcore/utils` [4.7.0 ~> 4.7.1], `@semcore/core` [2.7.0 ~> 2.7.1]).
 
 ## [4.12.0] - 2023-09-19
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/select` [4.11.0 ~> 4.12.0]).
+* Version preminor update due to children dependencies update (`@semcore/select` [4.11.0 ~> 4.12.0]).
 
 ## [4.11.0] - 2023-09-15
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/select` [4.10.3 ~> 4.11.0]).
+* Version preminor update due to children dependencies update (`@semcore/select` [4.10.3 ~> 4.11.0]).
 
 ## [4.10.3] - 2023-09-13
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.7.3 ~> 5.8.0], `@semcore/flex-box` [5.6.3 ~> 5.7.0], `@semcore/input` [4.8.3 ~> 4.9.0], `@semcore/select` [4.10.2 ~> 4.10.3], `@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.7.3 ~> 5.8.0], `@semcore/flex-box` [5.6.3 ~> 5.7.0], `@semcore/input` [4.8.3 ~> 4.9.0], `@semcore/select` [4.10.2 ~> 4.10.3], `@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
 
 ## [4.10.2] - 2023-09-12
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.7.2 ~> 5.7.3], `@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/input` [4.8.2 ~> 4.8.3], `@semcore/select` [4.10.1 ~> 4.10.2], `@semcore/core` [2.6.2 ~> 2.6.3]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.7.2 ~> 5.7.3], `@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/input` [4.8.2 ~> 4.8.3], `@semcore/select` [4.10.1 ~> 4.10.2], `@semcore/core` [2.6.2 ~> 2.6.3]).
 
 ## [4.10.1] - 2023-09-08
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.7.1 ~> 5.7.2], `@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/input` [4.8.1 ~> 4.8.2], `@semcore/select` [4.10.0 ~> 4.10.1], `@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.7.1 ~> 5.7.2], `@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/input` [4.8.1 ~> 4.8.2], `@semcore/select` [4.10.0 ~> 4.10.1], `@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
 
 ## [4.10.0] - 2023-09-05
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/select` [4.9.1 ~> 4.10.0]).
+* Version preminor update due to children dependencies update (`@semcore/select` [4.9.1 ~> 4.10.0]).
 
 ## [4.9.1] - 2023-09-05
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.7.0 ~> 5.7.1], `@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/input` [4.8.0 ~> 4.8.1], `@semcore/select` [4.9.0 ~> 4.9.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.7.0 ~> 5.7.1], `@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/input` [4.8.0 ~> 4.8.1], `@semcore/select` [4.9.0 ~> 4.9.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
 
 ## [4.9.0] - 2023-09-04
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/button` [5.6.0 ~> 5.7.0], `@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/input` [4.7.0 ~> 4.8.0], `@semcore/select` [4.8.0 ~> 4.9.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
+* Version preminor update due to children dependencies update (`@semcore/button` [5.6.0 ~> 5.7.0], `@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/input` [4.7.0 ~> 4.8.0], `@semcore/select` [4.8.0 ~> 4.9.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
 
 ## [4.8.0] - 2023-08-28
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/button` [5.5.1 ~> 5.6.0], `@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/input` [4.6.1 ~> 4.7.0], `@semcore/select` [4.7.1 ~> 4.8.0], `@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
+* Version preminor update due to children dependencies update (`@semcore/button` [5.5.1 ~> 5.6.0], `@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/input` [4.6.1 ~> 4.7.0], `@semcore/select` [4.7.1 ~> 4.8.0], `@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
 
 ## [4.7.1] - 2023-08-24
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.5.0 ~> 5.5.1], `@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/input` [4.6.0 ~> 4.6.1], `@semcore/select` [4.7.0 ~> 4.7.1], `@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.5.0 ~> 5.5.1], `@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/input` [4.6.0 ~> 4.6.1], `@semcore/select` [4.7.0 ~> 4.7.1], `@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
 
 ## [4.7.0] - 2023-08-23
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/select` [4.6.0 ~> 4.7.0]).
+* Version preminor update due to children dependencies update (`@semcore/select` [4.6.0 ~> 4.7.0]).
 
 ## [4.6.0] - 2023-08-23
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/button` [5.3.1 ~> 5.5.0], `@semcore/flex-box` [5.3.1 ~> 5.4.0], `@semcore/input` [4.4.1 ~> 4.6.0], `@semcore/select` [4.5.1 ~> 4.6.0], `@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
+* Version preminor update due to children dependencies update (`@semcore/button` [5.3.1 ~> 5.5.0], `@semcore/flex-box` [5.3.1 ~> 5.4.0], `@semcore/input` [4.4.1 ~> 4.6.0], `@semcore/select` [4.5.1 ~> 4.6.0], `@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
 
 ## [4.5.1] - 2023-08-21
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.3.0 ~> 5.3.1], `@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/input` [4.4.0 ~> 4.4.1], `@semcore/select` [4.5.0 ~> 4.5.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.3.0 ~> 5.3.1], `@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/input` [4.4.0 ~> 4.4.1], `@semcore/select` [4.5.0 ~> 4.5.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
 
 ## [4.5.0] - 2023-08-18
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/button` [5.2.2 ~> 5.3.0], `@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/input` [4.3.2 ~> 4.4.0], `@semcore/select` [4.4.1 ~> 4.5.0], `@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
+* Version preminor update due to children dependencies update (`@semcore/button` [5.2.2 ~> 5.3.0], `@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/input` [4.3.2 ~> 4.4.0], `@semcore/select` [4.4.1 ~> 4.5.0], `@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
 
 ## [4.4.1] - 2023-08-18
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.2.1 ~> 5.2.2], `@semcore/input` [4.3.1 ~> 4.3.2], `@semcore/select` [4.4.0 ~> 4.4.1]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.2.1 ~> 5.2.2], `@semcore/input` [4.3.1 ~> 4.3.2], `@semcore/select` [4.4.0 ~> 4.4.1]).
 
 ## [4.4.0] - 2023-08-17
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/select` [4.3.2 ~> 4.4.0]).
+* Version preminor update due to children dependencies update (`@semcore/select` [4.3.2 ~> 4.4.0]).
 
 ## [4.3.2] - 2023-08-16
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/button` [5.2.0 ~> 5.2.1], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/input` [4.3.0 ~> 4.3.1], `@semcore/select` [4.3.1 ~> 4.3.2], `@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/core` [2.2.0 ~> 2.2.1]).
+* Version prepatch update due to children dependencies update (`@semcore/button` [5.2.0 ~> 5.2.1], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/input` [4.3.0 ~> 4.3.1], `@semcore/select` [4.3.1 ~> 4.3.2], `@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/core` [2.2.0 ~> 2.2.1]).
 
 ## [4.3.1] - 2023-08-10
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/select` [4.3.0 ~> 4.3.1]).
+* Version patch update due to children dependencies update (`@semcore/select` [4.3.0 ~> 4.3.1]).
 
 ## [4.3.0] - 2023-08-07
 
 ### Changed
 
-- Version minor update due to children dependencies update (`@semcore/button` [5.1.0 ~> 5.2.0], `@semcore/flex-box` [5.1.0 ~> 5.2.0], `@semcore/input` [4.2.0 ~> 4.3.0], `@semcore/select` [4.2.0 ~> 4.3.0], `@semcore/utils` [4.0.0 ~> 4.1.0]).
+* Version minor update due to children dependencies update (`@semcore/button` [5.1.0 ~> 5.2.0], `@semcore/flex-box` [5.1.0 ~> 5.2.0], `@semcore/input` [4.2.0 ~> 4.3.0], `@semcore/select` [4.2.0 ~> 4.3.0], `@semcore/utils` [4.0.0 ~> 4.1.0]).
 
 ## [4.2.0] - 2023-08-01
 
 ### Changed
 
-- Version minor update due to children dependencies update (`@semcore/button` [5.0.1 ~> 5.1.0], `@semcore/flex-box` [5.0.0 ~> 5.1.0], `@semcore/input` [4.1.0 ~> 4.2.0], `@semcore/select` [4.1.0 ~> 4.2.0]).
+* Version minor update due to children dependencies update (`@semcore/button` [5.0.1 ~> 5.1.0], `@semcore/flex-box` [5.0.0 ~> 5.1.0], `@semcore/input` [4.1.0 ~> 4.2.0], `@semcore/select` [4.1.0 ~> 4.2.0]).
 
 ## [4.1.0] - 2023-07-27
 
 ### Changed
 
-- Use `event.key` instead of `event.code` for better support of non QWERTY keyboard layouts.
+* Use `event.key` instead of `event.code` for better support of non QWERTY keyboard layouts.
 
 ## [4.0.2] - 2023-07-24
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [5.0.0 ~> 5.0.1], `@semcore/input` [4.0.0 ~> 4.0.1], `@semcore/select` [4.0.1 ~> 4.0.2]).
+* Version patch update due to children dependencies update (`@semcore/button` [5.0.0 ~> 5.0.1], `@semcore/input` [4.0.0 ~> 4.0.1], `@semcore/select` [4.0.1 ~> 4.0.2]).
 
 ## [4.0.1] - 2023-07-18
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/select` [4.0.0 ~> 4.0.1]).
+* Version patch update due to children dependencies update (`@semcore/select` [4.0.0 ~> 4.0.1]).
 
 ## [4.0.0] - 2023-07-17
 
 ### Break
 
-- Strict, backward incompatible typings.
+* Strict, backward incompatible typings.
 
 ## [3.7.4] - 2023-07-17
 
@@ -466,25 +478,25 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/select` [3.10.1 ~> 3.10.2]).
+* Version patch update due to children dependencies update (`@semcore/select` [3.10.1 ~> 3.10.2]).
 
 ## [3.7.1] - 2023-06-27
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.4.7 ~> 4.4.8], `@semcore/flex-box` [4.7.31 ~> 4.7.32], `@semcore/input` [3.7.0 ~> 3.7.1], `@semcore/select` [3.9.6 ~> 3.10.1], `@semcore/utils` [3.53.4 ~> 3.54.0]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.4.7 ~> 4.4.8], `@semcore/flex-box` [4.7.31 ~> 4.7.32], `@semcore/input` [3.7.0 ~> 3.7.1], `@semcore/select` [3.9.6 ~> 3.10.1], `@semcore/utils` [3.53.4 ~> 3.54.0]).
 
 ## [3.7.0] - 2023-06-22
 
 ### Added
 
-- Swedish (`sv`) locale support.
+* Swedish (`sv`) locale support.
 
 ## [3.6.9] - 2023-06-16
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/select` [3.9.4 ~> 3.9.5]).
+* Version patch update due to children dependencies update (`@semcore/select` [3.9.4 ~> 3.9.5]).
 
 ## [3.6.8] - 2023-06-15
 
@@ -492,139 +504,139 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.4.6 ~> 4.4.7], `@semcore/flex-box` [4.7.30 ~> 4.7.31], `@semcore/input` [3.6.31 ~> 3.6.32], `@semcore/select` [3.9.2 ~> 3.9.3], `@semcore/utils` [3.53.3 ~> 3.53.4]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.4.6 ~> 4.4.7], `@semcore/flex-box` [4.7.30 ~> 4.7.31], `@semcore/input` [3.6.31 ~> 3.6.32], `@semcore/select` [3.9.2 ~> 3.9.3], `@semcore/utils` [3.53.3 ~> 3.53.4]).
 
 ## [3.6.6] - 2023-06-13
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/select` [3.9.1 ~> 3.9.2]).
+* Version patch update due to children dependencies update (`@semcore/select` [3.9.1 ~> 3.9.2]).
 
 ## [3.6.5] - 2023-06-13
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/select` [3.9.0 ~> 3.9.1]).
+* Version patch update due to children dependencies update (`@semcore/select` [3.9.0 ~> 3.9.1]).
 
 ## [3.6.4] - 2023-06-13
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/select` [3.8.3 ~> 3.9.0]).
+* Version patch update due to children dependencies update (`@semcore/select` [3.8.3 ~> 3.9.0]).
 
 ## [3.6.3] - 2023-06-12
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.4.5 ~> 4.4.6], `@semcore/flex-box` [4.7.29 ~> 4.7.30], `@semcore/input` [3.6.30 ~> 3.6.31], `@semcore/select` [3.8.2 ~> 3.8.3], `@semcore/utils` [3.53.2 ~> 3.53.3]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.4.5 ~> 4.4.6], `@semcore/flex-box` [4.7.29 ~> 4.7.30], `@semcore/input` [3.6.30 ~> 3.6.31], `@semcore/select` [3.8.2 ~> 3.8.3], `@semcore/utils` [3.53.2 ~> 3.53.3]).
 
 ## [3.6.2] - 2023-06-12
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/select` [3.8.1 ~> 3.8.2]).
+* Version patch update due to children dependencies update (`@semcore/select` [3.8.1 ~> 3.8.2]).
 
 ## [3.6.1] - 2023-06-09
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.4.4 ~> 4.4.5], `@semcore/flex-box` [4.7.28 ~> 4.7.29], `@semcore/input` [3.6.29 ~> 3.6.30], `@semcore/select` [3.8.0 ~> 3.8.1], `@semcore/utils` [3.53.1 ~> 3.53.2]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.4.4 ~> 4.4.5], `@semcore/flex-box` [4.7.28 ~> 4.7.29], `@semcore/input` [3.6.29 ~> 3.6.30], `@semcore/select` [3.8.0 ~> 3.8.1], `@semcore/utils` [3.53.1 ~> 3.53.2]).
 
 ## [3.6.0] - 2023-06-09
 
 ### Added
 
-- Polish (`pl`) locale support.
+* Polish (`pl`) locale support.
 
 ## [3.5.1] - 2023-06-07
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.4.3 ~> 4.4.4], `@semcore/flex-box` [4.7.27 ~> 4.7.28], `@semcore/input` [3.6.28 ~> 3.6.29], `@semcore/select` [3.6.18 ~> 3.7.0], `@semcore/utils` [3.53.0 ~> 3.53.1]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.4.3 ~> 4.4.4], `@semcore/flex-box` [4.7.27 ~> 4.7.28], `@semcore/input` [3.6.28 ~> 3.6.29], `@semcore/select` [3.6.18 ~> 3.7.0], `@semcore/utils` [3.53.0 ~> 3.53.1]).
 
 ## [3.5.0] - 2023-06-06
 
 ### Added
 
-- Focused text part highlight.
+* Focused text part highlight.
 
 ## [3.4.56] - 2023-06-07
 
 ### Fixed
 
-- Improved keyboard navigation.
+* Improved keyboard navigation.
 
 ## [3.4.55] - 2023-05-31
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.4.2 ~> 4.4.3], `@semcore/flex-box` [4.7.26 ~> 4.7.27], `@semcore/input` [3.6.27 ~> 3.6.28], `@semcore/select` [3.6.16 ~> 3.6.17], `@semcore/utils` [3.52.0 ~> 3.53.0]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.4.2 ~> 4.4.3], `@semcore/flex-box` [4.7.26 ~> 4.7.27], `@semcore/input` [3.6.27 ~> 3.6.28], `@semcore/select` [3.6.16 ~> 3.6.17], `@semcore/utils` [3.52.0 ~> 3.53.0]).
 
 ## [3.4.54] - 2023-05-25
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.4.1 ~> 4.4.2], `@semcore/flex-box` [4.7.25 ~> 4.7.26], `@semcore/input` [3.6.26 ~> 3.6.27], `@semcore/select` [3.6.15 ~> 3.6.16], `@semcore/utils` [3.51.1 ~> 3.52.0]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.4.1 ~> 4.4.2], `@semcore/flex-box` [4.7.25 ~> 4.7.26], `@semcore/input` [3.6.26 ~> 3.6.27], `@semcore/select` [3.6.15 ~> 3.6.16], `@semcore/utils` [3.51.1 ~> 3.52.0]).
 
 ## [3.4.53] - 2023-05-24
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.4.0 ~> 4.4.1], `@semcore/flex-box` [4.7.24 ~> 4.7.25], `@semcore/input` [3.6.25 ~> 3.6.26], `@semcore/select` [3.6.14 ~> 3.6.15], `@semcore/utils` [3.51.0 ~> 3.51.1]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.4.0 ~> 4.4.1], `@semcore/flex-box` [4.7.24 ~> 4.7.25], `@semcore/input` [3.6.25 ~> 3.6.26], `@semcore/select` [3.6.14 ~> 3.6.15], `@semcore/utils` [3.51.0 ~> 3.51.1]).
 
 ## [3.4.52] - 2023-05-22
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.3.24 ~> 4.4.0], `@semcore/flex-box` [4.7.23 ~> 4.7.24], `@semcore/input` [3.5.25 ~> 3.6.25], `@semcore/select` [3.6.13 ~> 3.6.14], `@semcore/utils` [3.50.7 ~> 3.51.0]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.3.24 ~> 4.4.0], `@semcore/flex-box` [4.7.23 ~> 4.7.24], `@semcore/input` [3.5.25 ~> 3.6.25], `@semcore/select` [3.6.13 ~> 3.6.14], `@semcore/utils` [3.50.7 ~> 3.51.0]).
 
 ## [3.4.51] - 2023-05-22
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/select` [3.6.12 ~> 3.6.13]).
+* Version patch update due to children dependencies update (`@semcore/select` [3.6.12 ~> 3.6.13]).
 
 ## [3.4.50] - 2023-05-11
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.3.23 ~> 4.3.24], `@semcore/flex-box` [4.7.22 ~> 4.7.23], `@semcore/input` [3.5.24 ~> 3.5.25], `@semcore/select` [3.6.11 ~> 3.6.12], `@semcore/utils` [3.50.6 ~> 3.50.7]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.3.23 ~> 4.3.24], `@semcore/flex-box` [4.7.22 ~> 4.7.23], `@semcore/input` [3.5.24 ~> 3.5.25], `@semcore/select` [3.6.11 ~> 3.6.12], `@semcore/utils` [3.50.6 ~> 3.50.7]).
 
 ## [3.4.49] - 2023-05-04
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.3.22 ~> 4.3.23], `@semcore/flex-box` [4.7.21 ~> 4.7.22], `@semcore/input` [3.5.23 ~> 3.5.24], `@semcore/select` [3.6.10 ~> 3.6.11], `@semcore/utils` [3.50.5 ~> 3.50.6]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.3.22 ~> 4.3.23], `@semcore/flex-box` [4.7.21 ~> 4.7.22], `@semcore/input` [3.5.23 ~> 3.5.24], `@semcore/select` [3.6.10 ~> 3.6.11], `@semcore/utils` [3.50.5 ~> 3.50.6]).
 
 ## [3.4.45] - 2023-05-02
 
 ### Changed
 
-- Removed `aria-flowto` because it has bad screen readers support and often confuse users in supporting screen readers.
+* Removed `aria-flowto` because it has bad screen readers support and often confuse users in supporting screen readers.
 
 ## [3.4.44] - 2023-04-28
 
 ### Added
 
-- Added ARIA attributes for better accessibility.
+* Added ARIA attributes for better accessibility.
 
 ## [3.4.40] - 2023-04-11
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.3.18 ~> 4.3.19]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.3.18 ~> 4.3.19]).
 
 ## [3.4.37] - 2023-03-28
 
 ### Added
 
-- Added default color (`--intergalactic-text-primary`) to `Separator` component.
+* Added default color (`--intergalactic-text-primary`) to `Separator` component.
 
 ## [3.4.36] - 2023-03-28
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.3.17 ~> 4.3.18], `@semcore/flex-box` [4.7.17 ~> 4.7.18], `@semcore/input` [3.5.17 ~> 3.5.18], `@semcore/select` [3.5.10 ~> 3.5.11], `@semcore/utils` [3.49.1 ~> 3.50.0]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.3.17 ~> 4.3.18], `@semcore/flex-box` [4.7.17 ~> 4.7.18], `@semcore/input` [3.5.17 ~> 3.5.18], `@semcore/select` [3.5.10 ~> 3.5.11], `@semcore/utils` [3.49.1 ~> 3.50.0]).
 
 ## [3.4.22] - 2023-03-01
 
@@ -632,7 +644,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/select` [3.4.20 ~> 3.4.21]).
+* Version patch update due to children dependencies update (`@semcore/select` [3.4.20 ~> 3.4.21]).
 
 ## [3.4.20] - 2023-02-22
 
@@ -640,7 +652,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.3.9 ~> 4.3.10], `@semcore/flex-box` [4.7.9 ~> 4.7.10], `@semcore/input` [3.5.9 ~> 3.5.10], `@semcore/select` [3.4.18 ~> 3.4.19], `@semcore/utils` [3.47.0 ~> 3.47.1]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.3.9 ~> 4.3.10], `@semcore/flex-box` [4.7.9 ~> 4.7.10], `@semcore/input` [3.5.9 ~> 3.5.10], `@semcore/select` [3.4.18 ~> 3.4.19], `@semcore/utils` [3.47.0 ~> 3.47.1]).
 
 ## [3.4.16] - 2023-02-13
 
@@ -648,13 +660,13 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Renamed rounding design token (`--intergalactic-rounded-medium` -> `--intergalactic-control-rounded`).
+* Renamed rounding design token (`--intergalactic-rounded-medium` -> `--intergalactic-control-rounded`).
 
 ## [3.4.14] - 2023-01-20
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.3.6 ~> 4.3.7], `@semcore/flex-box` [4.7.6 ~> 4.7.7], `@semcore/input` [3.5.6 ~> 3.5.7], `@semcore/select` [3.4.13 ~> 3.4.14], `@semcore/utils` [3.45.0 ~> 3.46.0]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.3.6 ~> 4.3.7], `@semcore/flex-box` [4.7.6 ~> 4.7.7], `@semcore/input` [3.5.6 ~> 3.5.7], `@semcore/select` [3.4.13 ~> 3.4.14], `@semcore/utils` [3.45.0 ~> 3.46.0]).
 
 ## [3.4.10] - 2023-01-11
 
@@ -662,7 +674,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/select` [3.4.8 ~> 3.4.9]).
+* Version patch update due to children dependencies update (`@semcore/select` [3.4.8 ~> 3.4.9]).
 
 ## [3.4.8] - 2023-01-10
 
@@ -670,294 +682,294 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.3.3 ~> 4.3.4], `@semcore/flex-box` [4.7.3 ~> 4.7.4], `@semcore/input` [3.5.3 ~> 3.5.4], `@semcore/select` [3.4.6 ~> 3.4.7], `@semcore/utils` [3.44.1 ~> 3.44.2]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.3.3 ~> 4.3.4], `@semcore/flex-box` [4.7.3 ~> 4.7.4], `@semcore/input` [3.5.3 ~> 3.5.4], `@semcore/select` [3.4.6 ~> 3.4.7], `@semcore/utils` [3.44.1 ~> 3.44.2]).
 
 ## [3.4.0] - 2022-12-14
 
 ### Added
 
-- Added internationalization of aria attributes.
+* Added internationalization of aria attributes.
 
 ## [3.3.2] - 2022-12-13
 
 ### Changed
 
-- Added `react-dom` to peer dependencies.
+* Added `react-dom` to peer dependencies.
 
 ## [3.3.1] - 2022-12-12
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/select` [3.3.0 ~> 3.3.1]).
+* Version patch update due to children dependencies update (`@semcore/select` [3.3.0 ~> 3.3.1]).
 
 ## [3.3.0] - 2022-12-12
 
 ### Added
 
-- Design tokens based theming.
+* Design tokens based theming.
 
 ## [3.2.4] - 2022-10-30
 
 ### Fixed
 
-- Fixed that some secret combination of arrows pressing was causing infinite focus call and temporary freeze of browser.
-- Fixed Screen readers support.
+* Fixed that some secret combination of arrows pressing was causing infinite focus call and temporary freeze of browser.
+* Fixed Screen readers support.
 
 ## [3.2.3] - 2022-10-24
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/select` [3.2.4 ~> 3.2.5]).
+* Version patch update due to children dependencies update (`@semcore/select` [3.2.4 ~> 3.2.5]).
 
 ## [3.2.0] - 2022-10-17
 
 ### Fixed
 
-- Fixed support of Safari.
+* Fixed support of Safari.
 
 ## [3.1.1] - 2022-10-17
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/select` [3.2.0 ~> 3.2.1]).
+* Version patch update due to children dependencies update (`@semcore/select` [3.2.0 ~> 3.2.1]).
 
 ## [3.1.0] - 2022-10-10
 
 ### Changed
 
-- Added support for React 18 🔥
+* Added support for React 18 🔥
 
 ## [3.0.36] - 2022-10-10
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.0.18 ~> 4.1.0], `@semcore/input` [3.0.16 ~> 3.1.0], `@semcore/select` [3.1.6 ~> 3.1.7]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.0.18 ~> 4.1.0], `@semcore/input` [3.0.16 ~> 3.1.0], `@semcore/select` [3.1.6 ~> 3.1.7]).
 
 ## [3.0.25] - 2022-08-23
 
 ### Added
 
-- Added missing type `defaultValue` in `index.d.ts`.
+* Added missing type `defaultValue` in `index.d.ts`.
 
 ## [3.0.24] - 2022-08-19
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.0.12 ~> 4.0.13]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.0.12 ~> 4.0.13]).
 
 ## [3.0.8] - 2022-05-30
 
 ### Fixed
 
-- Fixed show `<Timepicker size='l' is12Hour/>` (added margin right to -4px for `Timepicker.Format`).
+* Fixed show `<Timepicker size='l' is12Hour/>` (added margin right to -4px for `Timepicker.Format`).
 
 ## [3.0.7] - 2022-05-27
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/button` [4.0.3 ~> 4.0.4]).
+* Version patch update due to children dependencies update (`@semcore/button` [4.0.3 ~> 4.0.4]).
 
 ## [3.0.2] - 2022-05-19
 
 ### Fixed
 
-- Updated Intergalactic internal dependencies to the latest.
+* Updated Intergalactic internal dependencies to the latest.
 
 ## [3.0.1] - 2022-05-18
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/input` [3.0.0 ~> 3.0.1], `@semcore/select` [3.0.0 ~> 3.0.1]).
+* Version patch update due to children dependencies update (`@semcore/input` [3.0.0 ~> 3.0.1], `@semcore/select` [3.0.0 ~> 3.0.1]).
 
 ## [3.0.0] - 2022-05-17
 
 ### BREAK
 
-- Updated styles according to the library redesign policy.
+* Updated styles according to the library redesign policy.
 
 ## [2.4.16] - 2022-05-16
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/select` [2.7.11 ~> 2.7.12]).
+* Version patch update due to children dependencies update (`@semcore/select` [2.7.11 ~> 2.7.12]).
 
 ## [2.4.6] - 2022-02-24
 
 ### Added
 
-- Added repository field to package.json file.
+* Added repository field to package.json file.
 
 ## [2.4.4] - 2021-8-26
 
 ### Changed
 
-- Add 'sideEffect=false' for more optimal build via webpack
+* Add 'sideEffect=false' for more optimal build via webpack
 
 ## [2.4.3] - 2021-08-23
 
 ### Changed
 
-- Changed height dropdown from `240px` to `180px`.
+* Changed height dropdown from `240px` to `180px`.
 
 ## [2.4.2] - 2021-06-04
 
 ### Added
 
-- [A11] Added `aria-label` for `Timepicker.Hours, Timepicker.Minutes`.
+* [A11] Added `aria-label` for `Timepicker.Hours, Timepicker.Minutes`.
 
 ## [2.4.1] - 2021-05-17
 
 ### Changed
 
-- Rewrite code from TS to JS 🧑‍💻
+* Rewrite code from TS to JS 🧑‍💻
 
 ## [2.3.0] - 2021-04-26
 
 ### Changed
 
-- Version of dependence `@semcore/core` has been changed to `1.11`.
-- Improved performance. Removed one component wrapper.
-- The style processing system has been changed.
-- Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
+* Version of dependence `@semcore/core` has been changed to `1.11`.
+* Improved performance. Removed one component wrapper.
+* The style processing system has been changed.
+* Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
 
 ## [2.2.1] - 2021-04-13
 
 ### Added
 
-- Added `type="button"` for controls `TimePicker.Format`.
+* Added `type="button"` for controls `TimePicker.Format`.
 
 ## [2.2.0] - 2021-03-31
 
 ### Changed
 
-- Changed view `TimePicker.Format`, now view don't have icons `TimeNight, TimeDay`.
+* Changed view `TimePicker.Format`, now view don't have icons `TimeNight, TimeDay`.
 
 ## [2.1.0] - 2020-12-17
 
 ### Added
 
-- Added supported react@17.
+* Added supported react@17.
 
 ## [2.0.3] - 2020-10-29
 
 ### Fixed
 
-- Added the placeholder for ID style tag to improve collision protection.
+* Added the placeholder for ID style tag to improve collision protection.
 
 ## [2.0.2] - 2020-09-08
 
 ### Fixed
 
-- Fixed possible styles collisions between components with different versions, but same styles
+* Fixed possible styles collisions between components with different versions, but same styles
 
 ## [2.0.1] - 2020-06-10
 
 ### Fixed
 
-- Исправлены TS типы
+* Исправлены TS типы
 
 ## [2.0.0] - 2020-06-03
 
 ### BREAK
 
-- Изменения описаны в [migration guide](/internal/migration-guide)
+* Изменения описаны в [migration guide](/internal/migration-guide)
 
 ## [1.4.1-prerelease.10] - 2020-05-20
 
 ### Changed
 
-- Убрано поведения для мобильных устройств из-за невозможности определить наличие мобильных контроллов.
+* Убрано поведения для мобильных устройств из-за невозможности определить наличие мобильных контроллов.
 
 ## [1.4.0] - 2020-04-27
 
 ### Added
 
-- Добавлено свойство `disablePortal` для отключения рендера в портал
+* Добавлено свойство `disablePortal` для отключения рендера в портал
 
 ## [1.3.1] - 2019-12-17
 
 ### Fixed
 
-- Исправлен транспайл цветовых переменных для стилей без префиксов (build.css)
+* Исправлен транспайл цветовых переменных для стилей без префиксов (build.css)
 
 ## [1.3.0] - 2019-12-12
 
 ### Added
 
-- Появилась возможность добавления различных стилистических тем через css переменные
-- Появилась возможность оптицонально подключать адаптивноссть
-- Появилась возможность изолировать стили даже в пределах одной страницы
+* Появилась возможность добавления различных стилистических тем через css переменные
+* Появилась возможность оптицонально подключать адаптивноссть
+* Появилась возможность изолировать стили даже в пределах одной страницы
 
 ### Changed
 
-- Изменен алгоритм вставки стилей в head
+* Изменен алгоритм вставки стилей в head
 
 ### Removed
 
-- Убраны относительные единицы измерения(rem), которые использовались для адаптивности
+* Убраны относительные единицы измерения(rem), которые использовались для адаптивности
 
 ## [1.2.1] - 2019-11-28
 
 ### Added
 
-- проброс `forwardedRef` для `Hours, Minutes`
+* проброс `forwardedRef` для `Hours, Minutes`
 
 ### Fixed
 
-- тип `onChange` для `Timepicker`
+* тип `onChange` для `Timepicker`
 
 ## [1.2.0] - 2019-11-14
 
 ### Added
 
-- Добавлена адаптивность на маленьких экранах(<768px)
+* Добавлена адаптивность на маленьких экранах(<768px)
 
 ## [1.1.4] - 2019-10-11
 
 ### Changed
 
-- Обновлены версии пакетов
-- Убран `root-ref` пакет
+* Обновлены версии пакетов
+* Убран `root-ref` пакет
 
 ## [1.1.3] - 2019-09-30
 
 ### Changed
 
-- Нужные зависимости перенесены в `utils`, размер должен стать меньше
+* Нужные зависимости перенесены в `utils`, размер должен стать меньше
 
 ## [1.1.2] - 2019-07-31
 
 ### Fixed
 
-- Исправлена сборка для рендера css на сервере
+* Исправлена сборка для рендера css на сервере
 
 ## [1.1.1] - 2019-07-04
 
 ### Added
 
-- Добавлен uncontroll режим
+* Добавлен uncontroll режим
 
 ## [1.0.4] - 2019-06-24
 
 ### Fixed
 
-- Исправлены ошибки в типизации
+* Исправлены ошибки в типизации
 
 ## [1.0.3] - 2019-05-24
 
 ### Fixed
 
-- Исправленно переключение форматов
+* Исправленно переключение форматов
 
 ## [1.0.2] - 2019-05-21
 
 ### Fixed
 
-- Исправленно отобрражение задизейбленного `PickerFormat`
-- Исправлена ошибка при отсутствии `value`
+* Исправленно отобрражение задизейбленного `PickerFormat`
+* Исправлена ошибка при отсутствии `value`
 
 ## [1.0.1] - 2019-05-14
 
 ### Added
 
-- Initial release
+* Initial release

--- a/semcore/time-picker/src/PickerInput.jsx
+++ b/semcore/time-picker/src/PickerInput.jsx
@@ -46,7 +46,7 @@ class ItemPicker extends Component {
 
   state = {
     dirtyValue: undefined,
-    visible: true,
+    visible: false,
   };
 
   parseValueWithMinMax = (value) => {

--- a/semcore/time-picker/src/PickerInput.jsx
+++ b/semcore/time-picker/src/PickerInput.jsx
@@ -30,9 +30,12 @@ function getOptions(min, max, step = 1) {
   });
 }
 
+const defaultPopperOffset = [-8, 4];
+
 class ItemPicker extends Component {
   static defaultProps = {
     placeholder: '00',
+    offset: defaultPopperOffset,
   };
 
   inputRef = React.createRef();
@@ -43,7 +46,7 @@ class ItemPicker extends Component {
 
   state = {
     dirtyValue: undefined,
-    visible: false,
+    visible: true,
   };
 
   parseValueWithMinMax = (value) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

`input` tags in time picker are very narrow. It's narrow because it needs background highlight when focused. This background highlight cannot be made by `:after` or `:before` pseudo elements because `input` tag cannot contain it. 

While Select trigger is more narrow than popper, it's displayed incorrectly. To overcome it, I've added default `offset` prop that compensate it on popper.

## How has this been tested?

Our screenshot tests can't screenshot popper in right position, so only manually.

## Screenshots:

Before:

<img width="254" alt="Screenshot 2024-02-22 at 16 25 17" src="https://github.com/semrush/intergalactic/assets/31261408/dea5e284-4a37-4ef0-9c4f-3784b8b946c7">

After:

<img width="216" alt="Screenshot 2024-02-22 at 16 09 23" src="https://github.com/semrush/intergalactic/assets/31261408/6aa70177-da6a-4677-a344-67096ab75345">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
