### PR TITLE
[86bxke46b][data-table] fixed virtual scroll in table

### DIFF
--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.27.2] - 2024-02-23
+
+### Fixed
+
+- Virtual scroll in table - setup row size observer in `requestAnimationFrame`.
+
 ## [4.27.1] - 2024-02-21
 
 ### Changed

--- a/semcore/data-table/src/Body.tsx
+++ b/semcore/data-table/src/Body.tsx
@@ -276,7 +276,7 @@ class Body extends Component<AsProps, State> {
       rowHeight !== undefined && virtualScroll ? rowHeight * rows.length : undefined;
 
     if (virtualScroll && columnsInitialized && !rowHeight) {
-      new Promise(() => this.setupRowSizeObserver());
+      requestAnimationFrame(this.setupRowSizeObserver);
     }
 
     const body = sstyled(styles)(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Right now, we setup row size observer in first render and if haven't have first row yet, don't try to setup it again. I've changed this logic, to setup row size in requestAnimationFrame - guaranty that we painted first row 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
I've tested it manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
