### PR TITLE
[dropdown-menu] footer focus a11y

### DIFF
--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.22.0] - 2024-02-29
+
+### Fixed
+
+- Allowed to `Tab` navigate from focusables inside of an item if the item was highlighted right before the focusable was focused.
+
 ## [4.21.1] - 2024-02-21
 
 ### Changed

--- a/semcore/dropdown-menu/__tests__/index.test.tsx
+++ b/semcore/dropdown-menu/__tests__/index.test.tsx
@@ -231,6 +231,47 @@ describe('DropdownMenu', () => {
     await userEvent.keyboard('[ArrowLeft]');
     expect(visible).toBe(false);
   });
+  test.sequential('focus lock highlites next item on focus out', async ({ expect }) => {
+    let highlightedIndex: number | undefined = undefined;
+    const { getByTestId } = render(
+      <DropdownMenu
+        placement='right'
+        onHighlightedIndexChange={(index) => {
+          highlightedIndex = index;
+        }}
+      >
+        <DropdownMenu.Trigger data-testid='dd-trigger' tag='button'>
+          Trigger
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Menu>
+          <DropdownMenu.Item>
+            Item 1{' '}
+            <button type='button' data-testid='delete-1'>
+              delete 1
+            </button>
+          </DropdownMenu.Item>
+          <DropdownMenu.Item>
+            Item 2{' '}
+            <button type='button' data-testid='delete-2'>
+              delete 2
+            </button>
+          </DropdownMenu.Item>
+        </DropdownMenu.Menu>
+      </DropdownMenu>,
+    );
+
+    await userEvent.keyboard('[Tab]');
+    await userEvent.keyboard('[Enter]');
+    expect(getByTestId('dd-trigger')).toHaveFocus();
+    await userEvent.keyboard('[ArrowDown]');
+    expect(highlightedIndex).toBe(0);
+    await userEvent.keyboard('[ArrowRight]');
+    expect(highlightedIndex).toBe(0);
+    expect(getByTestId('delete-1')).toHaveFocus();
+    await userEvent.keyboard('[Tab]');
+    expect(highlightedIndex).toBe(null);
+    expect(getByTestId('delete-2')).toHaveFocus();
+  });
   describe.sequential('opens nested menu', () => {
     test.sequential('by tab', async ({ expect }) => {
       const { getByTestId } = render(

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import cn from 'classnames';
 import createComponent, { Component, sstyled, Root } from '@semcore/core';
 import Dropdown from '@semcore/dropdown';
-import { Flex, useBox, useFlex } from '@semcore/flex-box';
+import { Flex, useBox } from '@semcore/flex-box';
 import ScrollAreaComponent from '@semcore/scroll-area';
 import uniqueIDEnhancement from '@semcore/utils/lib/uniqueID';
 import i18nEnhance from '@semcore/utils/lib/enhances/i18nEnhance';
 import { localizedMessages } from './translations/__intergalactic-dynamic-locales';
 import { useFocusLock } from '@semcore/utils/lib/use/useFocusLock';
+import { hasParent } from '@semcore/utils/lib/hasParent';
 
 import scrollStyles from './styleScrollArea';
 import style from './style/dropdown-menu.shadow.css';
@@ -236,7 +237,9 @@ class DropdownMenuRoot extends Component {
   getItemProps(props, index) {
     const { size, highlightedIndex, uid } = this.asProps;
     const highlighted = index === highlightedIndex;
-    let ref = this.itemRefs[index];
+    let ref = (node) => {
+      this.itemRefs[index] = node;
+    };
     this.itemProps[index] = props;
     if (highlighted) {
       ref = (node) => {
@@ -253,8 +256,20 @@ class DropdownMenuRoot extends Component {
       triggerRef: this.triggerRef,
       ref,
       index,
+      handleFocusOut: this.handleItemFocusOut,
     };
   }
+
+  handleItemFocusOut = (event) => {
+    if (event.relatedTarget === this.popperRef.current) return;
+    const focused = event.relatedTarget;
+
+    if (hasParent(focused, this.popperRef.current)) {
+      this.handlers.highlightedIndex(null);
+      this.setState({ focusLockItemIndex: null });
+      focused.focus();
+    }
+  };
 
   handleNestingClick = (event) => {
     const itemIndex = this.itemRefs.indexOf(event.currentTarget);
@@ -429,11 +444,11 @@ function Menu(props) {
   );
 }
 
-function Item({ styles, label, triggerRef, focusLock, disabled, highlighted }) {
+function Item({ styles, label, triggerRef, focusLock, disabled, highlighted, handleFocusOut }) {
   const SDropdownMenuItem = Root;
   const ref = React.useRef();
 
-  useFocusLock(ref, false, triggerRef, !focusLock || disabled, true);
+  useFocusLock(ref, false, triggerRef, !focusLock || disabled, true, handleFocusOut);
 
   return sstyled(styles)(
     <SDropdownMenuItem


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

After #1111 it was found that focusable elements inside of dropdown-menu footer are not very accessible. It's very hard to get to them with tab key navigation.

I have added additional check that disabled focus lock if focus goes out of item but is kept inside of dropdown popper.

## How has this been tested?

Manually on wide range of cases and with unit test on the main case – tab navigation goes from one focusable to another.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [x] I have added new unit tests on added of fixed functionality.
