### PR TITLE
[86bxp9vbw][button] fixed old themization

### DIFF
--- a/semcore/button/CHANGELOG.md
+++ b/semcore/button/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.20.4] - 2024-02-29
+
+### Fixed
+
+- Old themization with `@semcore/babel-plugin-react-semcore` wasn't working.
+
 ## [5.20.3] - 2024-02-21
 
 ### Changed

--- a/semcore/button/src/style/button.shadow.css
+++ b/semcore/button/src/style/button.shadow.css
@@ -249,17 +249,6 @@ SButton[neighborLocation='both'],
 SButton[neighborLocation='left'] {
   position: relative;
 
-  SButton+& {
-    &:after {
-      content: '';
-      position: absolute;
-      top: -1px;
-      left: -1px;
-      width: 1px;
-      height: calc(100% + 2px);
-    }
-  }
-
   &:after {
     background-color: var(--intergalactic-text-primary-invert, #ffffff);
   }
@@ -269,6 +258,16 @@ SButton[neighborLocation='left'] {
       background-color: var(--intergalactic-border-primary, #c4c7cf);
     }
   }
+}
+
+SButton+SButton[neighborLocation='both']:after,
+SButton+SButton[neighborLocation='left']:after {
+  content: '';
+  position: absolute;
+  top: -1px;
+  left: -1px;
+  width: 1px;
+  height: calc(100% + 2px);
 }
 
 SSpin {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

For unknown reason postcss with `@semcore/babel-plugin-react-semcore` break on `SButton+&` selector. I've replaced this selector with a simpler equivalent that doesn't break. 

## How has this been tested?

Manually on existing project only.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
