### PR TITLE
[86bxngmv2][table] allowed to disable StickyHead portal

### DIFF
--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.28.0] - 2024-02-29
+
+### Added
+
+- `disablePortal` prop to `Table.StickyHead`.
+
+### Changed
+
+- Sortable focused headers cell now shows sorting icon.
+
 ## [4.27.3] - 2024-02-27
 
 ### Fixed

--- a/semcore/table/src/StickyHead.jsx
+++ b/semcore/table/src/StickyHead.jsx
@@ -215,8 +215,8 @@ function ContainerSticky(props, ref) {
     ...other
   } = props;
   const { styles } = React.useContext(ContextTable);
-  const { container, tableDOM } = React.useContext(StickyHeadContext);
-  const thead = container.getElementsByTagName('thead')[0];
+  const { container, tableDOM, disablePortal } = React.useContext(StickyHeadContext);
+  const thead = container.getElementsByTagName('thead')[disablePortal ? 1 : 0];
   const styleBar = {};
 
   if (tableDOM) {
@@ -268,6 +268,7 @@ function StickyHeadInner(props, ref) {
     top: offsetTop = 0,
     bottom: offsetBottom = 0,
     container: propsContainer,
+    disablePortal,
     ...other
   } = props;
   const top = typeof offsetTop === 'number' ? offsetTop : parseInt(offsetTop, 10);
@@ -440,20 +441,20 @@ function StickyHeadInner(props, ref) {
   if (!container) return null;
 
   const tableDOM = container.getElementsByTagName('table')[0];
+  const stickyCore = (
+    <ContainerStickyCore
+      setRefContainer={setRefScrollContainer}
+      positionFixed={positionFixed}
+      top={top}
+      bottom={bottom}
+      ref={ref}
+      {...other}
+    />
+  );
 
   return (
-    <StickyHeadContext.Provider value={{ container, tableDOM }}>
-      {createPortal(
-        <ContainerStickyCore
-          setRefContainer={setRefScrollContainer}
-          positionFixed={positionFixed}
-          top={top}
-          bottom={bottom}
-          ref={ref}
-          {...other}
-        />,
-        container,
-      )}
+    <StickyHeadContext.Provider value={{ container, tableDOM, disablePortal }}>
+      {disablePortal ? stickyCore : createPortal(stickyCore, container)}
     </StickyHeadContext.Provider>
   );
 }

--- a/semcore/table/src/index.d.ts
+++ b/semcore/table/src/index.d.ts
@@ -85,6 +85,12 @@ export type StickyHeadProps = ScrollAreaProps & {
   bottom?: string | number;
   /** Handler that is called when the fixed position is changed */
   onFixed?: (positionFixed: string) => void;
+
+  /**
+   * If enabled, header will be rendered without portal to the end of table container
+   * @default false
+   */
+  disablePortal?: boolean;
 };
 
 /** @deprecated */

--- a/semcore/table/src/style/table.shadow.css
+++ b/semcore/table/src/style/table.shadow.css
@@ -123,21 +123,25 @@ SCellHead[borderRight] {
 SCellHead[sorting] {
   cursor: pointer;
 
-  &[use='primary']:hover {
+  &[use='primary']:hover,
+  &[use='primary']:focus {
     background-color: var(--intergalactic-table-th-primary-cell-hover, #e0e1e9);
   }
 
-  &:hover SSortWrapper {
+  &:hover SSortWrapper,
+  &:focus SSortWrapper {
     flex-basis: calc(var(--intergalactic-spacing-1x, 4px) + 16px);
     opacity: 1;
   }
 
-  &:hover SSortWrapper:before {
+  &:hover SSortWrapper:before,
+  &:focus SSortWrapper:before {
     display: block;
     opacity: 1;
   }
 
-  &:hover SSortIcon {
+  &:hover SSortIcon,
+  &:focus SSortIcon {
     display: block;
     opacity: 1;
   }
@@ -308,7 +312,7 @@ SStickyHeadTable {
 
 SStickyHead[position='fixed'] {
   position: fixed;
-  z-index: 1;
+  z-index: 2;
 }
 
 SStickyHead[position='top'] {


### PR DESCRIPTION
## Motivation and Context

It's like https://github.com/semrush/intergalactic/pull/1132 but without breaking changes.

## How has this been tested?

Manually only.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
