### PR TITLE
[86bxpbc49][carousel] fixed onIndexChange to return correct value

### DIFF
--- a/semcore/carousel/CHANGELOG.md
+++ b/semcore/carousel/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.28.2] - 2024-03-01
+
+### Fixed
+
+- `onIndexChange` to return reminder from absolute selected index.
+
 ## [3.28.1] - 2024-02-21
 
 ### Changed

--- a/semcore/carousel/CHANGELOG.md
+++ b/semcore/carousel/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Fixed
 
-- `onIndexChange` to return reminder from absolute selected index.
+- `onIndexChange` to return correct index.
 
 ## [3.28.1] - 2024-02-21
 

--- a/semcore/carousel/__tests__/index.test.tsx
+++ b/semcore/carousel/__tests__/index.test.tsx
@@ -63,7 +63,7 @@ describe('Carousel', () => {
 
     const container = getByTestId('container');
     fireEvent.keyDown(container, { key: 'ArrowLeft' });
-    expect(spy).toHaveBeenCalledWith(-1);
+    expect(spy).toHaveBeenCalledWith(1);
     fireEvent.keyDown(container, { key: 'ArrowRight' });
     expect(spy).toHaveBeenCalledWith(0);
   });
@@ -203,7 +203,7 @@ describe('Carousel.Prev', () => {
     fireEvent.click(prev);
 
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith(-1);
+    expect(spy).toHaveBeenCalledWith(1);
   });
 
   test('Should not support call onIndexChange for bounded property', () => {

--- a/semcore/carousel/src/Carousel.tsx
+++ b/semcore/carousel/src/Carousel.tsx
@@ -214,7 +214,7 @@ class CarouselRoot extends Component<
         }),
         () => {
           this.transformContainer();
-          this.handlers.index(this.state.selectedIndex);
+          this.handlers.index(this.getReminderIndex());
         },
       );
 
@@ -238,7 +238,7 @@ class CarouselRoot extends Component<
         }),
         () => {
           this.transformContainer();
-          this.handlers.index(this.state.selectedIndex);
+          this.handlers.index(this.getReminderIndex());
         },
       );
 
@@ -378,6 +378,20 @@ class CarouselRoot extends Component<
     return transform;
   }
 
+  getReminderIndex() {
+    const { items, selectedIndex } = this.state;
+
+    if (items.length === 0) {
+      return 0;
+    }
+
+    if (selectedIndex >= 0) {
+      return selectedIndex % items.length;
+    }
+
+    return (items.length + (selectedIndex % items.length)) % items.length;
+  }
+
   isSelected(index: number) {
     const { items, selectedIndex } = this.state;
 
@@ -385,11 +399,7 @@ class CarouselRoot extends Component<
       return true;
     }
 
-    if (selectedIndex >= 0) {
-      return index === selectedIndex % items.length;
-    }
-
-    return index === (items.length + (selectedIndex % items.length)) % items.length;
+    return index === this.getReminderIndex();
   }
 
   renderModal(isSmall: boolean, ComponentItems: any[]) {

--- a/semcore/carousel/src/Carousel.tsx
+++ b/semcore/carousel/src/Carousel.tsx
@@ -214,7 +214,7 @@ class CarouselRoot extends Component<
         }),
         () => {
           this.transformContainer();
-          this.handlers.index(this.getReminderIndex());
+          this.handlers.index(this.getIndex());
         },
       );
 
@@ -238,7 +238,7 @@ class CarouselRoot extends Component<
         }),
         () => {
           this.transformContainer();
-          this.handlers.index(this.getReminderIndex());
+          this.handlers.index(this.getIndex());
         },
       );
 
@@ -378,7 +378,7 @@ class CarouselRoot extends Component<
     return transform;
   }
 
-  getReminderIndex() {
+  getIndex() {
     const { items, selectedIndex } = this.state;
 
     if (items.length === 0) {
@@ -399,7 +399,7 @@ class CarouselRoot extends Component<
       return true;
     }
 
-    return index === this.getReminderIndex();
+    return index === this.getIndex();
   }
 
   renderModal(isSmall: boolean, ComponentItems: any[]) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Before fix, `onIndexChange` return absolute select index(negative value or more then items count). I've added function to get correct value (between 0 and max count of items).
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
I've fixed unit tests for this new behaviour
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
