### PR TITLE
[tag] fixed order in layers for close icon

### DIFF
--- a/semcore/tag/CHANGELOG.md
+++ b/semcore/tag/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.27.3] - 2024-03-01
+
+### Fixed
+
+- Order in layers for `Tag.Close` component for correct handling `onClick` events.
+
 ## [5.27.2] - 2024-02-21
 
 ### Changed

--- a/semcore/tag/src/style/tag.shadow.css
+++ b/semcore/tag/src/style/tag.shadow.css
@@ -249,6 +249,7 @@ SClose {
   align-items: center;
   justify-content: center;
   padding: var(--intergalactic-spacing-1x, 4px);
+  position: relative;
 
   & path {
     opacity: 0.5;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
For now, `:before` container in `Tag` overlaps all tag content, so, `onClick` for `Tag.Close` doesn't fire. I've fixed it.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
I've tested it manually.
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [X] I have added new unit tests on added of fixed functionality.
