### PR TITLE
[86bxp0fxm][data-table] added handler for scrolling to the column header after focusing

### DIFF
--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.28.1] - 2024-03-04
+
+### Added
+
+- Handler for scrolling to the column header after focusing.
+
 ## [4.28.0] - 2024-02-29
 
 ### Added

--- a/semcore/data-table/src/Head.tsx
+++ b/semcore/data-table/src/Head.tsx
@@ -56,6 +56,12 @@ class Head extends Component<AsProps> {
     }
   };
 
+  handleColumnFocus = (event: React.FocusEvent) => {
+    setTimeout(() => {
+      event.target.scrollIntoView();
+    }, 0);
+  };
+
   renderColumns(columns: Column[], width: number) {
     return columns.map((column) => this.renderColumn(column, width));
   }
@@ -114,6 +120,7 @@ class Head extends Component<AsProps> {
         style={style}
         hidden={hidden}
         aria-sort={ariaSortValue}
+        onFocus={this.handleColumnFocus}
       >
         {isGroup ? (
           <>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
As we have a virtual scroll for the table header, we should manually scroll to the focused nodes. I've added this logic. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
I've tested it manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
