### PR TITLE
[86bxp8ngf][d3-chart] fixed double reading label on legendItem checkbox

### DIFF
--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.31.1] - 2024-03-05
+
+### Fixed
+
+- Double reading label on `LegentItem` checkbox.
+
 ## [3.31.0] - 2024-03-01
 
 ### Added

--- a/semcore/d3-chart/src/component/ChartLegend/LegendItem/LegendItem.tsx
+++ b/semcore/d3-chart/src/component/ChartLegend/LegendItem/LegendItem.tsx
@@ -100,13 +100,13 @@ class LegendItemRoot extends Component<
 
   render() {
     const SLegendItem = Root;
-    const { styles, Children, shape } = this.asProps;
+    const { styles, Children, shape, label } = this.asProps;
 
     // @ts-ignore
     const disabled = StaticShapes.includes(shape);
 
     return sstyled(styles)(
-      <SLegendItem render={Flex} disabled={disabled}>
+      <SLegendItem render={Flex} disabled={disabled} aria-label={label}>
         <Children />
       </SLegendItem>,
     );
@@ -126,7 +126,6 @@ function Shape(props: IRootComponentProps & ShapeProps & DOMAttributes<HTMLLabel
     Children,
     children: hasChildren,
     onKeyUp,
-    label,
     patterns,
   } = props;
 
@@ -150,7 +149,6 @@ function Shape(props: IRootComponentProps & ShapeProps & DOMAttributes<HTMLLabel
           checked={checked}
           theme={checked ? color : undefined}
           onKeyUp={onKeyUp}
-          aria-label={label}
         />
         {patterns && (
           <Box mt={'2px'} mr={1}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
I've removed `aria-label` from checkbox and moved it to the container for row with checkbox and label.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
I've tested in manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
