### PR TITLE
[website] fix URL typo for accordion case in Table docs

### DIFF
--- a/website/docs/table-group/table-showcase/table-showcase.md
+++ b/website/docs/table-group/table-showcase/table-showcase.md
@@ -31,7 +31,7 @@ const group = {
   accordion: {
 
     title: 'Accordion',
-    route: '/intergalactic/table-group/table-controls//table-controls#accordion',
+    route: '/intergalactic/table-group/table-controls/table-controls#accordion',
     disabled: false,
     type: 'table',
 


### PR DESCRIPTION
No dev review needed. Just a small typo fix for URL of the accordion case for Table.