### PR TITLE
[86bxphhbu][tooltip] fixed that VO wasn't reading tooltip content in safari

### DIFF
--- a/semcore/tooltip/CHANGELOG.md
+++ b/semcore/tooltip/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [6.21.0] - 2024-03-05
+
+### Fixed
+
+- VoiceOver was not reading the tooltip content in Safari.
+
+### Changed
+
+- `aria-live` container that announces the tooltip content was moved from tooltip inner container with `display: contents` to tooltip popper wrapper.
+
 ## [6.20.3] - 2024-03-01
 
 ### Changed

--- a/semcore/tooltip/src/Tooltip.jsx
+++ b/semcore/tooltip/src/Tooltip.jsx
@@ -6,6 +6,7 @@ import resolveColorEnhance from '@semcore/utils/lib/enhances/resolveColorEnhance
 import { isAdvanceMode } from '@semcore/utils/lib/findComponent';
 import logger from '@semcore/utils/lib/logger';
 import uniqueIDEnhancement from '@semcore/utils/lib/uniqueID';
+import Portal from '@semcore/portal';
 
 import style from './style/tooltip.shadow.css';
 
@@ -115,20 +116,24 @@ function TooltipTrigger(props) {
 }
 
 function TooltipPopper(props) {
-  const { Children, styles, theme, resolveColor } = props;
+  const { Children, styles, theme, resolveColor, disablePortal, ignorePortalsStacking } = props;
   const STooltip = Root;
   const SArrow = Box;
-  const STooltipContent = 'span';
 
   return sstyled(styles)(
-    <>
-      <STooltip render={Popper.Popper} role='tooltip' use:theme={resolveColor(theme)}>
-        <STooltipContent aria-live={theme === 'warning' ? 'assertive' : 'polite'}>
+    <Portal disablePortal={disablePortal} ignorePortalsStacking={ignorePortalsStacking}>
+      <div aria-live={theme === 'warning' ? 'assertive' : 'polite'}>
+        <STooltip
+          render={Popper.Popper}
+          use:disablePortal
+          role='tooltip'
+          use:theme={resolveColor(theme)}
+        >
           <Children />
-        </STooltipContent>
-        <SArrow data-popper-arrow use:theme={resolveColor(theme)} />
-      </STooltip>
-    </>,
+          <SArrow data-popper-arrow use:theme={resolveColor(theme)} />
+        </STooltip>
+      </div>
+    </Portal>,
   );
 }
 

--- a/semcore/tooltip/src/style/tooltip.shadow.css
+++ b/semcore/tooltip/src/style/tooltip.shadow.css
@@ -136,7 +136,3 @@ STooltip[data-popper-placement^='right'] SArrow {
     border-bottom-color: transparent !important;
   }
 }
-
-STooltipContent {
-  display: contents;
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

We use `aria-live` on tooltip to make it accessible in browsers that doesn't support `aria-describedby`.

We can't apply `aria-live` directly on Tooltip Popper cause it has `tabIndex={0}`. Chrome and FF both has a weird bug – if `aria-live` element has `tabIndex={0}`, VO announces content twice.
It was overcome with a 'display: contents' element inside of Tooltip Popper that was wrapping it's content and applying aria-live.

On the other hand it was found that Safari doesn't announce `aria-live` at all if element has  `display: contents`.

To overcome it, I've removed that inner div and added outer div with `aria-live`. It also required to disable normal popper portal and add a new one.

## How has this been tested?

Manually. Need to enable VO tests in different browsers (will do it later) to test it.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
