### PR TITLE
[86bxry0ne][base-trigger] fixed that filter trigger was sharing triggerRef between instances

### DIFF
--- a/semcore/base-trigger/CHANGELOG.md
+++ b/semcore/base-trigger/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.26.7] - 2024-03-06
+
+### Fixed
+
+- In some rare cases `FilterTrigger` may share it's ref between component instances.
+
 ## [4.26.6] - 2024-03-01
 
 ### Changed

--- a/semcore/base-trigger/src/FilterTrigger.jsx
+++ b/semcore/base-trigger/src/FilterTrigger.jsx
@@ -46,13 +46,13 @@ class RootFilterTrigger extends Component {
     }),
     uniqueIDEnhancement(),
   ];
-  static defaultProps = {
+  static defaultProps = () => ({
     includeInputProps: filterTriggerInputProps,
     i18n: localizedMessages,
     locale: 'en',
     triggerRef: React.createRef(),
     role: 'group',
-  };
+  });
 
   handleStopPropagation = (e) => e.stopPropagation();
 


### PR DESCRIPTION

## Motivation and Context

On one of product that uses our lib it was found that FilterTrigger shares `triggerRef` from defaultProps across instances. It seems that it's because defaultProps param is static but I can't reproduce it in our playgrounds or tests env.

## How has this been tested?

Only on the product. After the change the bug gone.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
