### PR TITLE
[86bxt50c9][date-picker] rolled back change format of `date` property in childre…

### DIFF
--- a/semcore/date-picker/CHANGELOG.md
+++ b/semcore/date-picker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.30.3] - 2024-03-07
+
+### Fixed
+
+- Rolled back change format of `date` property in children render function of `MonthPicker` and `MonthRangePicker` components.
+
 ## [4.30.2] - 2024-03-05
 
 ### Changed

--- a/semcore/date-picker/src/components/Calendar.jsx
+++ b/semcore/date-picker/src/components/Calendar.jsx
@@ -132,7 +132,8 @@ class CalendarAbstract extends Component {
     const disabled = _disabled.some(includesDate(date, unit));
 
     return {
-      date: this.formatter(date, locale),
+      date: formatDDMMYY(date, locale),
+      dateKey: this.formatter(date, locale),
       children: '',
       startSelected: selecting.startSelected,
       endSelected: selecting.endSelected,
@@ -189,12 +190,12 @@ class CalendarAbstract extends Component {
     fire(this, 'onHighlightedChange', highlighted.length ? [highlighted[0]] : []);
   };
 
-  getUnitProps({ date }) {
+  getUnitProps({ dateKey }) {
     const { unitRefs } = this.asProps;
     return {
       ref: (node) => {
-        if (!date) return;
-        unitRefs[date] = node;
+        if (!dateKey) return;
+        unitRefs[dateKey] = node;
       },
     };
   }


### PR DESCRIPTION
…n render function of `MonthPicker` and `MonthRangePicker` components

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

In #1142 format of `date` prop in calendar unit was changed. Our users were relying on old format in Calendar component children render function. I've rolled format back and added separated key to properly handle unit refs.

## How has this been tested?

Manually, it's enough for this rollback.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
