### PR TITLE
[86bxthz5q][animation] fixed collapse animation with preserveNode prop

### DIFF
--- a/semcore/animation/CHANGELOG.md
+++ b/semcore/animation/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.19.2] - 2024-03-07
+
+### Fixed
+
+- `Collapse` animation was not working with `preserveNode` prop.
+
 ## [2.19.1] - 2024-03-06
 
 ### Changed

--- a/semcore/animation/src/Collapse.jsx
+++ b/semcore/animation/src/Collapse.jsx
@@ -40,6 +40,8 @@ function Collapse({ onAnimationStart, onAnimationEnd, overflowHidden = true, ...
     [props.visible],
   );
 
+  const visibleRef = React.useRef(props.visible);
+  visibleRef.current = props.visible;
   const handleAnimationEnd = React.useCallback((event) => {
     if (event.currentTarget !== event.target) return;
     if (onAnimationEnd) onAnimationEnd(event);
@@ -47,7 +49,8 @@ function Collapse({ onAnimationStart, onAnimationEnd, overflowHidden = true, ...
 
     setTimeout(() => {
       if (!element) return;
-      element.style.height = 'auto';
+      if (visibleRef.current) element.style.height = 'auto';
+      if (!visibleRef.current) element.style.height = `${0}px`;
       if (overflowHidden) {
         element.style.overflow = overflowRef.current;
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

It was found that with `preserveNode` collapse animation wasn't working properly – after finishing animation the collapse component was always showing it's cotnent.

## How has this been tested?

We have no autotests for animations 🤷 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
