### PR TITLE
[86bxtdz6n][d3-chart] added logic to define X and Y axis for a11y summary in Bar charts

### DIFF
--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.31.2] - 2024-03-07
+
+### Added
+
+- Logic to define X and Y axis for a11y summary in Bar charts.
+
 ## [3.31.1] - 2024-03-05
 
 ### Changed

--- a/semcore/d3-chart/src/Bar.jsx
+++ b/semcore/d3-chart/src/Bar.jsx
@@ -80,6 +80,7 @@ class BarRoot extends Component {
       transparent,
       maxBarSize = Infinity,
       patterns,
+      dataHintsHandler,
     } = this.asProps;
     const offset = typeof offsetProps === 'function' ? offsetProps(i) : offsetProps;
     const [xScale, yScale] = scale;
@@ -105,9 +106,10 @@ class BarRoot extends Component {
     });
 
     if (groupKey) {
-      this.asProps.dataHintsHandler.describeGroupedValues(groupKey, y);
+      dataHintsHandler.describeGroupedValues(groupKey, y);
     } else {
-      this.asProps.dataHintsHandler.describeValueEntity(`${i}.${y}`, groupKey ?? d[x]);
+      dataHintsHandler.describeValueEntity(`${i}.${y}`, groupKey ?? d[x]);
+      dataHintsHandler.specifyDataRowFields(x, y);
     }
 
     return (

--- a/website/docs/data-display/bar-chart/examples/date-format.tsx
+++ b/website/docs/data-display/bar-chart/examples/date-format.tsx
@@ -32,7 +32,10 @@ const Demo = () => {
         </YAxis>
         <XAxis>
           <XAxis.Ticks>
-            {({ value, index }) => ({ children: index % 2 === 0 ? getDate(value) : '' })}
+            {({ value, index }) => ({
+              children: index % 2 === 0 ? getDate(value) : '',
+              value: getDate(value),
+            })}
           </XAxis.Ticks>
         </XAxis>
         <Bar x='date_chart' y='download' />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
For the Bar charts with more then 5 columns we created empty summary, because we don't define X and Y axis values in Bar component. I've fixed it.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
