### PR TITLE
[popper] fixed in controlled mode popper was infinitely returning focus to trigger on close attempt

### DIFF
--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.21.0] - 2024-03-07
+
+### Fixed
+
+- In controlled mode popper was infinitely returning focus to trigger on close attempt.
+
 ## [5.20.5] - 2024-03-07
 
 ### Changed

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -433,6 +433,7 @@ function Trigger(props) {
       setTimeout(() => {
         if (activeRef.current) return;
         if (!isFocusInside(popperRef.current) && document.activeElement !== document.body) return;
+        if (focusSourceRef.current !== 'keyboard') return;
 
         setFocus(triggerRef.current);
       }, 1);


### PR DESCRIPTION
## Motivation and Context

We hade a very stupid bug – after closing popper was returning focus to trigger even if last user interaction was caused by mouse. It wasn't noticeable with uncontrolled poppers but noticable, e.g. in example below: 

```tsx
const Demo = () => {
  const [type, setType] = React.useState('');
  const [focusedInput, setFocusedInput] = React.useState(false);
  const onFocus = React.useCallback(() => setFocusedInput(true), []);
  const onBlur = React.useCallback(() => setFocusedInput(false), []);

  return (
    <>
      <Box mt={2}>
        <Tooltip title='FUCK' visible={focusedInput}>
          <input onBlur={onBlur} onFocus={onFocus} />
        </Tooltip>
      </Box>
    </>
  );
};
```

## How has this been tested?

I've tested it manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
