### PR TITLE
[86bxtttpp][base-trigger] added type button to button trigger button tag

### DIFF
--- a/semcore/base-trigger/CHANGELOG.md
+++ b/semcore/base-trigger/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.27.1] - 2024-03-07
+
+### Fixed
+
+- Behavior in forms was broken.
+
 ## [4.27.0] - 2024-03-04
 
 ### Changed

--- a/semcore/base-trigger/src/ButtonTrigger.jsx
+++ b/semcore/base-trigger/src/ButtonTrigger.jsx
@@ -42,7 +42,7 @@ class RootButtonTrigger extends Component {
     const { Children, styles, loading, empty } = this.asProps;
 
     return sstyled(styles)(
-      <Root render={BaseTrigger} tag={'button'}>
+      <Root render={BaseTrigger} tag='button' type='button'>
         {addonTextChildren(Children, ButtonTrigger.Text, ButtonTrigger.Addon, empty)}
         <SButtonAddon>
           {loading ? <SButtonTriggerSpin size='xs' theme={false} /> : <ChevronDown />}


### PR DESCRIPTION
## Motivation and Context

In #1156 we made button trigger to use button tag. And also we forgot to specify button type. So, the default type `submit` is used. It totally breaks our selects & co. in forms.

## How has this been tested?

No testing needed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
