### PR TITLE
[86bxfdxh2][date-picker] refactored range pickers setNextDisplayedPeriod and fixed it's wrong dates results in month pickers

### DIFF
--- a/semcore/date-picker/CHANGELOG.md
+++ b/semcore/date-picker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.30.5] - 2024-03-08
+
+### Fixed
+
+- In month date range pickers the second calendar was not usable from the keyboard.
+
 ## [4.30.4] - 2024-03-07
 
 ### Changed

--- a/semcore/date-picker/src/components/DateRangeComparatorAbstract.jsx
+++ b/semcore/date-picker/src/components/DateRangeComparatorAbstract.jsx
@@ -215,21 +215,23 @@ class DateRangeComparatorAbstract extends Component {
     const day = this.keyDiff[key];
 
     const setNextDisplayedPeriod = (next_highlighted) => {
-      const [left_period, right_period] = next_highlighted;
+      const [startPeriod, endPeriod] = next_highlighted;
+      const highlightedPeriod = endPeriod || startPeriod;
 
-      const monthDisplayedPeriod = displayedPeriod?.getMonth();
-      const period = right_period || left_period;
+      let displayedPeriodNormalized = displayedPeriod?.getDate();
+      let highlightedPeriodNormalized = highlightedPeriod?.getDate();
+      if (this.navigateStep === 'month') {
+        displayedPeriodNormalized = displayedPeriod?.getMonth();
+        highlightedPeriodNormalized = highlightedPeriod?.getMonth();
+      }
+      if (this.navigateStep === 'year') {
+        displayedPeriodNormalized = displayedPeriod?.getYear();
+        highlightedPeriodNormalized = highlightedPeriod?.getYear();
+      }
+      const offset = highlightedPeriodNormalized - displayedPeriodNormalized;
 
-      if (period) {
-        if (!monthDisplayedPeriod) {
-          return period;
-        }
-
-        if (period.getMonth() - monthDisplayedPeriod > 1) {
-          return DateRangeComparatorAbstract.subtract(period, 1, 'month');
-        } else if (period.getMonth() - monthDisplayedPeriod < 0) {
-          return period;
-        }
+      if (offset < 0 || offset > 1) {
+        return highlightedPeriod;
       }
       return displayedPeriod;
     };

--- a/semcore/date-picker/src/components/RangePickerAbstract.jsx
+++ b/semcore/date-picker/src/components/RangePickerAbstract.jsx
@@ -123,21 +123,23 @@ class RangePickerAbstract extends Component {
     const day = this.keyDiff[key];
 
     const setNextDisplayedPeriod = (next_highlighted) => {
-      const [left_period, right_period] = next_highlighted;
+      const [startPeriod, endPeriod] = next_highlighted;
+      const highlightedPeriod = endPeriod || startPeriod;
 
-      const monthDisplayedPeriod = displayedPeriod?.getMonth();
-      const period = right_period || left_period;
+      let displayedPeriodNormalized = displayedPeriod?.getDate();
+      let highlightedPeriodNormalized = highlightedPeriod?.getDate();
+      if (this.navigateStep === 'month') {
+        displayedPeriodNormalized = displayedPeriod?.getMonth();
+        highlightedPeriodNormalized = highlightedPeriod?.getMonth();
+      }
+      if (this.navigateStep === 'year') {
+        displayedPeriodNormalized = displayedPeriod?.getYear();
+        highlightedPeriodNormalized = highlightedPeriod?.getYear();
+      }
+      const offset = highlightedPeriodNormalized - displayedPeriodNormalized;
 
-      if (period) {
-        if (!monthDisplayedPeriod) {
-          return period;
-        }
-
-        if (period.getMonth() - monthDisplayedPeriod > 1) {
-          return RangePickerAbstract.subtract(period, 1, 'month');
-        } else if (period.getMonth() - monthDisplayedPeriod < 0) {
-          return period;
-        }
+      if (offset < 0 || offset > 1) {
+        return highlightedPeriod;
       }
       return displayedPeriod;
     };


### PR DESCRIPTION
## Motivation and Context

It was found that in month range pickers the second calendar wasn't usable from keyboard. I found that the function setNextDisplayedPeriod was made very weird and unpredictable. I refactored it – now it's much simpler and predictable.

## How has this been tested?

Manually on all types of date pickers.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
