### PR TITLE
[scroll-area] Check that focused (clicked) element is outside scroll area container in both directions (top-bottom and left-right) before scroll to them.

### DIFF
--- a/semcore/scroll-area/CHANGELOG.md
+++ b/semcore/scroll-area/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Change
 
-- Check that focused (clicked) element is  outside scroll area container in both directions (top-bottom and left-right) before scroll to them.
+- Check that focused (clicked) element is outside scroll area container in both directions (top-bottom and left-right) before scroll to them.
 
 ## [5.20.8] - 2024-03-08
 

--- a/semcore/scroll-area/CHANGELOG.md
+++ b/semcore/scroll-area/CHANGELOG.md
@@ -4,9 +4,9 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ## [5.20.9] - 2024-03-11
 
-### Change
+### Fixed
 
-- Check that focused (clicked) element is outside scroll area container in both directions (top-bottom and left-right) before scroll to them.
+- Unexpected scroll in some corner cases.
 
 ## [5.20.8] - 2024-03-08
 

--- a/semcore/scroll-area/CHANGELOG.md
+++ b/semcore/scroll-area/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.20.9] - 2024-03-11
+
+### Change
+
+- Check that focused (clicked) element is  outside scroll area container in both directions (top-bottom and left-right) before scroll to them.
+
 ## [5.20.8] - 2024-03-08
 
 ### Fixed

--- a/semcore/scroll-area/src/ScrollArea.jsx
+++ b/semcore/scroll-area/src/ScrollArea.jsx
@@ -128,14 +128,17 @@ class ScrollAreaRoot extends Component {
         const element = e.target.getBoundingClientRect();
 
         if (viewPort) {
-          const inViewPort =
-            element.top >= viewPort.top &&
-            element.bottom <= viewPort.bottom &&
-            element.left >= viewPort.left &&
-            element.right <= viewPort.right;
+          const notInViewPort =
+            (element.top >= viewPort.bottom) ||
+            (element.bottom <= viewPort.top) ||
+            (element.left >= viewPort.right) ||
+            (element.right <= viewPort.left);
 
-          if (!inViewPort && this.asProps.keyboardFocused) {
-            e.target.scrollIntoView();
+          if (notInViewPort && this.asProps.keyboardFocused) {
+            e.target.scrollIntoView({
+              block: 'nearest',
+              inline: 'nearest',
+            });
           }
         }
       }

--- a/semcore/scroll-area/src/ScrollArea.jsx
+++ b/semcore/scroll-area/src/ScrollArea.jsx
@@ -129,10 +129,10 @@ class ScrollAreaRoot extends Component {
 
         if (viewPort) {
           const notInViewPort =
-            (element.top >= viewPort.bottom) ||
-            (element.bottom <= viewPort.top) ||
-            (element.left >= viewPort.right) ||
-            (element.right <= viewPort.left);
+            element.top >= viewPort.bottom ||
+            element.bottom <= viewPort.top ||
+            element.left >= viewPort.right ||
+            element.right <= viewPort.left;
 
           if (notInViewPort && this.asProps.keyboardFocused) {
             e.target.scrollIntoView({

--- a/semcore/scroll-area/src/ScrollArea.jsx
+++ b/semcore/scroll-area/src/ScrollArea.jsx
@@ -128,13 +128,13 @@ class ScrollAreaRoot extends Component {
         const element = e.target.getBoundingClientRect();
 
         if (viewPort) {
-          const notInViewPort =
+          const outOfViewport =
             element.top >= viewPort.bottom ||
             element.bottom <= viewPort.top ||
             element.left >= viewPort.right ||
             element.right <= viewPort.left;
 
-          if (notInViewPort && this.asProps.keyboardFocused) {
+          if (outOfViewport && this.asProps.keyboardFocused) {
             e.target.scrollIntoView({
               block: 'nearest',
               inline: 'nearest',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
I've change a condition in check "should we scroll or not" from element is fully inside contained to element not in container at all.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
