### PR TITLE
[global] some fixes in publish release scripts

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Fail if test step actually failed
         if: steps.test.outcome != 'success'
         run: exit 1
-  publish-semcore-prerelease:
+  publish-prerelease:
     runs-on: ubuntu-latest
     needs: [static-lint, unit-tests, browser-tests]
     env:
@@ -218,66 +218,6 @@ jobs:
         run: |
           pnpm --filter intergalactic-migrate run build
           pnpm publish-prerelease
-  publish-intergalactic-prerelease:
-    runs-on: ubuntu-latest
-    needs: [static-lint, unit-tests, browser-tests]
-    env:
-      GITHUB_SECRET: ${{ secrets.BOT_ACCOUNT_GITHUB_TOKEN }}
-      GCLOUD_SECRET: ${{ secrets.GCLOUD_SECRET }}
-    steps:
-      - uses: actions/checkout@v4.1.1
-        with:
-          token: ${{ secrets.BOT_ACCOUNT_GITHUB_TOKEN }}
-      - uses: pnpm/action-setup@v2.2.4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          version: 8
-          run_install: false
-      - uses: actions/setup-node@v4.0.1
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: |
-          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4.0.0
-        name: Restore pnpm cache
-        with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-      - name: Restore cached build
-        uses: actions/cache@v4.0.0
-        with:
-          path: |
-            semcore/*/lib
-            tools/*/lib
-            semcore/icon/**/*.js
-            semcore/icon/**/*.mjs
-            semcore/icon/**/*.d.ts
-            semcore/illustration/**/*.js
-            semcore/illustration/**/*.mjs
-            semcore/illustration/**/*.d.ts
-          key: build-${{ hashFiles('**/pnpm-lock.yaml', '**/CHANGELOG.md') }}-4
-      - name: Install restored dependencies
-        run: |
-          pnpm install
-      - name: Github GPG Auth
-        uses: crazy-max/ghaction-import-gpg@v5.3.0
-        with:
-          gpg_private_key: ${{ secrets.BOT_ACCOUNT_GPG_PRIVATE_KEY }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          git_committer_name: semrush-ci-whale
-          git_committer_email: semrush-ci-whale@users.noreply.github.com
-      - name: NPM setup
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ".npmrc"
-          echo "strict-peer-dependencies=false" >> ".npmrc"
-      - name: NPM auth check
-        run: pnpm whoami
-      - name: Deliver prerelease
-        run: |
-          pnpm --filter intergalactic-migrate run build
-          pnpm intg-publish-prerelease
   browser-tests:
     runs-on: ubuntu-latest
     needs: build

--- a/tools/continuous-delivery/bin/intg-publish-prerelease.ts
+++ b/tools/continuous-delivery/bin/intg-publish-prerelease.ts
@@ -1,9 +1,0 @@
-#!/usr/bin/env tsm
-
-/**
- * Options:
- *   --dry-run
- */
-import { publishPreRelease } from '../src/intg-release/publishPreRelease';
-
-await publishPreRelease();

--- a/tools/continuous-delivery/index.ts
+++ b/tools/continuous-delivery/index.ts
@@ -18,6 +18,10 @@ import { GitUtils } from './src/utils/gitUtils';
 import { NpmUtils } from './src/utils/npmUtils';
 import * as process from 'process';
 import { closeTasks } from './src/intg-release/closeTasks';
+import {
+  updateIntergalacticChangelog,
+  setIntergalacticPrereleaseVersion,
+} from './src/intg-release/updateIntergalacticChangelog';
 
 export const initPrerelease = async () => {
   const npmData = await fetchFromNpm();
@@ -67,6 +71,8 @@ export const initPrerelease = async () => {
       versionPatches.push(patch);
     }
 
+    await updateIntergalacticChangelog();
+
     await GitUtils.initNewPrerelease(versionPatches);
   }
 };
@@ -89,9 +95,11 @@ export const publishPrerelease = async () => {
       };
     }),
   );
+
+  await setIntergalacticPrereleaseVersion(prerelease);
   log('Updated versions to prerelease.');
 
-  await NpmUtils.publish(updatedPackages, true);
+  await NpmUtils.publish(updatedPackages.concat('intergalactic'), true);
 };
 
 export const publishRelease = async () => {

--- a/tools/continuous-delivery/package.json
+++ b/tools/continuous-delivery/package.json
@@ -5,9 +5,7 @@
   "bin": {
     "init-prerelease": "bin/init-prerelease.ts",
     "publish-prerelease": "bin/publish-prerelease.ts",
-    "publish-release": "bin/publish-release.ts",
-    "intg-publish-release": "bin/intg-publish-release.ts",
-    "intg-publish-prerelease": "bin/intg-publish-prerelease.ts"
+    "publish-release": "bin/publish-release.ts"
   },
   "private": true,
   "license": "MIT",

--- a/tools/continuous-delivery/src/intg-release/closeTasks.ts
+++ b/tools/continuous-delivery/src/intg-release/closeTasks.ts
@@ -1,5 +1,6 @@
 import Git from 'simple-git';
 import { log, prerelaseSuffix } from '../utils';
+import * as crypto from 'crypto';
 
 const git = Git();
 

--- a/tools/continuous-delivery/src/intg-release/closeTasks.ts
+++ b/tools/continuous-delivery/src/intg-release/closeTasks.ts
@@ -1,20 +1,14 @@
 import Git from 'simple-git';
-import { log } from '../utils';
-import fetch from 'node-fetch';
-import * as crypto from 'crypto';
+import { log, prerelaseSuffix } from '../utils';
 
 const git = Git();
 
 export const closeTasks = async (version: string) => {
-  const tags = await git.tags();
-  const latestTag = tags.latest;
-
-  if (!latestTag) {
-    log('No latest tag, skip');
-    return;
-  }
-
-  const logs = await git.log({ from: latestTag });
+  const tags = await git.tags(['v*', '--sort', 'creatordate']);
+  const releaseTags = tags.all.filter((tag) => !tag.includes(prerelaseSuffix));
+  const currentReleaseTagIndex = releaseTags.findIndex((tag) => tag === `v${version}`);
+  const prevReleaseTag = releaseTags[currentReleaseTagIndex - 1];
+  const logs = await git.log({ from: prevReleaseTag });
   const regexp = new RegExp(/\[(.*?)\]/gi);
   const taskIds = logs.all
     .map((item) => {

--- a/tools/continuous-delivery/src/intg-release/updateIntergalacticChangelog.ts
+++ b/tools/continuous-delivery/src/intg-release/updateIntergalacticChangelog.ts
@@ -10,7 +10,7 @@ import { GitUtils } from '../utils/gitUtils';
 
 const dirname = path.resolve(process.cwd(), 'node_modules', 'intergalactic');
 
-const publishPreRelease = async () => {
+const updateIntergalacticChangelog = async () => {
   const packageJsonFilePath = path.resolve(dirname, 'package.json');
   const packageJson = fs.readJSONSync(packageJsonFilePath);
   const deps = fs.readJSONSync(path.resolve(dirname, 'components.json'));
@@ -44,9 +44,14 @@ const publishPreRelease = async () => {
   // 4) Update version in package.json
   packageJson.version = currentTag;
   fs.writeJsonSync(packageJsonFilePath, packageJson, { spaces: 2 });
-
-  // 5) Publish package
-  await publishTarball(packageJson.name, dirname, true);
 };
 
-export { publishPreRelease };
+const setIntergalacticPrereleaseVersion = async (prerelease: string) => {
+  const packageJsonFilePath = path.resolve(dirname, 'package.json');
+  const packageJson = fs.readJSONSync(packageJsonFilePath);
+
+  packageJson.version = `${packageJson.version}-${prerelease}`;
+  fs.writeJsonSync(packageJsonFilePath, packageJson, { spaces: 2 });
+};
+
+export { updateIntergalacticChangelog, setIntergalacticPrereleaseVersion };

--- a/tools/continuous-delivery/src/utils/gitUtils.ts
+++ b/tools/continuous-delivery/src/utils/gitUtils.ts
@@ -1,4 +1,5 @@
 import Git from 'simple-git';
+import { execSync } from 'child_process';
 import { log, prerelaseSuffix } from '../utils';
 import { VersionPatch } from '../makeVersionPatches';
 import { NpmUtils } from './npmUtils';
@@ -35,10 +36,11 @@ export class GitUtils {
   }
 
   public static async getCurrentTag(): Promise<string | null> {
-    const tags = await git.tags();
-    const latestTag = tags.latest ?? null;
+    const tag = execSync('git describe --tags --abbrev=0', {
+      encoding: 'utf-8',
+    });
 
-    return latestTag;
+    return tag.trim();
   }
 
   public static async getPrerelease(): Promise<string | null> {


### PR DESCRIPTION
`simple-git` `tags` command return list of tags, sorted by semantic version number by default. So, as currentTag in release we have latest prerelease tag of this version. Also, sort by `creatordate` doesn't work, because for prerelease and release we'll have the same dates, so, we'll get prerelease too.
I've changed `getCurrentTag` method to use `git describe` and fixed version in message to slack and fixed a list of tasks to close.

Also, I've changed logic of generating changelogs and publishing for `intergalactic` package.