### PR TITLE
[86bxwjwjc][utils] use React.useId in useUID when it's avaialble

### DIFF
--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.21.0] - 2024-03-13
+
+### Fixed
+
+- `useUID` hook was producing different ids on SSR and client. Now it uses `React.useId` if it's available.
+
 ## [4.20.5] - 2024-03-04
 
 ### Fixed

--- a/semcore/utils/src/uniqueID.ts
+++ b/semcore/utils/src/uniqueID.ts
@@ -19,7 +19,7 @@ const createSource = (prefix = 'ui-kit-'): ContextType => ({ value: 1, prefix })
 
 export const useUID = (prefix?: string): string => {
   const context = register.get<ContextType>('uid-context', createSource(prefix));
-  const [uid] = React.useState<number>(context.value++);
+  const [uid] = React.useId ? [React.useId()] : React.useState<number>(context.value++);
 
   useEnhancedEffect(() => {
     register.set<ContextType>('uid-context', context);

--- a/semcore/utils/src/uniqueID.ts
+++ b/semcore/utils/src/uniqueID.ts
@@ -20,12 +20,14 @@ const createSource = (prefix = 'ui-kit-'): ContextType => ({ value: 1, prefix })
 export const useUID = (prefix?: string): string => {
   const context = register.get<ContextType>('uid-context', createSource(prefix));
   const [uid] = React.useId ? [React.useId()] : React.useState<number>(context.value++);
+  const trimmedUid =
+    String(uid).startsWith(':') && String(uid).endsWith(':') ? String(uid).slice(1, -1) : uid;
 
   useEnhancedEffect(() => {
     register.set<ContextType>('uid-context', context);
-  }, [uid]);
+  }, [trimmedUid]);
 
-  return (context.prefix ?? '') + uid;
+  return (context.prefix ?? '') + trimmedUid;
 };
 
 export default (prefix?: string) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

On one of existing project hydration errors were faced. It was caused by different `uid` generated by `useUID` hook on the client and on the server. I made it to use React.useId when it's available (we want to support older versions of React).

## How has this been tested?

I've modified code of library in node_modules of that project and ensured that hydration errors have gone.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
