### PR TITLE
[86bxtt4bg][dropdown-menu] highlight initially selected item after opening dropdown

### DIFF
--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.24.0] - 2024-03-13
+
+### Changed
+
+- Highlight initially selected item after opening dropdown.
+
 ## [4.23.2] - 2024-03-11
 
 ### Changed

--- a/semcore/dropdown-menu/__tests__/index.test.tsx
+++ b/semcore/dropdown-menu/__tests__/index.test.tsx
@@ -209,6 +209,32 @@ describe('DropdownMenu', () => {
     });
   });
 
+  test.only.concurrent('highlights selected item', async ({ expect }) => {
+    let highlightedIndex: number | undefined = undefined;
+
+    const component = render(
+      <DropdownMenu
+        placement='right'
+        onHighlightedIndexChange={(i) => {
+          highlightedIndex = i;
+        }}
+      >
+        <DropdownMenu.Trigger tag='button' data-testid='dd-trigger'>
+          Trigger
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Menu>
+          <DropdownMenu.Item>Item 1</DropdownMenu.Item>
+          <DropdownMenu.Item>Item 2</DropdownMenu.Item>
+          <DropdownMenu.Item selected>Item 3</DropdownMenu.Item>
+        </DropdownMenu.Menu>
+      </DropdownMenu>,
+    );
+
+    const trigger = component.getByTestId('dd-trigger');
+    await userEvent.click(trigger);
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    await expect(highlightedIndex).toBe(2);
+  });
   test.sequential('arrows open/close', async ({ expect }) => {
     let visible = undefined;
     render(

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -53,6 +53,12 @@ class DropdownMenuRoot extends Component {
         (visible) => {
           if (!visible) {
             this.ignoreTriggerKeyboardFocusUntil = Date.now() + 100;
+          } else {
+            setTimeout(() => {
+              const selectedItem = this.itemProps.find((item) => item.selected);
+              if (!selectedItem || this.asProps.highlightedIndex !== null) return;
+              this.handlers.highlightedIndex(this.itemProps.indexOf(selectedItem));
+            }, 0);
           }
         },
       ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

In our dropdown menus highlight navigation works from selected item. And it's quite counterintuitively that after opening that selected item has "hidden" highlight. This PR makes this "hidden" highlight explicit.

## How has this been tested?

On select components. With unit & manual testing.

## Screenshots:

Select with selected item.

Before:

<img width="155" alt="Screenshot 2024-03-13 at 18 03 47" src="https://github.com/semrush/intergalactic/assets/31261408/7e848356-82b6-42f9-9c86-c2b707db880f">

After:

<img width="210" alt="Screenshot 2024-03-13 at 18 03 24" src="https://github.com/semrush/intergalactic/assets/31261408/33d13b50-3cbb-439f-af44-d63dfbd5fe86">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [x] I have added new unit tests on added of fixed functionality.
