### PR TITLE
[86bxtpffy][notice-bubble] close button now uses `button` tag (instead of `div` before)

### DIFF
--- a/semcore/notice-bubble/CHANGELOG.md
+++ b/semcore/notice-bubble/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.25.0] - 2024-03-14
+
+### Changed
+
+- Close button now uses `button` tag (instead of `div` before).
+
 ## [5.24.5] - 2024-03-07
 
 ### Changed

--- a/semcore/notice-bubble/src/NoticeBubble.jsx
+++ b/semcore/notice-bubble/src/NoticeBubble.jsx
@@ -157,6 +157,8 @@ class ViewInfo extends Component {
         onMouseLeave={callAllEventHandlers(onMouseLeave, this.handlerMouseLeave)}
       >
         <SDismiss
+          tag='button'
+          type='button'
           title={getI18nText('close')}
           onClick={this.handlerClose}
           aria-label={getI18nText('close')}


### PR DESCRIPTION
## Motivation and Context

Using div as button is not good. I've replaced it with button tag and specified button type.

## How has this been tested?

No tests needed, I've just ensured that visually nothing changed.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
