### PR TITLE
[86bxxmcf9][dropdown-menu] fixed that `Enter` or `Space` keypress on focusable element inside of DropdownMenu was causing last highlighted item to be clicked

### DIFF
--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.24.1] - 2024-03-15
+
+### Fixed
+
+- `Enter` or `Space` keypress on focusable element inside of DropdownMenu was causing last highlighted item to be clicked.
+
 ## [4.24.0] - 2024-03-13
 
 ### Changed

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -182,7 +182,7 @@ class DropdownMenuRoot extends Component {
       }
       case ' ':
       case 'Enter':
-        if (this.highlightedItemRef.current) {
+        if (this.highlightedItemRef.current && highlightedIndex !== null) {
           e.stopPropagation();
           e.preventDefault();
           this.highlightedItemRef.current.click();


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Bug is very silly:

https://github.com/semrush/intergalactic/assets/31261408/387bdcc8-bce4-4800-a3b5-0687f62dbd9e

## How has this been tested?

I've just ensured that it was really fixed. No tests needed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
