### PR TITLE
[86bxxyr07][select] fixed that `Select.Option.Checkbox` wasn't visually checked in dev strict mode

### DIFF
--- a/semcore/select/CHANGELOG.md
+++ b/semcore/select/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Fixed
 
-- `Select.Option.Checkbox` wasn't visually checked in dev strict mode.
+- `Select.Option.Checkbox` visual displaying.
 
 ## [4.33.0] - 2024-03-15
 

--- a/semcore/select/src/Select.jsx
+++ b/semcore/select/src/Select.jsx
@@ -342,8 +342,8 @@ function Checkbox(providedProps) {
   const { className, style } = styles.cn('SOptionCheckbox', {
     size,
     'use:theme': resolveColor(theme),
-    checked: selected,
     indeterminate,
+    selected,
   });
 
   return (

--- a/semcore/select/src/style/select.shadow.css
+++ b/semcore/select/src/style/select.shadow.css
@@ -20,31 +20,34 @@ SOptionCheckbox {
 
   width: 16px;
   height: 16px;
+}
 
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    margin: 0 var(--intergalactic-spacing-05x, 2px);
-    background-repeat: no-repeat;
-    background-position: center center;
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iNyIgdmlld0JveD0iMCAwIDEwIDciIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik04LjI1IDFMNCA1LjI1TDEuNzUgMyIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPC9zdmc+Cg==');
-  }
+SOptionCheckbox::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: 0 var(--intergalactic-spacing-05x, 2px);
+  background-repeat: no-repeat;
+  background-position: center center;
+}
+
+SOptionCheckbox[selected]::after {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iNyIgdmlld0JveD0iMCAwIDEwIDciIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik04LjI1IDFMNCA1LjI1TDEuNzUgMyIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPC9zdmc+Cg==');
 }
 
 SOptionCheckbox[size='l'] {
   width: 20px;
   height: 20px;
-
-  &::after {
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOSIgdmlld0JveD0iMCAwIDEyIDkiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0xMSAxLjVMNC43NSA3Ljc1TDEgNCIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPC9zdmc+Cg==');
-  }
 }
 
-SOptionCheckbox[checked]:before {
+SOptionCheckbox[size='l'][selected]::after {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOSIgdmlld0JveD0iMCAwIDEyIDkiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0xMSAxLjVMNC43NSA3Ljc1TDEgNCIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPC9zdmc+Cg==');
+}
+
+SOptionCheckbox[selected]:before {
   background-color: var(--intergalactic-control-primary-info, #008ff8);
   border-color: var(--intergalactic-control-primary-info, #008ff8);
 }
@@ -58,7 +61,8 @@ SOptionCheckbox[theme]:before {
   border-color: var(--theme);
 }
 
-SOptionCheckbox[theme][checked]:before {
+SOptionCheckbox[theme][selected]:before,
+SOptionCheckbox[theme][indeterminate]:before {
   background-color: var(--theme);
   border-color: var(--theme);
 }


### PR DESCRIPTION
## Motivation and Context

Mechanism that was passing `selected` from `Select.Option` to `Select.Option.Checkbox` is very fragile and breaks in strict mode (definitely in dev mode and possible in production mode).

I've fixed it by creating a context over the select option and passing only specific props to `Select.Option.Checkbox`.

Fixes https://github.com/semrush/intergalactic/issues/1212

## How has this been tested?

Manually in strict dev mode .

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
