### PR TITLE
[86bxx59vm][widget-empty] added image width/height, removed alt

### DIFF
--- a/semcore/widget-empty/CHANGELOG.md
+++ b/semcore/widget-empty/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.20.0] - 2024-03-18
+
+### Fixed
+
+- Added widget empty image default width and height.
+- Widget empty image alt set to empty string to hide it from screen readers.
+
 ## [4.19.0] - 2024-03-15
 
 ### Changed

--- a/semcore/widget-empty/src/WidgetEmpty.jsx
+++ b/semcore/widget-empty/src/WidgetEmpty.jsx
@@ -21,7 +21,7 @@ class WidgetEmpty extends Component {
       <SWidgetEmpty render={Flex}>
         {isNode(icon) && (
           <SImage aria-hidden='true'>
-            {typeof icon === 'string' ? <img src={icon} alt='widget empty icon' /> : icon}
+            {typeof icon === 'string' ? <img src={icon} alt='' /> : icon}
           </SImage>
         )}
         <Children />

--- a/semcore/widget-empty/src/style/widget-empty.shadow.css
+++ b/semcore/widget-empty/src/style/widget-empty.shadow.css
@@ -10,6 +10,8 @@ SImage {
   align-items: flex-end;
   justify-content: center;
   margin-bottom: var(--intergalactic-spacing-3x, 12px);
+  width: 80px;
+  height: 80px;
 }
 
 STitle {
@@ -27,10 +29,10 @@ SDescription {
   max-width: 400px;
 }
 
-STitle + SDescription {
+STitle+SDescription {
   margin-top: var(--intergalactic-spacing-1x, 4px);
 }
 
-SDescription + SDescription {
+SDescription+SDescription {
   margin-top: var(--intergalactic-spacing-2x, 8px);
 }


### PR DESCRIPTION
## Motivation and Context

Widget empty image had a layout shift after first render. I've set a fixed width and height on it to prevent that layout shift.

## How has this been tested?

Not sure it's possible to test it.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
