### PR TITLE
[86bxyarnp][inline-input] added onBlurBehavior=none

### DIFF
--- a/semcore/inline-input/__tests__/index.test.tsx
+++ b/semcore/inline-input/__tests__/index.test.tsx
@@ -143,10 +143,12 @@ describe('InlineInput', () => {
     await expect(await snapshot(component)).toMatchImageSnapshot(task);
   });
 
-  test.concurrent('on blur behavior', () => {
+  test.only.concurrent('on blur behavior', () => {
     vi.useFakeTimers();
     const spyCancel = vi.fn();
     const spyConfirm = vi.fn();
+    const spyNone = vi.fn();
+    const spyUndefined = vi.fn();
 
     const { getByTestId } = render(
       <>
@@ -156,11 +158,23 @@ describe('InlineInput', () => {
         <InlineInput data-testid='behavior-confirm' onBlurBehavior='confirm' onConfirm={spyConfirm}>
           <InlineInput.Value />
         </InlineInput>
+        <InlineInput data-testid='behavior-none' onBlurBehavior='none' onConfirm={spyNone}>
+          <InlineInput.Value />
+        </InlineInput>
+        <InlineInput
+          data-testid='behavior-undefined'
+          onBlurBehavior={undefined}
+          onConfirm={spyUndefined}
+        >
+          <InlineInput.Value />
+        </InlineInput>
       </>,
     );
 
     expect(spyCancel).toHaveBeenCalledTimes(0);
     expect(spyConfirm).toHaveBeenCalledTimes(0);
+    expect(spyNone).toHaveBeenCalledTimes(0);
+    expect(spyUndefined).toHaveBeenCalledTimes(0);
 
     /** bubbling doesn't work in jest? */
     fireEvent.blur(getByTestId('behavior-cancel'));
@@ -173,6 +187,16 @@ describe('InlineInput', () => {
       vi.runAllTimers();
     });
     expect(spyConfirm).toHaveBeenCalledTimes(1);
+    fireEvent.blur(getByTestId('behavior-none'));
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(spyNone).toHaveBeenCalledTimes(0);
+    fireEvent.blur(getByTestId('behavior-undefined'));
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(spyUndefined).toHaveBeenCalledTimes(1);
     vi.useRealTimers();
   });
 

--- a/semcore/inline-input/src/index.d.ts
+++ b/semcore/inline-input/src/index.d.ts
@@ -55,7 +55,7 @@ export type InlineInputProps = BoxProps & {
    * defines callback (`onCancel` or `onConfirm`) triggered when `blur` event out of container fired
    * Triggered after all previous macrotasks completed (internally called inside of `setTimeout`)
    */
-  onBlurBehavior?: 'cancel' | 'confirm';
+  onBlurBehavior?: 'cancel' | 'confirm' | 'none';
   locale?: string;
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Currently it's not possible to disable onBlurBehavior. This PR adds such option.

## How has this been tested?

Manually and with a new unit test case.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [x] I have added new unit tests on added of fixed functionality.
