### PR TITLE
[86bxyc2u2][input-tags] wasn't allowing to move focus back of empty container

### DIFF
--- a/semcore/input-tags/CHANGELOG.md
+++ b/semcore/input-tags/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.25.0] - 2024-03-18
+
+### Fixed
+
+- It wasn't possible to move focus back from the empty input-tags container with `Shift+Tab`.
+
 ## [4.24.0] - 2024-03-15
 
 ### Changed

--- a/semcore/input-tags/src/InputTags.tsx
+++ b/semcore/input-tags/src/InputTags.tsx
@@ -153,6 +153,7 @@ class InputTags extends Component<IInputTagsProps> {
     if (!container || target !== container) return;
     const hasTags = this.tagsRefs.some(Boolean);
     if (hasTags) return;
+    if (event.relatedTarget === this.inputRef.current) return;
     this.moveFocusToInput(event);
   };
 


### PR DESCRIPTION
## Motivation and Context

Backward navigation on page with `shift+tab` makes user stuck in container if it's empty. It happens because focused input tags container moves focus to the input in the end of container. I've added additional check to prevent looping focus back to this input.

## How has this been tested?

Only manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
