### PR TITLE
[86bxxhdzg][utils, popper] made focus lock to work in popper with disabled portal

### DIFF
--- a/semcore/popper/__tests__/popper.browser-test.tsx
+++ b/semcore/popper/__tests__/popper.browser-test.tsx
@@ -1,0 +1,43 @@
+import { test } from '@semcore/testing-utils/playwright';
+import { e2eStandToHtml } from '@semcore/testing-utils/e2e-stand';
+
+test.describe('Popper', () => {
+  test('Focus lock', async ({ page }) => {
+    const standPath = 'semcore/popper/__tests__/stands/dropdown.tsx';
+    const htmlContent = await e2eStandToHtml(standPath, 'en');
+
+    await page.setContent(htmlContent);
+    await page.mouse.click(1, 1);
+
+    for (let i = 0; i < 50; i++) {
+      await page.keyboard.press('Tab');
+    }
+
+    await page.waitForFunction(() => {
+      const focusedElement = document.activeElement;
+      return (
+        focusedElement?.matches('[data-testid="popper"]') ||
+        focusedElement?.matches('[data-testid="input-in-popper"]')
+      );
+    });
+  });
+  test('Focus lock with disablePortal', async ({ page }) => {
+    const standPath = 'semcore/popper/__tests__/stands/disablePortal.tsx';
+    const htmlContent = await e2eStandToHtml(standPath, 'en');
+
+    await page.setContent(htmlContent);
+    await page.mouse.click(1, 1);
+
+    for (let i = 0; i < 50; i++) {
+      await page.keyboard.press('Tab');
+    }
+
+    await page.waitForFunction(() => {
+      const focusedElement = document.activeElement;
+      return (
+        focusedElement?.matches('[data-testid="popper"]') ||
+        focusedElement?.matches('[data-testid="input-in-popper"]')
+      );
+    });
+  });
+});

--- a/semcore/popper/__tests__/stands/disablePortal.tsx
+++ b/semcore/popper/__tests__/stands/disablePortal.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+// @ts-ignore
 import DropdownMenu from 'intergalactic/dropdown-menu';
+// @ts-ignore
 import { ButtonTrigger } from 'intergalactic/base-trigger';
 
 const Demo = () => {

--- a/semcore/popper/__tests__/stands/disablePortal.tsx
+++ b/semcore/popper/__tests__/stands/disablePortal.tsx
@@ -10,7 +10,7 @@ const Demo = () => {
       <DropdownMenu visible disablePortal>
         <DropdownMenu.Trigger tag={ButtonTrigger}>Disabled portal</DropdownMenu.Trigger>
         <DropdownMenu.Popper p={5} data-testid='popper'>
-          <input />
+          <input data-testid='input-in-popper' />
         </DropdownMenu.Popper>
       </DropdownMenu>
       <input />

--- a/semcore/popper/__tests__/stands/disablePortal.tsx
+++ b/semcore/popper/__tests__/stands/disablePortal.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import DropdownMenu from 'intergalactic/dropdown-menu';
+import { ButtonTrigger } from 'intergalactic/base-trigger';
+
+const Demo = () => {
+  return (
+    <div>
+      <DropdownMenu visible disablePortal>
+        <DropdownMenu.Trigger tag={ButtonTrigger}>Disabled portal</DropdownMenu.Trigger>
+        <DropdownMenu.Popper p={5} data-testid='popper'>
+          <input />
+        </DropdownMenu.Popper>
+      </DropdownMenu>
+      <input />
+    </div>
+  );
+};
+
+export default Demo;

--- a/semcore/popper/__tests__/stands/dropdown.tsx
+++ b/semcore/popper/__tests__/stands/dropdown.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import DropdownMenu from 'intergalactic/dropdown-menu';
+import { ButtonTrigger } from 'intergalactic/base-trigger';
+
+const Demo = () => {
+  return (
+    <div>
+      <DropdownMenu visible>
+        <DropdownMenu.Trigger tag={ButtonTrigger}>Disabled portal</DropdownMenu.Trigger>
+        <DropdownMenu.Popper p={5} data-testid='popper'>
+          <input data-testid='input-in-popper' />
+        </DropdownMenu.Popper>
+      </DropdownMenu>
+      <input />
+    </div>
+  );
+};
+
+export default Demo;

--- a/semcore/popper/__tests__/stands/dropdown.tsx
+++ b/semcore/popper/__tests__/stands/dropdown.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+// @ts-ignore
 import DropdownMenu from 'intergalactic/dropdown-menu';
+// @ts-ignore
 import { ButtonTrigger } from 'intergalactic/base-trigger';
 
 const Demo = () => {

--- a/semcore/popper/__tests__/stands/dropdown.tsx
+++ b/semcore/popper/__tests__/stands/dropdown.tsx
@@ -8,7 +8,7 @@ const Demo = () => {
   return (
     <div>
       <DropdownMenu visible>
-        <DropdownMenu.Trigger tag={ButtonTrigger}>Disabled portal</DropdownMenu.Trigger>
+        <DropdownMenu.Trigger tag={ButtonTrigger}>Enabled portal</DropdownMenu.Trigger>
         <DropdownMenu.Popper p={5} data-testid='popper'>
           <input data-testid='input-in-popper' />
         </DropdownMenu.Popper>

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -489,22 +489,18 @@ function PopperPopper(props) {
 
   // https://github.com/facebook/react/issues/11387
   const stopPropagation = React.useCallback((event) => event.stopPropagation(), []);
-  const propagateFocusLockSyntheticEvent = React.useCallback(
-    (event) => {
-      event.stopPropagation();
-      if (!disablePortal) return;
-      const syntheticEvent = new Event(syntheticEvents[event.type], {
-        bubbles: true,
-      });
-      Object.defineProperty(syntheticEvent, 'target', { writable: false, value: event.target });
-      Object.defineProperty(syntheticEvent, 'relatedTarget', {
-        writable: false,
-        value: event.relatedTarget,
-      });
-      ref.current?.dispatchEvent(syntheticEvent);
-    },
-    [disablePortal],
-  );
+  const propagateFocusLockSyntheticEvent = React.useCallback((event) => {
+    event.stopPropagation();
+    const syntheticEvent = new Event(syntheticEvents[event.type], {
+      bubbles: true,
+    });
+    Object.defineProperty(syntheticEvent, 'target', { writable: false, value: event.target });
+    Object.defineProperty(syntheticEvent, 'relatedTarget', {
+      writable: false,
+      value: event.relatedTarget,
+    });
+    ref.current?.dispatchEvent(syntheticEvent);
+  }, []);
 
   useFocusLock(
     ref,
@@ -566,11 +562,11 @@ function PopperPopper(props) {
           onMouseOver={stopPropagation}
           onMouseOut={stopPropagation}
           onMouseUp={stopPropagation}
-          onKeyDown={propagateFocusLockSyntheticEvent}
+          onKeyDown={disablePortal ? propagateFocusLockSyntheticEvent : stopPropagation}
           onKeyPress={stopPropagation}
           onKeyUp={stopPropagation}
           onFocus={stopPropagation}
-          onBlur={propagateFocusLockSyntheticEvent}
+          onBlur={disablePortal ? propagateFocusLockSyntheticEvent : stopPropagation}
           onChange={stopPropagation}
           onInput={stopPropagation}
           onInvalid={stopPropagation}

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -496,8 +496,11 @@ function PopperPopper(props) {
       const syntheticEvent = new Event(syntheticEvents[event.type], {
         bubbles: true,
       });
-      syntheticEvent.target = event.target;
-      syntheticEvent.relatedTarget = event.relatedTarget;
+      // In JSDom event properties are read-only
+      if (Object.getOwnPropertyDescriptor(event, 'target').writable) {
+        syntheticEvent.target = event.target;
+        syntheticEvent.relatedTarget = event.relatedTarget;
+      }
       ref.current?.dispatchEvent(syntheticEvent);
     },
     [disablePortal],

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -496,11 +496,11 @@ function PopperPopper(props) {
       const syntheticEvent = new Event(syntheticEvents[event.type], {
         bubbles: true,
       });
-      // In JSDom event properties are read-only
-      if (Object.getOwnPropertyDescriptor(event, 'target').writable) {
-        syntheticEvent.target = event.target;
-        syntheticEvent.relatedTarget = event.relatedTarget;
-      }
+      Object.defineProperty(syntheticEvent, 'target', { writable: false, value: event.target });
+      Object.defineProperty(syntheticEvent, 'relatedTarget', {
+        writable: false,
+        value: event.relatedTarget,
+      });
       ref.current?.dispatchEvent(syntheticEvent);
     },
     [disablePortal],

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -11,7 +11,7 @@ import {
   useFocusLock,
   isFocusInside,
   setFocus,
-  syntheticEvents,
+  makeFocusLockSyntheticEvent,
 } from '@semcore/utils/lib/use/useFocusLock';
 import { callAllEventHandlers } from '@semcore/utils/lib/assignProps';
 import pick from '@semcore/utils/lib/pick';
@@ -490,16 +490,8 @@ function PopperPopper(props) {
   // https://github.com/facebook/react/issues/11387
   const stopPropagation = React.useCallback((event) => event.stopPropagation(), []);
   const propagateFocusLockSyntheticEvent = React.useCallback((event) => {
-    event.stopPropagation();
-    const syntheticEvent = new Event(syntheticEvents[event.type], {
-      bubbles: true,
-    });
-    Object.defineProperty(syntheticEvent, 'target', { writable: false, value: event.target });
-    Object.defineProperty(syntheticEvent, 'relatedTarget', {
-      writable: false,
-      value: event.relatedTarget,
-    });
-    ref.current?.dispatchEvent(syntheticEvent);
+    event.nativeEvent.stopImmediatePropagation();
+    ref.current?.dispatchEvent(makeFocusLockSyntheticEvent(event));
   }, []);
 
   useFocusLock(
@@ -562,11 +554,11 @@ function PopperPopper(props) {
           onMouseOver={stopPropagation}
           onMouseOut={stopPropagation}
           onMouseUp={stopPropagation}
-          onKeyDown={disablePortal ? propagateFocusLockSyntheticEvent : stopPropagation}
+          onKeyDown={propagateFocusLockSyntheticEvent}
           onKeyPress={stopPropagation}
           onKeyUp={stopPropagation}
           onFocus={stopPropagation}
-          onBlur={disablePortal ? propagateFocusLockSyntheticEvent : stopPropagation}
+          onBlur={propagateFocusLockSyntheticEvent}
           onChange={stopPropagation}
           onInput={stopPropagation}
           onInvalid={stopPropagation}

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -7,7 +7,12 @@ import OutsideClick from '@semcore/outside-click';
 import Portal, { PortalProvider } from '@semcore/portal';
 import NeighborLocation from '@semcore/neighbor-location';
 import { setRef } from '@semcore/utils/lib/ref';
-import { useFocusLock, isFocusInside, setFocus } from '@semcore/utils/lib/use/useFocusLock';
+import {
+  useFocusLock,
+  isFocusInside,
+  setFocus,
+  syntheticEvents,
+} from '@semcore/utils/lib/use/useFocusLock';
 import { callAllEventHandlers } from '@semcore/utils/lib/assignProps';
 import pick from '@semcore/utils/lib/pick';
 import uniqueIDEnhancement from '@semcore/utils/lib/uniqueID';
@@ -484,6 +489,19 @@ function PopperPopper(props) {
 
   // https://github.com/facebook/react/issues/11387
   const stopPropagation = React.useCallback((event) => event.stopPropagation(), []);
+  const propagateFocusLockSyntheticEvent = React.useCallback(
+    (event) => {
+      event.stopPropagation();
+      if (!disablePortal) return;
+      const syntheticEvent = new Event(syntheticEvents[event.type], {
+        bubbles: true,
+      });
+      syntheticEvent.target = event.target;
+      syntheticEvent.relatedTarget = event.relatedTarget;
+      ref.current?.dispatchEvent(syntheticEvent);
+    },
+    [disablePortal],
+  );
 
   useFocusLock(
     ref,
@@ -545,11 +563,11 @@ function PopperPopper(props) {
           onMouseOver={stopPropagation}
           onMouseOut={stopPropagation}
           onMouseUp={stopPropagation}
-          onKeyDown={stopPropagation}
+          onKeyDown={propagateFocusLockSyntheticEvent}
           onKeyPress={stopPropagation}
           onKeyUp={stopPropagation}
           onFocus={stopPropagation}
-          onBlur={stopPropagation}
+          onBlur={propagateFocusLockSyntheticEvent}
           onChange={stopPropagation}
           onInput={stopPropagation}
           onInvalid={stopPropagation}

--- a/semcore/utils/src/use/useFocusLock.ts
+++ b/semcore/utils/src/use/useFocusLock.ts
@@ -14,9 +14,30 @@ export { isFocusInside, setFocus };
 
 const focusBordersConsumers = new Set();
 
-export const syntheticEvents = {
+const syntheticEvents = {
   blur: 'focusout-intergalactic-focus-lock-synthetic',
   keydown: 'keydown-intergalactic-focus-lock-synthetic',
+};
+/**
+ * Synthetic event are special events that always bypass all propagation guards and reaches focus lock event listeners.
+ * You should always prevent native event propagation in order to prevent focus enforcing double calls.
+ */
+export const makeFocusLockSyntheticEvent = (baseEvent: Event) => {
+  const event = baseEvent as any;
+  const type = event.type as keyof typeof syntheticEvents;
+  if (!(type in syntheticEvents)) {
+    const supported = Object.keys(syntheticEvents).join(', ');
+    throw new Error(`Unable to make synthetic event for ${type}, ${supported} are supported`);
+  }
+  const syntheticEvent = new Event(syntheticEvents[type], {
+    bubbles: true,
+  });
+  Object.defineProperty(syntheticEvent, 'target', { writable: false, value: event.target });
+  Object.defineProperty(syntheticEvent, 'relatedTarget', {
+    writable: false,
+    value: event.relatedTarget,
+  });
+  return syntheticEvent;
 };
 
 const useFocusBorders = (React: ReactT, disabled?: boolean) => {

--- a/semcore/utils/src/use/useFocusLock.ts
+++ b/semcore/utils/src/use/useFocusLock.ts
@@ -14,6 +14,11 @@ export { isFocusInside, setFocus };
 
 const focusBordersConsumers = new Set();
 
+export const syntheticEvents = {
+  blur: 'focusout-intergalactic-focus-lock-synthetic',
+  keydown: 'keydown-intergalactic-focus-lock-synthetic',
+};
+
 const useFocusBorders = (React: ReactT, disabled?: boolean) => {
   useUniqueIdHookMock(React);
   React.useEffect(() => {
@@ -107,7 +112,6 @@ const useFocusLockHook = (
     (event: Event & { relatedTarget?: HTMLElement; target?: HTMLElement }) => {
       const focusCameFrom = event.target;
       const focusMovedTo = event.relatedTarget;
-
       setTimeout(() => {
         if (!focusCameFrom) return;
         if (autoTriggerRef.current) return;
@@ -199,9 +203,11 @@ const useFocusLockHook = (
     if (focusableChildren.length === 0 && autoFocus !== 'enforced') return;
 
     document.body.addEventListener('focusout', handleFocusOut as any);
+    document.body.addEventListener(syntheticEvents.blur, handleFocusOut as any);
     document.body.addEventListener('mousedown', handleMouseEvent);
     document.body.addEventListener('touchstart', handleMouseEvent);
     document.body.addEventListener('keydown', handleKeyboardEvent);
+    document.body.addEventListener(syntheticEvents.keydown, handleKeyboardEvent);
 
     if (autoFocus)
       setFocus(
@@ -211,9 +217,11 @@ const useFocusLockHook = (
 
     return () => {
       document.body.removeEventListener('focusout', handleFocusOut as any);
+      document.body.removeEventListener(syntheticEvents.blur, handleFocusOut as any);
       document.body.removeEventListener('mousedown', handleMouseEvent);
       document.body.removeEventListener('touchstart', handleMouseEvent);
       document.body.removeEventListener('keydown', handleKeyboardEvent);
+      document.body.removeEventListener(syntheticEvents.keydown, handleKeyboardEvent);
       returnFocus();
       autoTriggerRef.current = null;
     };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -39,6 +39,10 @@ export default defineConfig({
         find: /^@semcore\/([\w-]*)$/,
         replacement: resolvePath(__dirname, 'semcore/$1/src'),
       },
+      {
+        find: /^intergalactic\/([\w-]*)$/,
+        replacement: resolvePath(__dirname, 'semcore/$1/src'),
+      },
     ],
   },
   test: {
@@ -57,6 +61,7 @@ export default defineConfig({
       'semcore/*/__tests__/**/*.vo-test.ts',
       'semcore/*/__tests__/**/*.browser-test.ts',
       'semcore/*/__tests__/**/*.browser-test.tsx',
+      'semcore/*/__tests__/**/stands',
       '**/__fixtures__',
       'tools/icon-transform-svg',
       '**/*.d.ts',


### PR DESCRIPTION
## Motivation and Context

If developer disables popper portal, popper prevents blur event to bubble of it. It's critical for work of focus lock, so I've added synthetic events in focus lock and made popper to forward it when it prevents specific event from bubbling. 

## How has this been tested?

I have added focus lock browser tests and covered disabledPortal caase.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [x] I have added new unit tests on added of fixed functionality.
