### PR TITLE
[date-picker] comparators missing locales

### DIFF
--- a/semcore/date-picker/CHANGELOG.md
+++ b/semcore/date-picker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.34.0] - 2024-03-25
+
+### Added
+
+- `DateRangeComparator` and `MonthDateRangeComparator` missing translations.
+
 ## [4.33.0] - 2024-03-22
 
 ### Changed

--- a/semcore/date-picker/src/translations/de.json
+++ b/semcore/date-picker/src/translations/de.json
@@ -12,5 +12,13 @@
   "last12Months": "Letzte 12 Monate",
   "prev": "Voriger Zeitraum",
   "next": "Nächster Zeitraum",
-  "input": "Datumsfeld"
+  "input": "Datumsfeld",
+  "compare": "Vergleichen mit",
+  "fromDate": "Vom {date}",
+  "toDate": "Bis {date}",
+  "dateRange": "Datumsbereich",
+  "dateRange1": "Erster Datumsbereich",
+  "dateRange2": "Zweiter Datumsbereich",
+  "selectingStarted": "Auswahl begonnen",
+  "selectingFinished": "Ausgewählt"
 }

--- a/semcore/date-picker/src/translations/es.json
+++ b/semcore/date-picker/src/translations/es.json
@@ -12,5 +12,13 @@
   "last12Months": "Últimos 12 meses",
   "prev": "Periodo precedente",
   "next": "Periodo siguiente",
-  "input": "Campo de datos"
+  "input": "Campo de datos",
+  "compare": "Comparar con",
+  "fromDate": "Desde {date}",
+  "toDate": "Hasta {date}",
+  "dateRange": "Rango de fechas",
+  "dateRange1": "Primer rango de fechas",
+  "dateRange2": "Segundo rango de fechas",
+  "selectingStarted": "Has empezado a seleccionar",
+  "selectingFinished": "Seleccionado"
 }

--- a/semcore/date-picker/src/translations/fr.json
+++ b/semcore/date-picker/src/translations/fr.json
@@ -12,5 +12,13 @@
   "last12Months": "12 derniers mois",
   "prev": "Période précédente",
   "next": "Période suivante",
-  "input": "Champ de date"
+  "input": "Champ de date",
+  "compare": "Comparer à",
+  "fromDate": "Du {date}",
+  "toDate": "Au {date}",
+  "dateRange": "Plage de dates",
+  "dateRange1": "Première plage de dates",
+  "dateRange2": "Deuxième plage de dates",
+  "selectingStarted": "Début de la sélection",
+  "selectingFinished": "Sélectionné"
 }

--- a/semcore/date-picker/src/translations/it.json
+++ b/semcore/date-picker/src/translations/it.json
@@ -12,5 +12,13 @@
   "last12Months": "Ultimi 12 mesi",
   "prev": "Periodo precedente",
   "next": "Periodo successivo",
-  "input": "Campo data"
+  "input": "Campo data",
+  "compare": "Confronta con",
+  "fromDate": "Da {date}",
+  "toDate": "A {date}",
+  "dateRange": "Intervallo temporale",
+  "dateRange1": "Primo intervallo temporale",
+  "dateRange2": "Secondo intervallo temporale",
+  "selectingStarted": "Inizia selezionando",
+  "selectingFinished": "Selezionato"
 }

--- a/semcore/date-picker/src/translations/ja.json
+++ b/semcore/date-picker/src/translations/ja.json
@@ -12,5 +12,13 @@
   "last12Months": "過去12か月間",
   "prev": "前期間",
   "next": "次の期間",
-  "input": "データフィールド"
+  "input": "データフィールド",
+  "compare": "次と比較",
+  "fromDate": "{date}から",
+  "toDate": "{date}まで",
+  "dateRange": "日付範囲",
+  "dateRange1": "一番目の日付範囲",
+  "dateRange2": "二番目の日付範囲",
+  "selectingStarted": "選択開始",
+  "selectingFinished": "選択終了"
 }

--- a/semcore/date-picker/src/translations/ko.json
+++ b/semcore/date-picker/src/translations/ko.json
@@ -12,5 +12,13 @@
   "last12Months": "최근 12개월",
   "prev": "지난 기간",
   "next": "다음 기간",
-  "input": "날짜 필드"
+  "input": "날짜 필드",
+  "compare": "비교 기간",
+  "fromDate": "{date}부터",
+  "toDate": "{date}까지",
+  "dateRange": "날짜 범위",
+  "dateRange1": "첫 번째 날짜 범위",
+  "dateRange2": "두 번째 날짜 범위",
+  "selectingStarted": "선택이 시작되었습니다",
+  "selectingFinished": "선택되었습니다"
 }

--- a/semcore/date-picker/src/translations/nl.json
+++ b/semcore/date-picker/src/translations/nl.json
@@ -12,5 +12,13 @@
   "last12Months": "Afgelopen 12 maanden",
   "prev": "Vorige periode",
   "next": "Volgende periode",
-  "input": "Datumveld"
+  "input": "Datumveld",
+  "compare": "Vergelijken met",
+  "fromDate": "Van {date}",
+  "toDate": "Tot {date}",
+  "dateRange": "Datumbereik",
+  "dateRange1": "Eerste datumbereik",
+  "dateRange2": "Tweede datumbereik",
+  "selectingStarted": "Begonnen met selecteren",
+  "selectingFinished": "Geselecteerd"
 }

--- a/semcore/date-picker/src/translations/pl.json
+++ b/semcore/date-picker/src/translations/pl.json
@@ -12,5 +12,13 @@
   "last12Months": "Ostatnie 12 miesięcy",
   "prev": "Poprzedni okres",
   "next": "Następny okres",
-  "input": "Pole daty"
+  "input": "Pole daty",
+  "compare": "Porównaj z",
+  "fromDate": "Od {date}",
+  "toDate": "Do {date}",
+  "dateRange": "Zakres dat",
+  "dateRange1": "Pierwszy zakres dat",
+  "dateRange2": "Drugi zakres dat",
+  "selectingStarted": "Rozpoczęto wybieranie",
+  "selectingFinished": "Wybrano"
 }

--- a/semcore/date-picker/src/translations/pt.json
+++ b/semcore/date-picker/src/translations/pt.json
@@ -12,5 +12,13 @@
   "last12Months": "Últimos 12 meses",
   "prev": "Período anterior",
   "next": "Próximo período",
-  "input": "Campo de data"
+  "input": "Campo de data",
+  "compare": "Comparar com",
+  "fromDate": "De {date}",
+  "toDate": "Até {date}",
+  "dateRange": "Intervalo de datas",
+  "dateRange1": "Primeiro intervalo de datas",
+  "dateRange2": "Segundo intervalo de datas",
+  "selectingStarted": "Seleção iniciada",
+  "selectingFinished": "Selecionado"
 }

--- a/semcore/date-picker/src/translations/sv.json
+++ b/semcore/date-picker/src/translations/sv.json
@@ -12,5 +12,13 @@
   "last12Months": "Senaste 12 månaderna",
   "prev": "Föregående period",
   "next": "Nästa period",
-  "input": "Datumfält"
+  "input": "Datumfält",
+  "compare": "Jämför med",
+  "fromDate": "Från {date}",
+  "toDate": "Till {date}",
+  "dateRange": "Datumintervall",
+  "dateRange1": "Första datumintervall",
+  "dateRange2": "Andra datumintervall",
+  "selectingStarted": "Började välja",
+  "selectingFinished": "Valt"
 }

--- a/semcore/date-picker/src/translations/tr.json
+++ b/semcore/date-picker/src/translations/tr.json
@@ -12,5 +12,13 @@
   "last12Months": "Son 12 ay",
   "prev": "Önceki dönem",
   "next": "Sonraki dönem",
-  "input": "Tarih alanı"
+  "input": "Tarih alanı",
+  "compare": "Şuna göre karşılaştır",
+  "fromDate": "{date} adresinden",
+  "toDate": "{date} tarihine kadar",
+  "dateRange": "Tarih aralığı",
+  "dateRange1": "İlk tarih aralığı",
+  "dateRange2": "İkinci tarih aralığı",
+  "selectingStarted": "Seçmeye başladım",
+  "selectingFinished": "Seçildi"
 }

--- a/semcore/date-picker/src/translations/vi.json
+++ b/semcore/date-picker/src/translations/vi.json
@@ -12,5 +12,13 @@
   "last12Months": "12 tháng qua",
   "prev": "Giai đoạn trước",
   "next": "Giai đoạn tới",
-  "input": "Trường ngày tháng"
+  "input": "Trường ngày tháng",
+  "compare": "So với",
+  "fromDate": "Từ {date}",
+  "toDate": "Đến {date}",
+  "dateRange": "Phạm vi ngày",
+  "dateRange1": "Khoảng thời gian đầu tiên",
+  "dateRange2": "Khoảng thời gian thứ hai",
+  "selectingStarted": "Bắt đầu chọn",
+  "selectingFinished": "Đã chọn"
 }

--- a/semcore/date-picker/src/translations/zh.json
+++ b/semcore/date-picker/src/translations/zh.json
@@ -12,5 +12,13 @@
   "last12Months": "过去 12 个月",
   "prev": "上一个时段",
   "next": "下一时段",
-  "input": "日期字段"
+  "input": "日期字段",
+  "compare": "比较",
+  "fromDate": "从 {date}",
+  "toDate": "至 {date}",
+  "dateRange": "日期范围",
+  "dateRange1": "第一个日期范围",
+  "dateRange2": "第二个日期范围",
+  "selectingStarted": "已开始选择",
+  "selectingFinished": "已选定"
 }


### PR DESCRIPTION

## Motivation and Context

Multiple locales where forgotten to be added to date range comparator components. This PR fixes it.

## How has this been tested?

No tests needed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
