### PR TITLE
[86bxxhdkq][dropdown-menu] clear highlightedItemRef on close

### DIFF
--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.24.2] - 2024-03-26
+
+### Fixed
+
+- After second reopen of dropdown menu, the second item was highlighted instead of the first one.
+
 ## [4.24.1] - 2024-03-15
 
 ### Fixed

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -387,6 +387,7 @@ class DropdownMenuRoot extends Component {
   componentDidUpdate() {
     if (!this.asProps.visible) {
       this.handlers.highlightedIndex(null);
+      this.highlightedItemRef.current = null;
     }
     if (
       (this.state.focusLockItemIndex !== this.asProps.highlightedIndex || !this.asProps.visible) &&


### PR DESCRIPTION
## Motivation and Context

While `highlightedIndex` was clearing on dropdown menu close, `highlightedItemRef` wasn't. It was causing bug that after second reopen of DropdownMenu, the second item was highlighted instead of first.

## How has this been tested?

Manually, it's enough for a such simple fix.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
