### PR TITLE
[popper] rolledback inter-label fix

### DIFF
--- a/semcore/dropdown-menu/__tests__/index.test.tsx
+++ b/semcore/dropdown-menu/__tests__/index.test.tsx
@@ -209,7 +209,7 @@ describe('DropdownMenu', () => {
     });
   });
 
-  test.only.concurrent('highlights selected item', async ({ expect }) => {
+  test.concurrent('highlights selected item', async ({ expect }) => {
     let highlightedIndex: number | undefined = undefined;
 
     const component = render(

--- a/semcore/inline-input/__tests__/index.test.tsx
+++ b/semcore/inline-input/__tests__/index.test.tsx
@@ -143,7 +143,7 @@ describe('InlineInput', () => {
     await expect(await snapshot(component)).toMatchImageSnapshot(task);
   });
 
-  test.only.concurrent('on blur behavior', () => {
+  test.concurrent('on blur behavior', () => {
     vi.useFakeTimers();
     const spyCancel = vi.fn();
     const spyConfirm = vi.fn();

--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
-## [5.25.1] - 2024-04-03
-
-### Fixed
-
-- Select with `disabpledPortal` inside a label was opening second time after selecting the option.
-
 ## [5.25.0] - 2024-03-27
 
 ### Changed

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -489,7 +489,6 @@ function PopperPopper(props) {
 
   // https://github.com/facebook/react/issues/11387
   const stopPropagation = React.useCallback((event) => {
-    event.preventDefault();
     event.stopPropagation();
   }, []);
   const propagateFocusLockSyntheticEvent = React.useCallback((event) => {


### PR DESCRIPTION
## Motivation and Context

I found that some of our tests are disabled by using only method. After enabling it, I found that recent update broken all events default behavior.

## How has this been tested?

With enabled tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Rollback

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [x] I have added new unit tests on added of fixed functionality.
