### PR TITLE
[86by5t73d][popper] fixed that Select and similar components with disabled portal were not working properly being wrapped into `label` tag

### DIFF
--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.26.0] - 2024-03-27
+
+### Fixed
+
+- Select and similar components with disabled portal were not working properly being wrapped into `label` tag.
+
 ## [5.25.0] - 2024-03-27
 
 ### Changed

--- a/semcore/popper/__tests__/popper.browser-test.tsx
+++ b/semcore/popper/__tests__/popper.browser-test.tsx
@@ -1,4 +1,4 @@
-import { test } from '@semcore/testing-utils/playwright';
+import { expect, test } from '@semcore/testing-utils/playwright';
 import { e2eStandToHtml } from '@semcore/testing-utils/e2e-stand';
 
 test.describe('Popper', () => {
@@ -41,5 +41,64 @@ test.describe('Popper', () => {
         );
       });
     }
+  });
+  test.describe('label', () => {
+    test('referenced', async ({ page }) => {
+      const standPath = 'semcore/popper/__tests__/stands/label-referenced.tsx';
+      const htmlContent = await e2eStandToHtml(standPath, 'en');
+
+      await page.setContent(htmlContent);
+
+      const option1Locator = await page.locator('text=Option 1');
+      const option3Locator = await page.locator('text=Option 3');
+
+      await expect(option3Locator).toHaveCount(0);
+
+      await page.locator('label').click();
+
+      await expect(option3Locator).toHaveCount(1);
+
+      await option1Locator.click();
+
+      await expect(option3Locator).toHaveCount(0);
+    });
+    test('wrapped', async ({ page }) => {
+      const standPath = 'semcore/popper/__tests__/stands/label-wrapped.tsx';
+      const htmlContent = await e2eStandToHtml(standPath, 'en');
+
+      await page.setContent(htmlContent);
+
+      const option1Locator = await page.locator('text=Option 1');
+      const option3Locator = await page.locator('text=Option 3');
+
+      await expect(option3Locator).toHaveCount(0);
+
+      await page.locator('label').click();
+
+      await expect(option3Locator).toHaveCount(1);
+
+      await option1Locator.click();
+
+      await expect(option3Locator).toHaveCount(0);
+    });
+    test('wrapped with disable portal', async ({ page }) => {
+      const standPath = 'semcore/popper/__tests__/stands/label-wrapped-disable-portal.tsx';
+      const htmlContent = await e2eStandToHtml(standPath, 'en');
+
+      await page.setContent(htmlContent);
+
+      const option1Locator = await page.locator('text=Option 1');
+      const option3Locator = await page.locator('text=Option 3');
+
+      await expect(option3Locator).toHaveCount(0);
+
+      await page.locator('label').click();
+
+      await expect(option3Locator).toHaveCount(1);
+
+      await option1Locator.click();
+
+      await expect(option3Locator).toHaveCount(0);
+    });
   });
 });

--- a/semcore/popper/__tests__/stands/label-referenced.tsx
+++ b/semcore/popper/__tests__/stands/label-referenced.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+// @ts-ignore
+import Select from 'intergalactic/select';
+
+const options = Array(5)
+  .fill('')
+  .map((_, index) => ({
+    label: `Option ${index}`,
+    children: `Option ${index}`,
+    value: index,
+  }));
+
+const Demo = () => {
+  return (
+    <div>
+      <div>
+        <label htmlFor='select'>Label</label>
+      </div>
+      <Select placeholder={'Select something'} options={options} id='select' />
+    </div>
+  );
+};
+
+export default Demo;

--- a/semcore/popper/__tests__/stands/label-wrapped-disable-portal.tsx
+++ b/semcore/popper/__tests__/stands/label-wrapped-disable-portal.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+// @ts-ignore
+import Select from 'intergalactic/select';
+
+const options = Array(5)
+  .fill('')
+  .map((_, index) => ({
+    label: `Option ${index}`,
+    children: `Option ${index}`,
+    value: index,
+  }));
+
+const Demo = () => {
+  return (
+    <label>
+      <div>Label</div>
+      <Select placeholder={'Select something'} options={options} disablePortal />
+    </label>
+  );
+};
+
+export default Demo;

--- a/semcore/popper/__tests__/stands/label-wrapped.tsx
+++ b/semcore/popper/__tests__/stands/label-wrapped.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+// @ts-ignore
+import Select from 'intergalactic/select';
+
+const options = Array(5)
+  .fill('')
+  .map((_, index) => ({
+    label: `Option ${index}`,
+    children: `Option ${index}`,
+    value: index,
+  }));
+
+const Demo = () => {
+  return (
+    <label>
+      <div>Label</div>
+      <Select placeholder={'Select something'} options={options} />
+    </label>
+  );
+};
+
+export default Demo;

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -260,7 +260,20 @@ class Popper extends Component {
   };
   bindHandlerKeyDown = (onKeyDown) => callAllEventHandlers(onKeyDown, this.handlerKeyDown);
 
+  lastPopperClick = 0;
   bindHandlerChangeVisibleWithTimer = (visible, component, action) => (e) => {
+    if (component === 'trigger' && action === 'onClick') {
+      const trigger = this.triggerRef.current;
+      const triggerClick = hasParent(e.target, trigger);
+      const associatedLabels = [...(trigger?.labels || [])];
+      const popperInsideOfLabel = associatedLabels.some((label) =>
+        hasParent(this.popperRef.current, label),
+      );
+
+      if (triggerClick && popperInsideOfLabel && Date.now() - this.lastPopperClick < 100) {
+        return;
+      }
+    }
     const now = Date.now();
     const focusAction = ['onFocus', 'onKeyboardFocus', 'onFocusCapture'].includes(action);
     if (
@@ -368,6 +381,7 @@ class Popper extends Component {
       popper: this.popper,
       disableEnforceFocus,
       handleFocusOut: this.handlePopperFocusOut,
+      onClick: this.handlePopperClick,
     };
   }
 
@@ -376,6 +390,10 @@ class Popper extends Component {
     if (hasParent(event.target, this.triggerRef.current)) return;
 
     this.bindHandlerChangeVisibleWithTimer(false, 'popper', 'onBlur')(event);
+  };
+
+  handlePopperClick = () => {
+    this.lastPopperClick = Date.now();
   };
 
   setContext() {


### PR DESCRIPTION
## Motivation and Context

Long time ago Select and other components were not supporting label tag clicks handling. Recently we fixed it. On the other had some of developers were wrapping Select's into labels without intention to get correct clicks handling and just for a11y tree labeling purpose.

Last case was broken by our update.
In this PR I'm adding additional checks. As we can't check if click comes from label tag I have added following check:
if trigger comes in window of 100ms after popper click and popper is a children of some of a label that is related to trigger, we should ignore this click.

## How has this been tested?

With added browser tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [x] I have added new unit tests on added of fixed functionality.
