### PR TITLE
[86byank03][dropdown-menu] fixed that DropdownMenu with input in the trigger was…

### DIFF
--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.26.2] - 2024-04-11
+
+### Fixed
+
+- DropdownMenu with input in the trigger was not highting current items when focus comes to input with mouse click.
+
 ## [4.26.1] - 2024-04-10
 
 ### Changed

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -130,6 +130,9 @@ class DropdownMenuRoot extends Component {
         return;
       }
     }
+    if (e.key.startsWith('Arrow') && !this.state.keyboardFocused) {
+      this.setState({ keyboardFocused: true });
+    }
     if (['ArrowLeft', 'ArrowRight'].includes(e.key)) {
       const item = highlightedIndex !== null && this.itemRefs[highlightedIndex];
       const focusable = getFocusableIn(item);


### PR DESCRIPTION
… not highlighted current items when focus comes to input with mouse click


## Motivation and Context

I've just discovered that recently comboboxes are broken in most use cases. If user clicks on trigger input (instead of coming with keyboard), highlighted items were not visually highlighted.

## How has this been tested?

Manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
