### PR TITLE
[86by23cx5][popper] fixed that in some cases popper mouseenter was unexpectedly ignored

### DIFF
--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.26.3] - 2024-04-12
+
+### Fixed
+
+- In some cases popper mouseenter was unexpectedly ignored.
+
 ## [5.26.2] - 2024-04-10
 
 ### Changed

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -50,12 +50,8 @@ const useUpdatePopperEveryFrame = (popperRef) => {
   return handleAnimationFrame;
 };
 
+let mouseMoveListenerAdded = false;
 let lastMouseMove = 0;
-if (canUseDOM()) {
-  document.addEventListener('mousemove', () => {
-    lastMouseMove = Date.now();
-  });
-}
 
 const MODIFIERS_OPTIONS = [
   'offset',
@@ -201,6 +197,19 @@ class Popper extends Component {
       this.popperRef.current,
       this.getPopperOptions(),
     );
+  }
+
+  componentDidMount() {
+    if (canUseDOM() && !mouseMoveListenerAdded) {
+      mouseMoveListenerAdded = true;
+      document.addEventListener(
+        'mousemove',
+        () => {
+          lastMouseMove = Date.now();
+        },
+        { capture: true },
+      );
+    }
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
## Motivation and Context

Without `capture: true` it was possible to prevent mousemove event from propagation. I've fixed it. Also moved it popper component mount to prevent mousemove listener to be added without poppers on the page. 

## How has this been tested?

Manually, for now it's enough.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
