### PR TITLE
[86by23cx5][pagination] fixed that component was loosing browser focus after reaching the last of first page with keyboard navigation

### DIFF
--- a/semcore/pagination/CHANGELOG.md
+++ b/semcore/pagination/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.32.0] - 2024-04-12
+
+### Fixed
+
+- Component was loosing browser focus after reaching the last of first page with keyboard navigation.
+
 ## [4.31.2] - 2024-04-10
 
 ### Changed

--- a/semcore/pagination/src/Pagination.jsx
+++ b/semcore/pagination/src/Pagination.jsx
@@ -58,6 +58,9 @@ class PaginationRoot extends Component {
   static style = style;
   static enhance = [i18nEnhance(localizedMessages)];
 
+  nextPageButtonRef = React.createRef();
+  prevPageButtonRef = React.createRef();
+
   state = {
     // Crutch, so as not to take out `dirtyCurrentPage` in props
     dirtyCurrentPage: undefined,
@@ -78,6 +81,21 @@ class PaginationRoot extends Component {
     }
   }
 
+  returnLostFocus = () => {
+    setTimeout(() => {
+      if (document.activeElement !== document.body) return;
+
+      const prevPageButton = this.prevPageButtonRef.current;
+      const nextPageButton = this.nextPageButtonRef.current;
+
+      if (prevPageButton && !prevPageButton.disabled) {
+        prevPageButton.focus();
+      } else if (nextPageButton && !nextPageButton.disabled) {
+        nextPageButton.focus();
+      }
+    }, 0);
+  };
+
   handlePageChange = (currentPage) => {
     currentPage = Number(currentPage);
     if (Number.isNaN(currentPage)) {
@@ -85,6 +103,7 @@ class PaginationRoot extends Component {
     }
     this.handlers.currentPage(currentPage);
     this.setState({ dirtyCurrentPage: undefined });
+    this.returnLostFocus();
   };
 
   handlePageValueChange = (value) => {
@@ -140,6 +159,7 @@ class PaginationRoot extends Component {
       disabled,
       onClick: () => this.handlePageChange(currentPage - 1),
       getI18nText,
+      ref: this.nextPageButtonRef,
     };
   };
 
@@ -151,6 +171,7 @@ class PaginationRoot extends Component {
       disabled,
       onClick: () => this.handlePageChange(currentPage + 1),
       getI18nText,
+      ref: this.prevPageButtonRef,
     };
   };
 


### PR DESCRIPTION
## Motivation and Context

When user reaches end/start of pagination using keyboard and next/prev buttons, the used button gets disabled, so the browser focus moved to body.

I've added additional check that returns focus if it lost.

## How has this been tested?

Manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
