### PR TITLE
[date-picker, input-mask] date input was trimmed a bit at the end

### DIFF
--- a/semcore/date-picker/CHANGELOG.md
+++ b/semcore/date-picker/CHANGELOG.md
@@ -12,6 +12,12 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 - Added missing translations for input trigger error tooltip.
 
+## [4.37.2] - 2024-04-15
+
+### Fixed
+
+- Input trigger text was little trimmed at the end.
+
 ## [4.37.1] - 2024-04-12
 
 ### Changed

--- a/semcore/date-picker/src/components/InputTrigger.jsx
+++ b/semcore/date-picker/src/components/InputTrigger.jsx
@@ -774,7 +774,7 @@ const MaskedInput = ({
       aliases={aliases}
       maskOnlySymbols={maskOnlySymbols}
       placeholder={mask}
-      w={appliedWidth}
+      inputW={appliedWidth}
       wMin={appliedWidth}
       {...otherProps}
       onFocus={handleFocus}

--- a/semcore/input-mask/CHANGELOG.md
+++ b/semcore/input-mask/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.24.0] - 2024-04-10
+
+### Added
+
+- `inputW` prop to override the width of the input field.
+
 ## [5.23.0] - 2024-04-15
 
 ### Changed

--- a/semcore/input-mask/src/InputMask.tsx
+++ b/semcore/input-mask/src/InputMask.tsx
@@ -75,6 +75,11 @@ export type InputMaskValueProps = InputValueProps & {
    * @default `{_: true}`
    */
   maskOnlySymbols?: Record<string, boolean>;
+
+  /**
+   * Overrids width of the input field
+   */
+  inputW?: string | number;
 };
 
 type InputMaskCtx = {
@@ -327,6 +332,7 @@ class Value extends Component<InputMaskValueProps, {}, {}, UniqueIDProps> {
       Children,
       forwardRef,
       uid,
+      inputW,
       ...otherProps
     } = this.asProps;
 
@@ -374,6 +380,7 @@ class Value extends Component<InputMaskValueProps, {}, {}, UniqueIDProps> {
                   ref={ref}
                   onFocus={this.onFocus}
                   value={value}
+                  w={inputW}
                   wMin={this.state.maskWidth}
                   aria-describedby={`hint-${uid}`}
                   {...controlProps}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Date Picker input trigger sets width on the input mask, but alongside being applied to input, it also applied to input container that should have paddings inside. This PR fixes it by a little ad hoc.

## How has this been tested?

Manually.

## Screenshots:

Before

<img width="489" alt="Screenshot 2024-04-15 at 18 09 34" src="https://github.com/semrush/intergalactic/assets/31261408/119bbeda-e410-441f-9229-e819263f6156">

After: 

<img width="434" alt="Screenshot 2024-04-15 at 18 09 18" src="https://github.com/semrush/intergalactic/assets/31261408/cf2a637c-dde5-4cb5-8a1c-770e49064025">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
