### PR TITLE
[86by2hktn][d3-chart] tooltip control

### DIFF
--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -2,567 +2,577 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.39.0] - 2024-04-16
+
+### Changed
+
+* Plot `eventEmitter` prop now is strongly typed.
+
+### Added
+
+* `PlotEventEmitter` class that allows to create typed event emitter for imperative control over chart tooltip.
+
 ## [3.38.1] - 2024-04-16
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [2.22.0 ~> 2.22.1], `@semcore/popper` [5.27.0 ~> 5.27.1], `@semcore/utils` [4.23.0 ~> 4.23.1], `@semcore/core` [2.20.0 ~> 2.20.1]).
+* Version patch update due to children dependencies update (`@semcore/animation` [2.22.0 ~> 2.22.1], `@semcore/popper` [5.27.0 ~> 5.27.1], `@semcore/utils` [4.23.0 ~> 4.23.1], `@semcore/core` [2.20.0 ~> 2.20.1]).
 
 ## [3.38.0] - 2024-04-12
 
 ### Added
 
-- `Cigarette` chart.
+* `Cigarette` chart.
 
 ## [3.37.4] - 2024-04-12
 
 ### Fixed
 
-- Dot's size for line, aria and bar charts.
+* Dot's size for line, aria and bar charts.
 
 ## [3.37.3] - 2024-04-12
 
 ### Fixed
 
-- background color for Bar chart from `--intergalactic-chart-palette-order-other-data` to `--intergalactic-chart-grid-bar-chart-base-bg`.
+* background color for Bar chart from `--intergalactic-chart-palette-order-other-data` to `--intergalactic-chart-grid-bar-chart-base-bg`.
 
 ## [3.37.2] - 2024-04-12
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/popper` [5.26.2 ~> 5.26.3]).
+* Version patch update due to children dependencies update (`@semcore/popper` [5.26.2 ~> 5.26.3]).
 
 ## [3.37.1] - 2024-04-10
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [2.21.1 ~> 2.21.2], `@semcore/utils` [4.22.1 ~> 4.22.2], `@semcore/core` [2.19.1 ~> 2.19.2]).
+* Version patch update due to children dependencies update (`@semcore/animation` [2.21.1 ~> 2.21.2], `@semcore/utils` [4.22.1 ~> 4.22.2], `@semcore/core` [2.19.1 ~> 2.19.2]).
 
 ## [3.37.0] - 2024-03-27
 
 ### Added
 
-- Api to customize a11y module values and titles formatting, see <https://developer.semrush.com/intergalactic/data-display/d3-chart/d3-chart-code#a11y-formatting> for details.
+* Api to customize a11y module values and titles formatting, see <https://developer.semrush.com/intergalactic/data-display/d3-chart/d3-chart-code#a11y-formatting> for details.
 
 ## [3.36.0] - 2024-03-27
 
 ### Changed
 
-- Version minor update due to children dependencies update (`@semcore/animation` [2.20.1 ~> 2.21.0], `@semcore/utils` [4.21.1 ~> 4.22.0], `@semcore/core` [2.18.1 ~> 2.19.0]).
+* Version minor update due to children dependencies update (`@semcore/animation` [2.20.1 ~> 2.21.0], `@semcore/utils` [4.21.1 ~> 4.22.0], `@semcore/core` [2.18.1 ~> 2.19.0]).
 
 ## [3.35.3] - 2024-03-26
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [2.20.0 ~> 2.20.1], `@semcore/popper` [5.23.0 ~> 5.24.0], `@semcore/utils` [4.21.0 ~> 4.21.1], `@semcore/core` [2.18.0 ~> 2.18.1]).
+* Version patch update due to children dependencies update (`@semcore/animation` [2.20.0 ~> 2.20.1], `@semcore/popper` [5.23.0 ~> 5.24.0], `@semcore/utils` [4.21.0 ~> 4.21.1], `@semcore/core` [2.18.0 ~> 2.18.1]).
 
 ## [3.35.2] - 2024-03-21
 
 ### Fixed
 
-- Errors in children render functions.
+* Errors in children render functions.
 
 ## [3.35.1] - 2024-03-20
 
 ### Changed
 
-- `DotCircle` size in Tooltip from 12px to 8px.
+* `DotCircle` size in Tooltip from 12px to 8px.
 
 ## [3.35.0] - 2024-03-19
 
 ### Changed
 
-- Version minor update due to children dependencies update (`@semcore/popper` [5.22.0 ~> 5.23.0]).
+* Version minor update due to children dependencies update (`@semcore/popper` [5.22.0 ~> 5.23.0]).
 
 ## [3.34.0] - 2024-03-12
 
 ### Changed
 
-- Improved `Chart.Bubble` plot scaling to better fit bubbles and reduce plot empty space.
+* Improved `Chart.Bubble` plot scaling to better fit bubbles and reduce plot empty space.
 
 ## [3.33.0] - 2024-03-12
 
 ### Added
 
-- Feature to render custom components (in foreignObject) as axis tick value.
+* Feature to render custom components (in foreignObject) as axis tick value.
 
 ## [3.32.0] - 2024-03-07
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/popper` [5.20.5 ~> 5.21.0]).
+* Version preminor update due to children dependencies update (`@semcore/popper` [5.20.5 ~> 5.21.0]).
 
 ## [3.31.3] - 2024-03-07
 
 ### Changed
 
-- Improve generation a11y summary for `StackBar`.
+* Improve generation a11y summary for `StackBar`.
 
 ## [3.31.2] - 2024-03-07
 
 ### Added
 
-- Logic to define X and Y axis for a11y summary in Bar charts.
+* Logic to define X and Y axis for a11y summary in Bar charts.
 
 ## [3.31.1] - 2024-03-05
 
 ### Changed
 
-- Use `event.key` instead of `event.code`.
+* Use `event.key` instead of `event.code`.
 
 ## [3.31.0] - 2024-03-01
 
 ### Added
 
-- `Line.Dots` and `Area.Dots` components `display` prop now accepts function that allows developers to granularly control which dots should be displayed.
+* `Line.Dots` and `Area.Dots` components `display` prop now accepts function that allows developers to granularly control which dots should be displayed.
 
 ### Fixed
 
-- a11y module "Skip to content after plot" link was not working in some cases.
+* a11y module "Skip to content after plot" link was not working in some cases.
 
 ## [3.30.2] - 2024-02-28
 
 ### Fixed
 
-- view of Line.Area with `null` in data.
+* view of Line.Area with `null` in data.
 
 ## [3.30.1] - 2024-02-26
 
 ### Fixed
 
-- paddings on X axis in Firefox.
+* paddings on X axis in Firefox.
 
 ## [3.30.0] - 2024-02-16
 
 ### Fixed
 
-- a11y module "Skip to content after plot" link was not working in some cases.
+* a11y module "Skip to content after plot" link was not working in some cases.
 
 ## [3.29.0] - 2024-02-16
 
 ### Changed
 
-- Removed wrongly added deprecation messages about `ReferenceLine` `value` props.
-- Added `valueEnd` prop to `ReferenceLine.Background` component that allows to specify background width by chart value.
+* Removed wrongly added deprecation messages about `ReferenceLine` `value` props.
+* Added `valueEnd` prop to `ReferenceLine.Background` component that allows to specify background width by chart value.
 
 ### Fixed
 
-- `patterns` prop was missing in multiple chart types.
+* `patterns` prop was missing in multiple chart types.
 
 ## [3.28.0] - 2024-02-13
 
 ### Changed
 
-- A11y module links are clickable by `Space` now (along with `Enter` as before).
+* A11y module links are clickable by `Space` now (along with `Enter` as before).
 
 ## [3.27.3] - 2024-02-13
 
 ### Fixed
 
-- `Dots` component was missing `value` prop in it's props mapping function.
+* `Dots` component was missing `value` prop in it's props mapping function.
 
 ## [3.27.2] - 2024-02-09
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/animation` [2.18.1 ~> 2.18.2], `@semcore/popper` [5.19.1 ~> 5.20.0], `@semcore/utils` [4.20.1 ~> 4.20.2], `@semcore/core` [2.17.1 ~> 2.17.2]).
+* Version prepatch update due to children dependencies update (`@semcore/animation` [2.18.1 ~> 2.18.2], `@semcore/popper` [5.19.1 ~> 5.20.0], `@semcore/utils` [4.20.1 ~> 4.20.2], `@semcore/core` [2.17.1 ~> 2.17.2]).
 
 ## [3.27.1] - 2024-02-06
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/animation` [2.18.0 ~> 2.18.1], `@semcore/flex-box` [5.18.0 ~> 5.19.0], `@semcore/utils` [4.20.0 ~> 4.20.1], `@semcore/core` [2.17.0 ~> 2.17.1]).
+* Version prepatch update due to children dependencies update (`@semcore/animation` [2.18.0 ~> 2.18.1], `@semcore/flex-box` [5.18.0 ~> 5.19.0], `@semcore/utils` [4.20.0 ~> 4.20.1], `@semcore/core` [2.17.0 ~> 2.17.1]).
 
 ## [3.27.0] - 2024-02-01
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/animation` [2.17.1 ~> 2.18.0], `@semcore/utils` [4.19.1 ~> 4.20.0], `@semcore/core` [2.16.1 ~> 2.17.0]).
+* Version preminor update due to children dependencies update (`@semcore/animation` [2.17.1 ~> 2.18.0], `@semcore/utils` [4.19.1 ~> 4.20.0], `@semcore/core` [2.16.1 ~> 2.17.0]).
 
 ## [3.26.1] - 2024-02-01
 
 ### Fixed
 
-- view data in BubbleChart.
-- prevent animation on every rerender.
+* view data in BubbleChart.
+* prevent animation on every rerender.
 
 ## [3.26.0] - 2024-01-25
 
 ### Added
 
-- `patterns` api that enhances charts accessibility.
+* `patterns` api that enhances charts accessibility.
 
 ## [3.25.1] - 2024-01-25
 
 ### Fixed
 
-- array index out-of-bounds crash and animation glitch at 0 duration.
+* array index out-of-bounds crash and animation glitch at 0 duration.
 
 ## [3.25.0] - 2024-01-19
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/animation` [2.15.0 ~> 2.16.0], `@semcore/utils` [4.17.0 ~> 4.18.0], `@semcore/core` [2.14.0 ~> 2.15.0]).
+* Version preminor update due to children dependencies update (`@semcore/animation` [2.15.0 ~> 2.16.0], `@semcore/utils` [4.17.0 ~> 4.18.0], `@semcore/core` [2.14.0 ~> 2.15.0]).
 
 ## [3.24.0] - 2024-01-19
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/animation` [2.14.1 ~> 2.15.0], `@semcore/core` [2.13.1 ~> 2.14.0]).
+* Version preminor update due to children dependencies update (`@semcore/animation` [2.14.1 ~> 2.15.0], `@semcore/core` [2.13.1 ~> 2.14.0]).
 
 ## [3.23.1] - 2024-01-16
 
 ### Fixed
 
-- Selection of next focusable element after chart plot.
+* Selection of next focusable element after chart plot.
 
 ## [3.23.0] - 2024-01-12
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/popper` [5.14.2 ~> 5.15.0]).
+* Version preminor update due to children dependencies update (`@semcore/popper` [5.14.2 ~> 5.15.0]).
 
 ## [3.22.3] - 2023-01-11
 
 ### Fixed
 
-- Error in ScatterPlot with undefined values.
+* Error in ScatterPlot with undefined values.
 
 ## [3.22.2] - 2024-01-10
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/animation` [2.14.0 ~> 2.14.1], `@semcore/utils` [4.16.0 ~> 4.16.2], `@semcore/core` [2.13.0 ~> 2.13.1]).
+* Version prepatch update due to children dependencies update (`@semcore/animation` [2.14.0 ~> 2.14.1], `@semcore/utils` [4.16.0 ~> 4.16.2], `@semcore/core` [2.13.0 ~> 2.13.1]).
 
 ## [3.22.1] - 2024-01-04
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/popper` [5.14.0 ~> 5.14.1]).
+* Version prepatch update due to children dependencies update (`@semcore/popper` [5.14.0 ~> 5.14.1]).
 
 ## [3.22.0] - 2023-12-22
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/animation` [2.13.1 ~> 2.14.0], `@semcore/popper` [5.13.0 ~> 5.14.0], `@semcore/utils` [4.15.1 ~> 4.16.0], `@semcore/core` [2.12.1 ~> 2.13.0]).
+* Version preminor update due to children dependencies update (`@semcore/animation` [2.13.1 ~> 2.14.0], `@semcore/popper` [5.13.0 ~> 5.14.0], `@semcore/utils` [4.15.1 ~> 4.16.0], `@semcore/core` [2.12.1 ~> 2.13.0]).
 
 ## [3.21.4-prerelease.10] - 2023-12-20
 
 ### Fixed
 
-- Order of chart lines/bars and tooltip HoverLine.
+* Order of chart lines/bars and tooltip HoverLine.
 
 ## [3.21.3] - 2023-12-14
 
 ### Fixed
 
-- Chart dots were not displaying in Firefox.
-- Charts appearing animation in Firefox.
+* Chart dots were not displaying in Firefox.
+* Charts appearing animation in Firefox.
 
 ## [3.21.3-prerelease.10] - 2023-12-14
 
 ### Fixed
 
-- Chart dots were not displaying in Firefox.
-- Charts appearing animation in Firefox.
+* Chart dots were not displaying in Firefox.
+* Charts appearing animation in Firefox.
 
 ## [3.21.2] - 2023-12-13
 
 ### Fixed
 
-- Squeeze of shapes in `ChartLegendTable`.
+* Squeeze of shapes in `ChartLegendTable`.
 
 ## [3.21.1] - 2023-12-12
 
 ### Fixed
 
-- `ChartLegendTable` labels trimming with `Ellipsis` component.
+* `ChartLegendTable` labels trimming with `Ellipsis` component.
 
 ## [3.21.0] - 2023-12-06
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/animation` [2.12.0 ~> 2.13.0], `@semcore/popper` [5.11.0 ~> 5.12.0], `@semcore/core` [2.11.0 ~> 2.12.0]).
+* Version preminor update due to children dependencies update (`@semcore/animation` [2.12.0 ~> 2.13.0], `@semcore/popper` [5.11.0 ~> 5.12.0], `@semcore/core` [2.11.0 ~> 2.12.0]).
 
 ## [3.20.1] - 2023-12-06
 
 ### Fixed
 
-- base element for `Dots`.
+* base element for `Dots`.
 
 ## [3.20.0] - 2023-12-04
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/animation` [2.11.0 ~> 2.12.0], `@semcore/utils` [4.13.0 ~> 4.14.0], `@semcore/core` [2.10.0 ~> 2.11.0]).
+* Version preminor update due to children dependencies update (`@semcore/animation` [2.11.0 ~> 2.12.0], `@semcore/utils` [4.13.0 ~> 4.14.0], `@semcore/core` [2.10.0 ~> 2.11.0]).
 
 ## [3.19.5] - 2023-11-24
 
 ### Fixed
 
-- Correct types for `Tooltip`s children render function.
+* Correct types for `Tooltip`s children render function.
 
 ## [3.18.4] - 2023-11-21
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/animation` [2.10.1 ~> 2.10.2], `@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/core` [2.9.1 ~> 2.9.2]).
+* Version prepatch update due to children dependencies update (`@semcore/animation` [2.10.1 ~> 2.10.2], `@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/core` [2.9.1 ~> 2.9.2]).
 
 ## [3.18.3] - 2023-11-13
 
 ### Fixed
 
-- Import path in `LegendItem`.
+* Import path in `LegendItem`.
 
 ## [3.18.2] - 2023-11-10
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/popper` [5.9.1 ~> 5.9.2]).
+* Version prepatch update due to children dependencies update (`@semcore/popper` [5.9.1 ~> 5.9.2]).
 
 ## [3.18.1] - 2023-11-08
 
 ### Fixed
 
-- Charts exporting to image.
+* Charts exporting to image.
 
 ## [3.18.0] - 2023-11-06
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/animation` [2.9.0 ~> 2.10.0], `@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/core` [2.8.0 ~> 2.9.0]).
+* Version preminor update due to children dependencies update (`@semcore/animation` [2.9.0 ~> 2.10.0], `@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/core` [2.8.0 ~> 2.9.0]).
 
 ## [3.17.0] - 2023-10-27
 
 ### Added
 
-- `ChartLegend` component.
+* `ChartLegend` component.
 
 ## [3.16.0] - 2023-10-26
 
 ### Added
 
-- Design tokens resolving for `color` props.
+* Design tokens resolving for `color` props.
 
 ### Changed
 
-- Default color of grouped charts (e.g for pie chart) are different by default.
-- Default text color is based on inversed and processed background color.
+* Default color of grouped charts (e.g for pie chart) are different by default.
+* Default text color is based on inversed and processed background color.
 
 ## [3.15.2] - 2023-10-24
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/animation` [2.8.1 ~> 2.8.2], `@semcore/popper` [5.7.7 ~> 5.7.8], `@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/core` [2.7.6 ~> 2.7.7]).
+* Version prepatch update due to children dependencies update (`@semcore/animation` [2.8.1 ~> 2.8.2], `@semcore/popper` [5.7.7 ~> 5.7.8], `@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/core` [2.7.6 ~> 2.7.7]).
 
 ## [3.15.1] - 2023-10-16
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/animation` [2.8.0 ~> 2.8.1], `@semcore/popper` [5.7.6 ~> 5.7.7], `@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/core` [2.7.5 ~> 2.7.6]).
+* Version prepatch update due to children dependencies update (`@semcore/animation` [2.8.0 ~> 2.8.1], `@semcore/popper` [5.7.6 ~> 5.7.7], `@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/core` [2.7.5 ~> 2.7.6]).
 
 ## [3.15.0] - 2023-10-11
 
 ### Added
 
-- `maxBarSize` prop for `Bars` (Bar, GroupBar, StackBar and horizontals).
-- `Line.Area` component.
+* `maxBarSize` prop for `Bars` (Bar, GroupBar, StackBar and horizontals).
+* `Line.Area` component.
 
 ## [3.14.1] - 2023-10-10
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.5 ~> 2.8.0], `@semcore/flex-box` [5.7.5 ~> 5.8.0], `@semcore/popper` [5.7.5 ~> 5.7.6]).
+* Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.5 ~> 2.8.0], `@semcore/flex-box` [5.7.5 ~> 5.8.0], `@semcore/popper` [5.7.5 ~> 5.7.6]).
 
 ## [3.14.0] - 2023-10-09
 
 ### Added
 
-- `nl` locale support.
+* `nl` locale support.
 
 ## [3.13.4] - 2023-10-06
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.4 ~> 2.7.5], `@semcore/utils` [4.8.1 ~> 4.8.2], `@semcore/core` [2.7.4 ~> 2.7.5]).
+* Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.4 ~> 2.7.5], `@semcore/utils` [4.8.1 ~> 4.8.2], `@semcore/core` [2.7.4 ~> 2.7.5]).
 
 ## [3.13.3] - 2023-10-03
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.3 ~> 2.7.4], `@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/core` [2.7.3 ~> 2.7.4]).
+* Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.3 ~> 2.7.4], `@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/core` [2.7.3 ~> 2.7.4]).
 
 ## [3.13.2] - 2023-10-02
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.2 ~> 2.7.3], `@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/core` [2.7.2 ~> 2.7.3]).
+* Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.2 ~> 2.7.3], `@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/core` [2.7.2 ~> 2.7.3]).
 
 ## [3.13.1] - 2023-09-20
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.1 ~> 2.7.2], `@semcore/core` [2.7.1 ~> 2.7.2]).
+* Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.1 ~> 2.7.2], `@semcore/core` [2.7.1 ~> 2.7.2]).
 
 ## [3.13.0] - 2023-09-20
 
 ### Added
 
-- `index` to render function context type of `HoverLine` and `HoverRect`.
-- `size`, `x` and `y` to render function context type of `XAxis.Ticks` and `YAxis.Ticks`.
+* `index` to render function context type of `HoverLine` and `HoverRect`.
+* `size`, `x` and `y` to render function context type of `XAxis.Ticks` and `YAxis.Ticks`.
 
 ## [3.12.0] - 2023-09-13
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/animation` [2.6.3 ~> 2.7.0], `@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
+* Version preminor update due to children dependencies update (`@semcore/animation` [2.6.3 ~> 2.7.0], `@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
 
 ## [3.11.3] - 2023-09-12
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/animation` [2.6.2 ~> 2.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
+* Version prepatch update due to children dependencies update (`@semcore/animation` [2.6.2 ~> 2.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
 
 ## [3.11.2] - 2023-09-08
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/animation` [2.6.1 ~> 2.6.2], `@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
+* Version prepatch update due to children dependencies update (`@semcore/animation` [2.6.1 ~> 2.6.2], `@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
 
 ## [3.11.1] - 2023-09-05
 
 ### Fixed
 
-- Fixed rendering zero segments pies in React<17.
+* Fixed rendering zero segments pies in React<17.
 
 ## [3.11.0] - 2023-09-04
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/animation` [2.5.0 ~> 2.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
+* Version preminor update due to children dependencies update (`@semcore/animation` [2.5.0 ~> 2.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
 
 ## [3.10.0] - 2023-08-28
 
 ### Fixed
 
-- Added `exports.types` field to fix types resolving.
-- Removed deprecation notes from `ticks` props (it was added by mistake).
+* Added `exports.types` field to fix types resolving.
+* Removed deprecation notes from `ticks` props (it was added by mistake).
 
 ### Added
 
-- Added `radius` prop on `Line.Dot` component.
+* Added `radius` prop on `Line.Dot` component.
 
 ## [3.9.0] - 2023-08-28
 
 ### Changed
 
-- Version preminor update due to children dependencies update (`@semcore/animation` [2.4.1 ~> 2.5.0], `@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
+* Version preminor update due to children dependencies update (`@semcore/animation` [2.4.1 ~> 2.5.0], `@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
 
 ## [3.8.2] - 2023-08-24
 
 ### Fixed
 
-- Passing `x` and `y` props to `Donut.Label` component.
+* Passing `x` and `y` props to `Donut.Label` component.
 
 ## [3.8.1] - 2023-08-24
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/animation` [2.4.0 ~> 2.4.1], `@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
+* Version prepatch update due to children dependencies update (`@semcore/animation` [2.4.0 ~> 2.4.1], `@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
 
 ## [3.8.0] - 2023-08-23
 
 ### Changed
 
-- Moved default props value from deprecated `FCComponent.defaultProps` to function default arguments.
+* Moved default props value from deprecated `FCComponent.defaultProps` to function default arguments.
 
 ## [3.7.0] - 2023-08-17
 
 ### Changed
 
-- Donut chart now doesn't render `Donut.Pie` that represent 0 part of circle.
+* Donut chart now doesn't render `Donut.Pie` that represent 0 part of circle.
 
 ## [3.6.0] - 2023-08-17
 
 ### Added
 
-- `paddingAngle` prop for Donut chart.
+* `paddingAngle` prop for Donut chart.
 
 ## [3.5.0] - 2023-08-17
 
 ### Added
 
-- Added special `interpolateValue` symbol that allows to interpolate points on line and area charts.
+* Added special `interpolateValue` symbol that allows to interpolate points on line and area charts.
 
 ## [3.4.1] - 2023-08-16
 
 ### Changed
 
-- Version prepatch update due to children dependencies update (`@semcore/animation` [2.2.0 ~> 2.2.1], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/core` [2.2.0 ~> 2.2.1]).
+* Version prepatch update due to children dependencies update (`@semcore/animation` [2.2.0 ~> 2.2.1], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/core` [2.2.0 ~> 2.2.1]).
 
 ## [3.4.0] - 2023-09-08
 
 ### Changed
 
-- Updated d3 dependencies to resolve peerDependencies mismatch.
+* Updated d3 dependencies to resolve peerDependencies mismatch.
 
 ## [3.3.1] - 2023-08-08
 
 ### Changed
 
-- Added `exports` fields for better nextjs support.
+* Added `exports` fields for better nextjs support.
 
 ## [3.3.0] - 2023-08-07
 
 ### Changed
 
-- Version minor update due to children dependencies update (`@semcore/animation` [2.1.0 ~> 2.2.0], `@semcore/utils` [4.0.0 ~> 4.1.0]).
+* Version minor update due to children dependencies update (`@semcore/animation` [2.1.0 ~> 2.2.0], `@semcore/utils` [4.0.0 ~> 4.1.0]).
 
 ## [3.2.0] - 2023-08-01
 
 ### Changed
 
-- Version minor update due to children dependencies update (`@semcore/animation` [2.0.0 ~> 2.1.0], `@semcore/flex-box` [5.0.0 ~> 5.1.0]).
+* Version minor update due to children dependencies update (`@semcore/animation` [2.0.0 ~> 2.1.0], `@semcore/flex-box` [5.0.0 ~> 5.1.0]).
 
 ## [3.1.1] - 2023-07-31
 
 ### Fixed
 
-- Donut chart hover animation after chart resizing.
+* Donut chart hover animation after chart resizing.
 
 ## [3.1.0] - 2023-07-27
 
 ### Changed
 
-- Use `event.key` instead of `event.code` for better support of non QWERTY keyboard layouts.
+* Use `event.key` instead of `event.code` for better support of non QWERTY keyboard layouts.
 
 ## [3.0.2] - 2023-07-24
 
 ### Fixed
 
-- Broken tooltip styles.
+* Broken tooltip styles.
 
 ## [3.0.1] - 2023-07-18
 
 ### Fix
 
-- Removed ResizeObserver initiating during SSR.
+* Removed ResizeObserver initiating during SSR.
 
 ## [3.0.0] - 2023-07-17
 
 ### Break
 
-- Strict, backward incompatible typings.
+* Strict, backward incompatible typings.
 
 ### Changed
 
-- Deprecated `import { Tooltip } from '@semcore/ui/d3-chart` in favor of better typed Tooltips.
-- On type level made `name` property of `Donut.Pie` obligatory.
-- On type level made `name` property of `Venn.Circle` obligatory.
+* Deprecated `import { Tooltip } from '@semcore/ui/d3-chart` in favor of better typed Tooltips.
+* On type level made `name` property of `Donut.Pie` obligatory.
+* On type level made `name` property of `Venn.Circle` obligatory.
 
 ### Added
 
-- Typed `HoverLine.Tooltip`, `HoverRect.Tooltip`, `Radar.Tooltip`, `Bubble.Tooltip`, `Donut.Tooltip`, `ScatterPlot.Tooltip` and `Venn.Tooltip`.
+* Typed `HoverLine.Tooltip`, `HoverRect.Tooltip`, `Radar.Tooltip`, `Bubble.Tooltip`, `Donut.Tooltip`, `ScatterPlot.Tooltip` and `Venn.Tooltip`.
 
 ## [2.17.5] - 2023-06-30
 
@@ -570,115 +580,115 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Fixed
 
-- Fixed animation on hover when moving mouse quickly on border of `Donut` chart.
+* Fixed animation on hover when moving mouse quickly on border of `Donut` chart.
 
 ## [2.17.3] - 2023-06-27
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.10.19 ~> 1.10.20], `@semcore/utils` [3.53.4 ~> 3.54.0]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.10.19 ~> 1.10.20], `@semcore/utils` [3.53.4 ~> 3.54.0]).
 
 ## [2.17.2] - 2023-06-22
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.10.18 ~> 1.10.19], `@semcore/utils` [3.53.3 ~> 3.53.4]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.10.18 ~> 1.10.19], `@semcore/utils` [3.53.3 ~> 3.53.4]).
 
 ## [2.17.1] - 2023-06-14
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.10.18 ~> 1.10.19], `@semcore/utils` [3.53.3 ~> 3.53.4]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.10.18 ~> 1.10.19], `@semcore/utils` [3.53.3 ~> 3.53.4]).
 
 ## [2.17.0] - 2023-06-12
 
 ### Added
 
-- Swedish (`sv`) locale support.
+* Swedish (`sv`) locale support.
 
 ## [2.16.2] - 2023-06-12
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.10.17 ~> 1.10.18], `@semcore/utils` [3.53.2 ~> 3.53.3]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.10.17 ~> 1.10.18], `@semcore/utils` [3.53.2 ~> 3.53.3]).
 
 ## [2.16.1] - 2023-06-09
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.10.16 ~> 1.10.17], `@semcore/utils` [3.53.1 ~> 3.53.2]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.10.16 ~> 1.10.17], `@semcore/utils` [3.53.1 ~> 3.53.2]).
 
 ## [2.16.0] - 2023-06-09
 
 ### Added
 
-- Polish (`pl`) locale support.
+* Polish (`pl`) locale support.
 
 ## [2.15.5] - 2023-06-07
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.10.15 ~> 1.10.16], `@semcore/popper` [4.17.17 ~> 4.19.0], `@semcore/utils` [3.53.0 ~> 3.53.1]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.10.15 ~> 1.10.16], `@semcore/popper` [4.17.17 ~> 4.19.0], `@semcore/utils` [3.53.0 ~> 3.53.1]).
 
 ## [2.15.4] - 2023-06-02
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.10.14 ~> 1.10.15]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.10.14 ~> 1.10.15]).
 
 ## [2.15.3] - 2023-05-31
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.10.13 ~> 1.10.14], `@semcore/utils` [3.52.0 ~> 3.53.0]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.10.13 ~> 1.10.14], `@semcore/utils` [3.52.0 ~> 3.53.0]).
 
 ## [2.15.2] - 2023-05-29
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.10.12 ~> 1.10.13]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.10.12 ~> 1.10.13]).
 
 ## [2.15.1] - 2023-05-25
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.10.11 ~> 1.10.12], `@semcore/utils` [3.51.1 ~> 3.52.0]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.10.11 ~> 1.10.12], `@semcore/utils` [3.51.1 ~> 3.52.0]).
 
 ## [2.15.0] - 2023-05-24
 
 ### Changed
 
-- Improved support of `zh` and `ja` locales in vertical titles.
+* Improved support of `zh` and `ja` locales in vertical titles.
 
 ## [2.14.10] - 2023-05-22
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.10.9 ~> 1.10.10], `@semcore/utils` [3.50.7 ~> 3.51.0]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.10.9 ~> 1.10.10], `@semcore/utils` [3.50.7 ~> 3.51.0]).
 
 ## [2.14.9] - 2023-05-22
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/popper` [4.17.10 ~> 4.17.11]).
+* Version patch update due to children dependencies update (`@semcore/popper` [4.17.10 ~> 4.17.11]).
 
 ## [2.14.8] - 2023-05-12
 
 ### Fixed
 
-- Fixed radial tree icons displaying.
+* Fixed radial tree icons displaying.
 
 ## [2.14.7] - 2023-05-11
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.10.8 ~> 1.10.9], `@semcore/utils` [3.50.6 ~> 3.50.7]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.10.8 ~> 1.10.9], `@semcore/utils` [3.50.6 ~> 3.50.7]).
 
 ## [2.14.6] - 2023-05-04
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.10.7 ~> 1.10.8], `@semcore/utils` [3.50.5 ~> 3.50.6]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.10.7 ~> 1.10.8], `@semcore/utils` [3.50.5 ~> 3.50.6]).
 
 ## [2.14.3] - 2023-05-02
 
@@ -686,139 +696,139 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Fixed
 
-- Fixed warnings in development mode.
+* Fixed warnings in development mode.
 
 ## [2.14.0] - 2023-04-19
 
 ### Added
 
-- Added automatic conversion of react components to text for accessibility titles.
+* Added automatic conversion of react components to text for accessibility titles.
 
 ## [2.13.13] - 2023-04-18
 
 ### Fixed
 
-- Fixed calculating height of `StackBar` and `HorizontalBar` components.
+* Fixed calculating height of `StackBar` and `HorizontalBar` components.
 
 ## [2.13.12] - 2023-04-18
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.10.1 ~> 1.10.2], `@semcore/utils` [3.50.0 ~> 3.50.3]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.10.1 ~> 1.10.2], `@semcore/utils` [3.50.0 ~> 3.50.3]).
 
 ## [2.13.8] - 2023-03-31
 
 ### Fixed
 
-- Fixed calculating width of `HorizontalBar` component.
+* Fixed calculating width of `HorizontalBar` component.
 
 ## [2.13.7] - 2023-03-31
 
 ### Fixed
 
-- Fixed display `Line.Null`.
+* Fixed display `Line.Null`.
 
 ## [2.13.6] - 2023-03-31
 
 ### Fixed
 
-- Fixed adding custom styles for `Radar` chart.
+* Fixed adding custom styles for `Radar` chart.
 
 ## [2.13.5] - 2023-03-29
 
 ### Fixed
 
-- Fixed calculating height of `Bar` component.
+* Fixed calculating height of `Bar` component.
 
 ## [2.13.4] - 2023-03-28
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.9.9 ~> 1.10.0], `@semcore/utils` [3.49.1 ~> 3.50.0]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.9.9 ~> 1.10.0], `@semcore/utils` [3.49.1 ~> 3.50.0]).
 
 ## [2.13.3] - 2023-03-27
 
 ### Fixed
 
-- Added correct display when there is no data in a11y table.
+* Added correct display when there is no data in a11y table.
 
 ## [2.13.2] - 2023-03-24
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.9.7 ~> 1.9.8], `@semcore/popper` [4.16.9 ~> 4.16.10], `@semcore/utils` [3.48.1 ~> 3.49.0]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.9.7 ~> 1.9.8], `@semcore/popper` [4.16.9 ~> 4.16.10], `@semcore/utils` [3.48.1 ~> 3.49.0]).
 
 ## [2.13.0] - 2023-03-23
 
 ### Added
 
-- Added `additionalFields` in `a11yAltTextConfig` for extra text description to the data when using a screen reader
+* Added `additionalFields` in `a11yAltTextConfig` for extra text description to the data when using a screen reader
 
 ## [2.12.2] - 2023-03-22
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.9.4 ~> 1.9.5], `@semcore/utils` [3.47.3 ~> 3.47.4]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.9.4 ~> 1.9.5], `@semcore/utils` [3.47.3 ~> 3.47.4]).
 
 ## [2.12.1] - 2023-03-21
 
 ### Fixed
 
-- Fixed `Radar` chart with negative rotation hover handling.
+* Fixed `Radar` chart with negative rotation hover handling.
 
 ## [2.12.0] - 2023-03-16
 
 ### Added
 
-- Add `angleOffset` parameter to `Radar` chart.
+* Add `angleOffset` parameter to `Radar` chart.
 
 ## [2.11.1] - 2023-03-16
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.9.3 ~> 1.9.4], `@semcore/utils` [3.47.2 ~> 3.47.3]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.9.3 ~> 1.9.4], `@semcore/utils` [3.47.2 ~> 3.47.3]).
 
 ## [2.11.0] - 2023-03-13
 
 ### Changed
 
-- Much improved a11y summary generation for `Radar` chart.
+* Much improved a11y summary generation for `Radar` chart.
 
 ## [2.10.0] - 2023-03-07
 
 ### Added
 
-- Added footer in `Tooltip`.
+* Added footer in `Tooltip`.
 
 ## [2.9.1] - 2023-03-06
 
 ### Fixed
 
-- Added backward compatibility with react 16.9.
+* Added backward compatibility with react 16.9.
 
 ## [2.9.0] - 2023-03-06
 
 ### Added
 
-- Added a new chart type `Radar`.
+* Added a new chart type `Radar`.
 
 ## [2.8.19] - 2023-03-01
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/popper` [4.16.3 ~> 4.16.4]).
+* Version patch update due to children dependencies update (`@semcore/popper` [4.16.3 ~> 4.16.4]).
 
 ## [2.8.18] - 2023-02-28
 
 ### Fixed
 
-- Fixed summary generation was broken after i18n enhancement release.
+* Fixed summary generation was broken after i18n enhancement release.
 
 ## [2.8.17] - 2023-02-28
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.9.1 ~> 1.9.2]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.9.1 ~> 1.9.2]).
 
 ## [2.8.16] - 2023-02-22
 
@@ -826,67 +836,67 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.9.0 ~> 1.9.1], `@semcore/utils` [3.47.0 ~> 3.47.1]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.9.0 ~> 1.9.1], `@semcore/utils` [3.47.0 ~> 3.47.1]).
 
 ## [2.8.14] - 2023-02-11
 
 ### Fixed
 
-- Added check for the presence of DON at start of animation for `RadialTree`.
+* Added check for the presence of DON at start of animation for `RadialTree`.
 
 ## [2.8.13] - 2023-02-10
 
 ### Fixed
 
-- Fixed display of `Bar` with height 0 - it is should not be rendered.
+* Fixed display of `Bar` with height 0 - it is should not be rendered.
 
 ## [2.8.12] - 2023-02-09
 
 ### Changed
 
-- Renamed rounding design token (`--intergalactic-rounded-medium` -> `--intergalactic-popper-rounded`).
+* Renamed rounding design token (`--intergalactic-rounded-medium` -> `--intergalactic-popper-rounded`).
 
 ## [2.8.11] - 2023-01-27
 
 ### Fixed
 
-- Fixed animation for `Donut`.
+* Fixed animation for `Donut`.
 
 ## [2.8.10] - 2023-01-26
 
 ### Changed
 
-- Changed minimum height in types for `Bar`.
+* Changed minimum height in types for `Bar`.
 
 ## [2.8.9] - 2023-01-25
 
 ### Fixed
 
-- Fixed and changed minimum height of `Bar`.
+* Fixed and changed minimum height of `Bar`.
 
 ## [2.8.8] - 2023-01-23
 
 ### Fixed
 
-- Fixed definition of users locale.
+* Fixed definition of users locale.
 
 ## [2.8.7] - 2023-01-19
 
 ### Fixed
 
-- Fixed animation in React strict mode for `RadialTree` and `Donut`.
+* Fixed animation in React strict mode for `RadialTree` and `Donut`.
 
 ## [2.8.6] - 2023-01-19
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.8.8 ~> 1.8.9], `@semcore/utils` [3.44.3 ~> 3.45.0]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.8.8 ~> 1.8.9], `@semcore/utils` [3.44.3 ~> 3.45.0]).
 
 ## [2.8.3] - 2022-01-10
 
 ### Fixed
 
-- Added prop `transparent` for all charts opacity
+* Added prop `transparent` for all charts opacity
 
 ## [2.8.2] - 2023-01-10
 
@@ -894,525 +904,525 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.8.5 ~> 1.8.6], `@semcore/utils` [3.44.1 ~> 3.44.2]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.8.5 ~> 1.8.6], `@semcore/utils` [3.44.1 ~> 3.44.2]).
 
 ## [2.8.0] - 2022-01-05
 
 ### Added
 
-- Added prop `transparent` for charts opacity
+* Added prop `transparent` for charts opacity
 
 ## [2.7.2] - 2022-12-27
 
 ### Fixed
 
-- Fixed `Donut` chart rendering when hovering over a chart while it is loading.
+* Fixed `Donut` chart rendering when hovering over a chart while it is loading.
 
 ## [2.7.1] - 2022-12-19
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.8.4 ~> 1.8.5], `@semcore/utils` [3.44.0 ~> 3.44.1]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.8.4 ~> 1.8.5], `@semcore/utils` [3.44.0 ~> 3.44.1]).
 
 ## [2.7.0] - 2022-12-14
 
 ### Changed
 
-- Supported semi-async internationalization of text in a11y module.
+* Supported semi-async internationalization of text in a11y module.
 
 ## [2.6.1] - 2022-12-13
 
 ### Changed
 
-- Added `react-dom` to peer dependencies.
+* Added `react-dom` to peer dependencies.
 
 ## [2.6.0] - 2022-12-12
 
 ### Added
 
-- Design tokens based theming.
+* Design tokens based theming.
 
 ## [2.5.2] - 2022-11-11
 
 ### Fixed
 
-- Allowed to pass any svg attributes.
+* Allowed to pass any svg attributes.
 
 ## [2.5.1] - 2022-11-11
 
 ### Fixed
 
-- Fixed `Bar` click handler typings.
+* Fixed `Bar` click handler typings.
 
 ## [2.5.0] - 2022-11-10
 
 ### Fixed
 
-- Fixed support handling of bars event handling with `paddingOuter`.
+* Fixed support handling of bars event handling with `paddingOuter`.
 
 ### Added
 
-- `Bar` component now supports `onClick` handler with bar data in callback.
+* `Bar` component now supports `onClick` handler with bar data in callback.
 
 ## [2.4.10] - 2022-11-03
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/popper` [4.13.3 ~> 4.13.4]).
+* Version patch update due to children dependencies update (`@semcore/popper` [4.13.3 ~> 4.13.4]).
 
 ## [2.4.9] - 2022-11-03
 
 ### Fixed
 
-- Fixed hover and active animated for `Donut` chart.
+* Fixed hover and active animated for `Donut` chart.
 
 ## [2.4.8] - 2022-11-02
 
 ### Fixed
 
-- Fixed display of minimum bar size in `StackBar`.
+* Fixed display of minimum bar size in `StackBar`.
 
 ### Added
 
-- Added display of minimum bar size in `HorizontalBar`.
+* Added display of minimum bar size in `HorizontalBar`.
 
 ## [2.4.7] - 2022-11-01
 
 ### Fixed
 
-- Fixed inner radius for `Donut` chart. It began to equal what is indicated in the `innerRadius` prop.
+* Fixed inner radius for `Donut` chart. It began to equal what is indicated in the `innerRadius` prop.
 
 ## [2.4.6] - 2022-10-31
 
 ### Fixed
 
-- Fixed reference lines were missing dashed style.
+* Fixed reference lines were missing dashed style.
 
 ## [2.4.5] - 2022-10-28
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.7.0 ~> 1.7.1], `@semcore/utils` [3.40.0 ~> 3.40.0]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.7.0 ~> 1.7.1], `@semcore/utils` [3.40.0 ~> 3.40.0]).
 
 ## [2.4.3] - 2022-10-20
 
 ### Fixed
 
-- Fixed typings of render functions.
+* Fixed typings of render functions.
 
 ## [2.4.2] - 2022-10-20
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.6.1 ~> 1.6.2], `@semcore/utils` [3.39.0 ~> 3.39.1]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.6.1 ~> 1.6.2], `@semcore/utils` [3.39.0 ~> 3.39.1]).
 
 ## [2.4.0] - 2022-10-10
 
 ### Changed
 
-- Added support for React 18 🔥
+* Added support for React 18 🔥
 
 ## [2.3.8] - 2022-10-10
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/popper` [4.11.31 ~> 4.12.0]).
+* Version patch update due to children dependencies update (`@semcore/popper` [4.11.31 ~> 4.12.0]).
 
 ## [2.3.7] - 2022-10-05
 
 ### Fixed
 
-- Ensured a11y module do not break mouse interactions.
+* Ensured a11y module do not break mouse interactions.
 
 ## [2.3.6] - 2022-10-04
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.5.10 ~> 1.5.11], `@semcore/utils` [3.37.1 ~> 3.37.2]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.5.10 ~> 1.5.11], `@semcore/utils` [3.37.1 ~> 3.37.2]).
 
 ## [2.3.5] - 2022-09-23
 
 ### Fixed
 
-- Fixed issue with uninitialized styles in some charts.
+* Fixed issue with uninitialized styles in some charts.
 
 ## [2.3.4] - 2022-09-21
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/popper` [4.11.29 ~> 4.11.30]).
+* Version patch update due to children dependencies update (`@semcore/popper` [4.11.29 ~> 4.11.30]).
 
 ## [2.3.3] - 2022-09-13
 
 ### Fixed
 
-- Changed paths in css files to relative.
+* Changed paths in css files to relative.
 
 ## [2.3.2] - 2022-08-30
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.5.9 ~> 1.5.10], `@semcore/utils` [3.37.0 ~> 3.37.1]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.5.9 ~> 1.5.10], `@semcore/utils` [3.37.0 ~> 3.37.1]).
 
 ## [2.3.0] - 2022-08-22
 
 ### Added
 
-- Introduced charts accessibility module.
+* Introduced charts accessibility module.
 
 ## [2.2.7] - 2022-08-18
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.5.7 ~> 1.5.8], `@semcore/utils` [3.36.0 ~> 3.37.0]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.5.7 ~> 1.5.8], `@semcore/utils` [3.36.0 ~> 3.37.0]).
 
 ## [2.2.5] - 2022-08-04
 
 ### Fixed
 
-- Fixed `ResponsiveContainer` memory leak on unmount.
+* Fixed `ResponsiveContainer` memory leak on unmount.
 
 ## [2.2.4] - 2022-08-02
 
 ### Fixed
 
-- `Venn` chart was not mentioned in exported types.
+* `Venn` chart was not mentioned in exported types.
 
 ## [2.2.3] - 2022-07-22
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.5.4 ~> 1.5.5], `@semcore/utils` [3.34.0 ~> 3.35.0]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.5.4 ~> 1.5.5], `@semcore/utils` [3.34.0 ~> 3.35.0]).
 
 ## [2.2.2] - 2022-07-20
 
 ### Fixed
 
-- Fixed ability to change `tag` in render(prop) functions.
-- Fixed `RadialTree` typings.
-- Fixed `RadialTree` rendering in Safari.
-- Fixed `RadialTree` radian labels rendering.
+* Fixed ability to change `tag` in render(prop) functions.
+* Fixed `RadialTree` typings.
+* Fixed `RadialTree` rendering in Safari.
+* Fixed `RadialTree` radian labels rendering.
 
 ## [2.2.1] - 2022-07-07
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.5.3 ~> 1.5.4], `@semcore/utils` [3.33.0 ~> 3.34.0]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.5.3 ~> 1.5.4], `@semcore/utils` [3.33.0 ~> 3.34.0]).
 
 ## [2.2.0] - 2022-06-30
 
 ### Added
 
-- Added index to Bubble chart
-- Added property minimal height `hMin` for Bar (`<Bar hMin={...}/>`)
-- Added property `active` for `Donut.Pie`
+* Added index to Bubble chart
+* Added property minimal height `hMin` for Bar (`<Bar hMin={...}/>`)
+* Added property `active` for `Donut.Pie`
 
 ### Fixed
 
-- Exclude props from html for `Tooltip.Dot`
-- Recalculate position for `Dot` after update scale
-- Optimization render `Dot`
+* Exclude props from html for `Tooltip.Dot`
+* Recalculate position for `Dot` after update scale
+* Optimization render `Dot`
 
 ## [2.1.0] - 2022-06-01
 
 ### Changed
 
-- Changed type names from 'ITooltipProps' to 'ITooltipChartProps' so that there are no intersections with other components.
-- Changed type names from 'ITooltipContext' to 'ITooltipChartContext' so that there are no intersections with other components.
+* Changed type names from 'ITooltipProps' to 'ITooltipChartProps' so that there are no intersections with other components.
+* Changed type names from 'ITooltipContext' to 'ITooltipChartContext' so that there are no intersections with other components.
 
 ## [2.0.10] - 2022-05-31
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.5.1 ~> 1.5.2], `@semcore/utils` [3.32.1 ~> 3.32.2], `@semcore/button` [4.0.4 ~> 4.0.5], `@semcore/checkbox` [6.0.3 ~> 6.0.4]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.5.1 ~> 1.5.2], `@semcore/utils` [3.32.1 ~> 3.32.2], `@semcore/button` [4.0.4 ~> 4.0.5], `@semcore/checkbox` [6.0.3 ~> 6.0.4]).
 
 ## [2.0.7] - 2022-05-25
 
 ### Fixed
 
-- Fixed position title for axis.
+* Fixed position title for axis.
 
 ## [2.0.6] - 2022-05-23
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/icon` [2.25.1 ~> 2.26.0]).
+* Version patch update due to children dependencies update (`@semcore/icon` [2.25.1 ~> 2.26.0]).
 
 ## [2.0.0] - 2022-05-17
 
 ### BREAK
 
-- Updated styles according to the library redesign policy.
+* Updated styles according to the library redesign policy.
 
 ## [1.9.0] - 2022-04-14
 
 ### Added
 
-- Added `<RadialTree />` chart.
+* Added `<RadialTree />` chart.
 
 ## [1.8.0] - 2022-04-11
 
 ### Fixed
 
-- Fixed left and right `<Axis.Title />` unexpected horizontal transition based on title characters count.
+* Fixed left and right `<Axis.Title />` unexpected horizontal transition based on title characters count.
 
 ## [1.7.1] - 2022-04-03
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.5.0 ~> 1.5.0]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.5.0 ~> 1.5.0]).
 
 ## [1.7.0] - 2022-03-28
 
 ### Fixed
 
-- Left and bottom plot titles now do not overlap axis ticks.
+* Left and bottom plot titles now do not overlap axis ticks.
 
 ## [1.6.9] - 2022-03-14
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/utils` [3.31.2 ~> 3.31.2], `@semcore/animation` [1.4.1 ~> 1.4.2]).
+* Version patch update due to children dependencies update (`@semcore/utils` [3.31.2 ~> 3.31.2], `@semcore/animation` [1.4.1 ~> 1.4.2]).
 
 ## [1.6.8] - 2022-03-10
 
 ### Fixed
 
-- Fixed figure cut on right or bottom edges when left or top margin is positive.
+* Fixed figure cut on right or bottom edges when left or top margin is positive.
 
 ## [1.6.7] - 2022-03-05
 
 ### Changed
 
-- Version patch update due to children dependencies update (`@semcore/animation` [1.4.0 ~> 1.4.1]).
+* Version patch update due to children dependencies update (`@semcore/animation` [1.4.0 ~> 1.4.1]).
 
 ## [1.6.5] - 2022-02-24
 
 ### Added
 
-- Added repository field to package.json file.
+* Added repository field to package.json file.
 
 ## [1.6.4] - 2022-02-10
 
 ### Fixed
 
-- Fixed animation display when resizing.
+* Fixed animation display when resizing.
 
 ## [1.6.3] - 2022-01-26
 
 ### Changed
 
-- Revert function `findComponent` for check children in `Tooltip`, because it's valid for children `() => ({})`.
+* Revert function `findComponent` for check children in `Tooltip`, because it's valid for children `() => ({})`.
 
 ## [1.6.2] - 2022-01-25
 
 ### Changed
 
-- Replaced function `findComponent` to `isAdvanceMode` for check children in `Tooltip`.
+* Replaced function `findComponent` to `isAdvanceMode` for check children in `Tooltip`.
 
 ## [1.6.1] - 2021-01-21
 
 ### Added
 
-- Added Bubble and Scatter plot charts
+* Added Bubble and Scatter plot charts
 
 ### Changed
 
-- Tooltip font size changed
+* Tooltip font size changed
 
 ## [1.5.6] - 2021-12-08
 
 ### Changed
 
-- Moved chart colors vars to style
+* Moved chart colors vars to style
 
 ## [1.5.5] - 2021-12-06
 
 ### Fixed
 
-- Calculate correct border radius for Bar.
+* Calculate correct border radius for Bar.
 
 ## [1.5.4] - 2021-11-24
 
 ### Fixed
 
-- Fixed set `scale` for `Area, Line`.
+* Fixed set `scale` for `Area, Line`.
 
 ## [1.5.3] - 2021-10-27
 
 ### Fixed
 
-- Returned data `(x, y, width, height)` in render function for `Bar, Horizontalbar`.
+* Returned data `(x, y, width, height)` in render function for `Bar, Horizontalbar`.
 
 ## [1.5.2] - 2021-10-22
 
 ### Fixed
 
-- Fixed field `e.currentTarget` for events in `eventEmitter`.
+* Fixed field `e.currentTarget` for events in `eventEmitter`.
 
 ## [1.5.1] - 2021-10-19
 
 ### Fixed
 
-- Fixed hide tooltip.
+* Fixed hide tooltip.
 
 ## [1.5.0] - 2021-10-15
 
 ### Added
 
-- Added prop `outerRadius` for `Donut` chart.
+* Added prop `outerRadius` for `Donut` chart.
 
 ### Changed
 
-- Fixed call animation for hover in sector `Donut` chart.
-- Fixed animation show `Dot` in `Line` chart.
+* Fixed call animation for hover in sector `Donut` chart.
+* Fixed animation show `Dot` in `Line` chart.
 
 ## [1.4.1] - 2021-10-13
 
 ### Fixed
 
-- Fixed react key-related warning for `Bar`.
+* Fixed react key-related warning for `Bar`.
 
 ## [1.4.0] - 2021-10-12
 
 ### Added
 
-- Added new event `onMouseMoveChart, onMouseLeaveChart` for eventEmitter.
+* Added new event `onMouseMoveChart, onMouseLeaveChart` for eventEmitter.
 
 ### Fixed
 
-- Fixed show/hide components `Hover, Dots`.
+* Fixed show/hide components `Hover, Dots`.
 
 ## [1.3.1] - 2021-10-06
 
 ### Fixed
 
-- Fixed dependencies in package.json.
+* Fixed dependencies in package.json.
 
 ## [1.3.0] - 2021-09-30
 
 ### Added
 
-- Added radius of curvature for `Bar, HorizontalBar`.
-- Added dynamic position tooltip for `HoverRect, HoverLine`.
-- Added hover for `Donut.Pie`.
+* Added radius of curvature for `Bar, HorizontalBar`.
+* Added dynamic position tooltip for `HoverRect, HoverLine`.
+* Added hover for `Donut.Pie`.
 
 ## [1.2.0] - 2021-09-24
 
 ### Added
 
-- The ability to pass "undefined" to skip some of the data.
+* The ability to pass "undefined" to skip some of the data.
 
 ## [1.1.0] - 2021-09-14
 
 ### Added
 
-- Display 1% of the sector as the minimum value for Donut chart
+* Display 1% of the sector as the minimum value for Donut chart
 
 ## [1.0.0] - 2021-09-08
 
 ### Added
 
-- Added animation for all charts.
+* Added animation for all charts.
 
 ## [1.0.0-15] - 2021-08-26
 
 ### Changed
 
-- Add 'sideEffect=false' for more optimal build via webpack
+* Add 'sideEffect=false' for more optimal build via webpack
 
 ## [1.0.0-14] - 2021-08-02
 
 ### Fixed
 
-- [ts] correct types.
+* [ts] correct types.
 
 ## [1.0.0-13] - 2021-06-18
 
 ### BREAK
 
-- Revert area for stack area chart.
-- Change data for Venn chart.
+* Revert area for stack area chart.
+* Change data for Venn chart.
 
 ### Changed
 
-- Add default ticks for Axis.
+* Add default ticks for Axis.
 
 ## [1.0.0-12] - 2021-06-02
 
 ### Added
 
-- Added Venn chart.
+* Added Venn chart.
 
 ## [1.0.0-11] - 2021-05-12
 
 ### Fixed
 
-- Fix TS type
+* Fix TS type
 
 ## [1.0.0-9] - 2021-04-26
 
 ### Changed
 
-- Version of dependence `@semcore/core` has been changed to `1.11`.
-- Improved performance. Removed one component wrapper.
-- The style processing system has been changed.
-- Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
+* Version of dependence `@semcore/core` has been changed to `1.11`.
+* Improved performance. Removed one component wrapper.
+* The style processing system has been changed.
+* Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
 
 ## [1.0.0-8] - 2021-04-20
 
 ### Fixed
 
-- Fixed version dependency for package `@semcore/popper`.
+* Fixed version dependency for package `@semcore/popper`.
 
 ## [1.0.0-7] - 2021-04-15
 
 ### Fixed
 
-- Fixed Plot naming.
+* Fixed Plot naming.
 
 ## [1.0.0-6] - 2021-04-15
 
 ### Added
 
-- Added Donut and Semi-donut charts.
+* Added Donut and Semi-donut charts.
 
 ## [1.0.0-5] - 2021-03-31
 
 ### Fixed
 
-- [TS] Fixed types for `Line` and `Area`.
+* [TS] Fixed types for `Line` and `Area`.
 
 ## [1.0.0-4] - 2021-03-30
 
 ### Added
 
-- Added Area and Stacked Area charts.
+* Added Area and Stacked Area charts.
 
 ## [1.0.0-3] - 2021-03-29
 
 ### Added
 
-- [TS] Added types for `Bar.Background, HorizontalBar.Background`.
+* [TS] Added types for `Bar.Background, HorizontalBar.Background`.
 
 ## [1.0.0-2] - 2021-03-18
 
 ### Fixed
 
-- Fixed calculate coordinates for `Hover` and `Tooltip` components.
+* Fixed calculate coordinates for `Hover` and `Tooltip` components.
 
 ## [1.0.0-1] - 2021-03-10
 
 ### Added
 
-- Added support property `tag` for all components.
+* Added support property `tag` for all components.
 
 ### Fixed
 
-- Fixed hover for `svg` element inside `XYPlot`.
+* Fixed hover for `svg` element inside `XYPlot`.
 
 ## [1.0.0-prerelease.10] - 2021-02-11
 
 ### Added
 
-- Initial release.
+* Initial release.

--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -6,573 +6,573 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Plot `eventEmitter` prop now is strongly typed.
+- Plot `eventEmitter` prop now is strongly typed.
 
 ### Added
 
-* `PlotEventEmitter` class that allows to create typed event emitter for imperative control over chart tooltip.
+- `PlotEventEmitter` class that allows to create typed event emitter for imperative control over chart tooltip.
 
 ## [3.38.1] - 2024-04-16
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [2.22.0 ~> 2.22.1], `@semcore/popper` [5.27.0 ~> 5.27.1], `@semcore/utils` [4.23.0 ~> 4.23.1], `@semcore/core` [2.20.0 ~> 2.20.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [2.22.0 ~> 2.22.1], `@semcore/popper` [5.27.0 ~> 5.27.1], `@semcore/utils` [4.23.0 ~> 4.23.1], `@semcore/core` [2.20.0 ~> 2.20.1]).
 
 ## [3.38.0] - 2024-04-12
 
 ### Added
 
-* `Cigarette` chart.
+- `Cigarette` chart.
 
 ## [3.37.4] - 2024-04-12
 
 ### Fixed
 
-* Dot's size for line, aria and bar charts.
+- Dot's size for line, aria and bar charts.
 
 ## [3.37.3] - 2024-04-12
 
 ### Fixed
 
-* background color for Bar chart from `--intergalactic-chart-palette-order-other-data` to `--intergalactic-chart-grid-bar-chart-base-bg`.
+- background color for Bar chart from `--intergalactic-chart-palette-order-other-data` to `--intergalactic-chart-grid-bar-chart-base-bg`.
 
 ## [3.37.2] - 2024-04-12
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/popper` [5.26.2 ~> 5.26.3]).
+- Version patch update due to children dependencies update (`@semcore/popper` [5.26.2 ~> 5.26.3]).
 
 ## [3.37.1] - 2024-04-10
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [2.21.1 ~> 2.21.2], `@semcore/utils` [4.22.1 ~> 4.22.2], `@semcore/core` [2.19.1 ~> 2.19.2]).
+- Version patch update due to children dependencies update (`@semcore/animation` [2.21.1 ~> 2.21.2], `@semcore/utils` [4.22.1 ~> 4.22.2], `@semcore/core` [2.19.1 ~> 2.19.2]).
 
 ## [3.37.0] - 2024-03-27
 
 ### Added
 
-* Api to customize a11y module values and titles formatting, see <https://developer.semrush.com/intergalactic/data-display/d3-chart/d3-chart-code#a11y-formatting> for details.
+- Api to customize a11y module values and titles formatting, see <https://developer.semrush.com/intergalactic/data-display/d3-chart/d3-chart-code#a11y-formatting> for details.
 
 ## [3.36.0] - 2024-03-27
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/animation` [2.20.1 ~> 2.21.0], `@semcore/utils` [4.21.1 ~> 4.22.0], `@semcore/core` [2.18.1 ~> 2.19.0]).
+- Version minor update due to children dependencies update (`@semcore/animation` [2.20.1 ~> 2.21.0], `@semcore/utils` [4.21.1 ~> 4.22.0], `@semcore/core` [2.18.1 ~> 2.19.0]).
 
 ## [3.35.3] - 2024-03-26
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [2.20.0 ~> 2.20.1], `@semcore/popper` [5.23.0 ~> 5.24.0], `@semcore/utils` [4.21.0 ~> 4.21.1], `@semcore/core` [2.18.0 ~> 2.18.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [2.20.0 ~> 2.20.1], `@semcore/popper` [5.23.0 ~> 5.24.0], `@semcore/utils` [4.21.0 ~> 4.21.1], `@semcore/core` [2.18.0 ~> 2.18.1]).
 
 ## [3.35.2] - 2024-03-21
 
 ### Fixed
 
-* Errors in children render functions.
+- Errors in children render functions.
 
 ## [3.35.1] - 2024-03-20
 
 ### Changed
 
-* `DotCircle` size in Tooltip from 12px to 8px.
+- `DotCircle` size in Tooltip from 12px to 8px.
 
 ## [3.35.0] - 2024-03-19
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/popper` [5.22.0 ~> 5.23.0]).
+- Version minor update due to children dependencies update (`@semcore/popper` [5.22.0 ~> 5.23.0]).
 
 ## [3.34.0] - 2024-03-12
 
 ### Changed
 
-* Improved `Chart.Bubble` plot scaling to better fit bubbles and reduce plot empty space.
+- Improved `Chart.Bubble` plot scaling to better fit bubbles and reduce plot empty space.
 
 ## [3.33.0] - 2024-03-12
 
 ### Added
 
-* Feature to render custom components (in foreignObject) as axis tick value.
+- Feature to render custom components (in foreignObject) as axis tick value.
 
 ## [3.32.0] - 2024-03-07
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/popper` [5.20.5 ~> 5.21.0]).
+- Version preminor update due to children dependencies update (`@semcore/popper` [5.20.5 ~> 5.21.0]).
 
 ## [3.31.3] - 2024-03-07
 
 ### Changed
 
-* Improve generation a11y summary for `StackBar`.
+- Improve generation a11y summary for `StackBar`.
 
 ## [3.31.2] - 2024-03-07
 
 ### Added
 
-* Logic to define X and Y axis for a11y summary in Bar charts.
+- Logic to define X and Y axis for a11y summary in Bar charts.
 
 ## [3.31.1] - 2024-03-05
 
 ### Changed
 
-* Use `event.key` instead of `event.code`.
+- Use `event.key` instead of `event.code`.
 
 ## [3.31.0] - 2024-03-01
 
 ### Added
 
-* `Line.Dots` and `Area.Dots` components `display` prop now accepts function that allows developers to granularly control which dots should be displayed.
+- `Line.Dots` and `Area.Dots` components `display` prop now accepts function that allows developers to granularly control which dots should be displayed.
 
 ### Fixed
 
-* a11y module "Skip to content after plot" link was not working in some cases.
+- a11y module "Skip to content after plot" link was not working in some cases.
 
 ## [3.30.2] - 2024-02-28
 
 ### Fixed
 
-* view of Line.Area with `null` in data.
+- view of Line.Area with `null` in data.
 
 ## [3.30.1] - 2024-02-26
 
 ### Fixed
 
-* paddings on X axis in Firefox.
+- paddings on X axis in Firefox.
 
 ## [3.30.0] - 2024-02-16
 
 ### Fixed
 
-* a11y module "Skip to content after plot" link was not working in some cases.
+- a11y module "Skip to content after plot" link was not working in some cases.
 
 ## [3.29.0] - 2024-02-16
 
 ### Changed
 
-* Removed wrongly added deprecation messages about `ReferenceLine` `value` props.
-* Added `valueEnd` prop to `ReferenceLine.Background` component that allows to specify background width by chart value.
+- Removed wrongly added deprecation messages about `ReferenceLine` `value` props.
+- Added `valueEnd` prop to `ReferenceLine.Background` component that allows to specify background width by chart value.
 
 ### Fixed
 
-* `patterns` prop was missing in multiple chart types.
+- `patterns` prop was missing in multiple chart types.
 
 ## [3.28.0] - 2024-02-13
 
 ### Changed
 
-* A11y module links are clickable by `Space` now (along with `Enter` as before).
+- A11y module links are clickable by `Space` now (along with `Enter` as before).
 
 ## [3.27.3] - 2024-02-13
 
 ### Fixed
 
-* `Dots` component was missing `value` prop in it's props mapping function.
+- `Dots` component was missing `value` prop in it's props mapping function.
 
 ## [3.27.2] - 2024-02-09
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.18.1 ~> 2.18.2], `@semcore/popper` [5.19.1 ~> 5.20.0], `@semcore/utils` [4.20.1 ~> 4.20.2], `@semcore/core` [2.17.1 ~> 2.17.2]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.18.1 ~> 2.18.2], `@semcore/popper` [5.19.1 ~> 5.20.0], `@semcore/utils` [4.20.1 ~> 4.20.2], `@semcore/core` [2.17.1 ~> 2.17.2]).
 
 ## [3.27.1] - 2024-02-06
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.18.0 ~> 2.18.1], `@semcore/flex-box` [5.18.0 ~> 5.19.0], `@semcore/utils` [4.20.0 ~> 4.20.1], `@semcore/core` [2.17.0 ~> 2.17.1]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.18.0 ~> 2.18.1], `@semcore/flex-box` [5.18.0 ~> 5.19.0], `@semcore/utils` [4.20.0 ~> 4.20.1], `@semcore/core` [2.17.0 ~> 2.17.1]).
 
 ## [3.27.0] - 2024-02-01
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.17.1 ~> 2.18.0], `@semcore/utils` [4.19.1 ~> 4.20.0], `@semcore/core` [2.16.1 ~> 2.17.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.17.1 ~> 2.18.0], `@semcore/utils` [4.19.1 ~> 4.20.0], `@semcore/core` [2.16.1 ~> 2.17.0]).
 
 ## [3.26.1] - 2024-02-01
 
 ### Fixed
 
-* view data in BubbleChart.
-* prevent animation on every rerender.
+- view data in BubbleChart.
+- prevent animation on every rerender.
 
 ## [3.26.0] - 2024-01-25
 
 ### Added
 
-* `patterns` api that enhances charts accessibility.
+- `patterns` api that enhances charts accessibility.
 
 ## [3.25.1] - 2024-01-25
 
 ### Fixed
 
-* array index out-of-bounds crash and animation glitch at 0 duration.
+- array index out-of-bounds crash and animation glitch at 0 duration.
 
 ## [3.25.0] - 2024-01-19
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.15.0 ~> 2.16.0], `@semcore/utils` [4.17.0 ~> 4.18.0], `@semcore/core` [2.14.0 ~> 2.15.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.15.0 ~> 2.16.0], `@semcore/utils` [4.17.0 ~> 4.18.0], `@semcore/core` [2.14.0 ~> 2.15.0]).
 
 ## [3.24.0] - 2024-01-19
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.14.1 ~> 2.15.0], `@semcore/core` [2.13.1 ~> 2.14.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.14.1 ~> 2.15.0], `@semcore/core` [2.13.1 ~> 2.14.0]).
 
 ## [3.23.1] - 2024-01-16
 
 ### Fixed
 
-* Selection of next focusable element after chart plot.
+- Selection of next focusable element after chart plot.
 
 ## [3.23.0] - 2024-01-12
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/popper` [5.14.2 ~> 5.15.0]).
+- Version preminor update due to children dependencies update (`@semcore/popper` [5.14.2 ~> 5.15.0]).
 
 ## [3.22.3] - 2023-01-11
 
 ### Fixed
 
-* Error in ScatterPlot with undefined values.
+- Error in ScatterPlot with undefined values.
 
 ## [3.22.2] - 2024-01-10
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.14.0 ~> 2.14.1], `@semcore/utils` [4.16.0 ~> 4.16.2], `@semcore/core` [2.13.0 ~> 2.13.1]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.14.0 ~> 2.14.1], `@semcore/utils` [4.16.0 ~> 4.16.2], `@semcore/core` [2.13.0 ~> 2.13.1]).
 
 ## [3.22.1] - 2024-01-04
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/popper` [5.14.0 ~> 5.14.1]).
+- Version prepatch update due to children dependencies update (`@semcore/popper` [5.14.0 ~> 5.14.1]).
 
 ## [3.22.0] - 2023-12-22
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.13.1 ~> 2.14.0], `@semcore/popper` [5.13.0 ~> 5.14.0], `@semcore/utils` [4.15.1 ~> 4.16.0], `@semcore/core` [2.12.1 ~> 2.13.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.13.1 ~> 2.14.0], `@semcore/popper` [5.13.0 ~> 5.14.0], `@semcore/utils` [4.15.1 ~> 4.16.0], `@semcore/core` [2.12.1 ~> 2.13.0]).
 
 ## [3.21.4-prerelease.10] - 2023-12-20
 
 ### Fixed
 
-* Order of chart lines/bars and tooltip HoverLine.
+- Order of chart lines/bars and tooltip HoverLine.
 
 ## [3.21.3] - 2023-12-14
 
 ### Fixed
 
-* Chart dots were not displaying in Firefox.
-* Charts appearing animation in Firefox.
+- Chart dots were not displaying in Firefox.
+- Charts appearing animation in Firefox.
 
 ## [3.21.3-prerelease.10] - 2023-12-14
 
 ### Fixed
 
-* Chart dots were not displaying in Firefox.
-* Charts appearing animation in Firefox.
+- Chart dots were not displaying in Firefox.
+- Charts appearing animation in Firefox.
 
 ## [3.21.2] - 2023-12-13
 
 ### Fixed
 
-* Squeeze of shapes in `ChartLegendTable`.
+- Squeeze of shapes in `ChartLegendTable`.
 
 ## [3.21.1] - 2023-12-12
 
 ### Fixed
 
-* `ChartLegendTable` labels trimming with `Ellipsis` component.
+- `ChartLegendTable` labels trimming with `Ellipsis` component.
 
 ## [3.21.0] - 2023-12-06
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.12.0 ~> 2.13.0], `@semcore/popper` [5.11.0 ~> 5.12.0], `@semcore/core` [2.11.0 ~> 2.12.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.12.0 ~> 2.13.0], `@semcore/popper` [5.11.0 ~> 5.12.0], `@semcore/core` [2.11.0 ~> 2.12.0]).
 
 ## [3.20.1] - 2023-12-06
 
 ### Fixed
 
-* base element for `Dots`.
+- base element for `Dots`.
 
 ## [3.20.0] - 2023-12-04
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.11.0 ~> 2.12.0], `@semcore/utils` [4.13.0 ~> 4.14.0], `@semcore/core` [2.10.0 ~> 2.11.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.11.0 ~> 2.12.0], `@semcore/utils` [4.13.0 ~> 4.14.0], `@semcore/core` [2.10.0 ~> 2.11.0]).
 
 ## [3.19.5] - 2023-11-24
 
 ### Fixed
 
-* Correct types for `Tooltip`s children render function.
+- Correct types for `Tooltip`s children render function.
 
 ## [3.18.4] - 2023-11-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.10.1 ~> 2.10.2], `@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/core` [2.9.1 ~> 2.9.2]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.10.1 ~> 2.10.2], `@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/core` [2.9.1 ~> 2.9.2]).
 
 ## [3.18.3] - 2023-11-13
 
 ### Fixed
 
-* Import path in `LegendItem`.
+- Import path in `LegendItem`.
 
 ## [3.18.2] - 2023-11-10
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/popper` [5.9.1 ~> 5.9.2]).
+- Version prepatch update due to children dependencies update (`@semcore/popper` [5.9.1 ~> 5.9.2]).
 
 ## [3.18.1] - 2023-11-08
 
 ### Fixed
 
-* Charts exporting to image.
+- Charts exporting to image.
 
 ## [3.18.0] - 2023-11-06
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.9.0 ~> 2.10.0], `@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/core` [2.8.0 ~> 2.9.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.9.0 ~> 2.10.0], `@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/core` [2.8.0 ~> 2.9.0]).
 
 ## [3.17.0] - 2023-10-27
 
 ### Added
 
-* `ChartLegend` component.
+- `ChartLegend` component.
 
 ## [3.16.0] - 2023-10-26
 
 ### Added
 
-* Design tokens resolving for `color` props.
+- Design tokens resolving for `color` props.
 
 ### Changed
 
-* Default color of grouped charts (e.g for pie chart) are different by default.
-* Default text color is based on inversed and processed background color.
+- Default color of grouped charts (e.g for pie chart) are different by default.
+- Default text color is based on inversed and processed background color.
 
 ## [3.15.2] - 2023-10-24
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.8.1 ~> 2.8.2], `@semcore/popper` [5.7.7 ~> 5.7.8], `@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/core` [2.7.6 ~> 2.7.7]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.8.1 ~> 2.8.2], `@semcore/popper` [5.7.7 ~> 5.7.8], `@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/core` [2.7.6 ~> 2.7.7]).
 
 ## [3.15.1] - 2023-10-16
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.8.0 ~> 2.8.1], `@semcore/popper` [5.7.6 ~> 5.7.7], `@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/core` [2.7.5 ~> 2.7.6]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.8.0 ~> 2.8.1], `@semcore/popper` [5.7.6 ~> 5.7.7], `@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/core` [2.7.5 ~> 2.7.6]).
 
 ## [3.15.0] - 2023-10-11
 
 ### Added
 
-* `maxBarSize` prop for `Bars` (Bar, GroupBar, StackBar and horizontals).
-* `Line.Area` component.
+- `maxBarSize` prop for `Bars` (Bar, GroupBar, StackBar and horizontals).
+- `Line.Area` component.
 
 ## [3.14.1] - 2023-10-10
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.5 ~> 2.8.0], `@semcore/flex-box` [5.7.5 ~> 5.8.0], `@semcore/popper` [5.7.5 ~> 5.7.6]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.5 ~> 2.8.0], `@semcore/flex-box` [5.7.5 ~> 5.8.0], `@semcore/popper` [5.7.5 ~> 5.7.6]).
 
 ## [3.14.0] - 2023-10-09
 
 ### Added
 
-* `nl` locale support.
+- `nl` locale support.
 
 ## [3.13.4] - 2023-10-06
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.4 ~> 2.7.5], `@semcore/utils` [4.8.1 ~> 4.8.2], `@semcore/core` [2.7.4 ~> 2.7.5]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.4 ~> 2.7.5], `@semcore/utils` [4.8.1 ~> 4.8.2], `@semcore/core` [2.7.4 ~> 2.7.5]).
 
 ## [3.13.3] - 2023-10-03
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.3 ~> 2.7.4], `@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/core` [2.7.3 ~> 2.7.4]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.3 ~> 2.7.4], `@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/core` [2.7.3 ~> 2.7.4]).
 
 ## [3.13.2] - 2023-10-02
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.2 ~> 2.7.3], `@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/core` [2.7.2 ~> 2.7.3]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.2 ~> 2.7.3], `@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/core` [2.7.2 ~> 2.7.3]).
 
 ## [3.13.1] - 2023-09-20
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.1 ~> 2.7.2], `@semcore/core` [2.7.1 ~> 2.7.2]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.1 ~> 2.7.2], `@semcore/core` [2.7.1 ~> 2.7.2]).
 
 ## [3.13.0] - 2023-09-20
 
 ### Added
 
-* `index` to render function context type of `HoverLine` and `HoverRect`.
-* `size`, `x` and `y` to render function context type of `XAxis.Ticks` and `YAxis.Ticks`.
+- `index` to render function context type of `HoverLine` and `HoverRect`.
+- `size`, `x` and `y` to render function context type of `XAxis.Ticks` and `YAxis.Ticks`.
 
 ## [3.12.0] - 2023-09-13
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.6.3 ~> 2.7.0], `@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.6.3 ~> 2.7.0], `@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
 
 ## [3.11.3] - 2023-09-12
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.6.2 ~> 2.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.6.2 ~> 2.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
 
 ## [3.11.2] - 2023-09-08
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.6.1 ~> 2.6.2], `@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.6.1 ~> 2.6.2], `@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
 
 ## [3.11.1] - 2023-09-05
 
 ### Fixed
 
-* Fixed rendering zero segments pies in React<17.
+- Fixed rendering zero segments pies in React<17.
 
 ## [3.11.0] - 2023-09-04
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.5.0 ~> 2.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.5.0 ~> 2.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
 
 ## [3.10.0] - 2023-08-28
 
 ### Fixed
 
-* Added `exports.types` field to fix types resolving.
-* Removed deprecation notes from `ticks` props (it was added by mistake).
+- Added `exports.types` field to fix types resolving.
+- Removed deprecation notes from `ticks` props (it was added by mistake).
 
 ### Added
 
-* Added `radius` prop on `Line.Dot` component.
+- Added `radius` prop on `Line.Dot` component.
 
 ## [3.9.0] - 2023-08-28
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.4.1 ~> 2.5.0], `@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.4.1 ~> 2.5.0], `@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
 
 ## [3.8.2] - 2023-08-24
 
 ### Fixed
 
-* Passing `x` and `y` props to `Donut.Label` component.
+- Passing `x` and `y` props to `Donut.Label` component.
 
 ## [3.8.1] - 2023-08-24
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.4.0 ~> 2.4.1], `@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.4.0 ~> 2.4.1], `@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
 
 ## [3.8.0] - 2023-08-23
 
 ### Changed
 
-* Moved default props value from deprecated `FCComponent.defaultProps` to function default arguments.
+- Moved default props value from deprecated `FCComponent.defaultProps` to function default arguments.
 
 ## [3.7.0] - 2023-08-17
 
 ### Changed
 
-* Donut chart now doesn't render `Donut.Pie` that represent 0 part of circle.
+- Donut chart now doesn't render `Donut.Pie` that represent 0 part of circle.
 
 ## [3.6.0] - 2023-08-17
 
 ### Added
 
-* `paddingAngle` prop for Donut chart.
+- `paddingAngle` prop for Donut chart.
 
 ## [3.5.0] - 2023-08-17
 
 ### Added
 
-* Added special `interpolateValue` symbol that allows to interpolate points on line and area charts.
+- Added special `interpolateValue` symbol that allows to interpolate points on line and area charts.
 
 ## [3.4.1] - 2023-08-16
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.2.0 ~> 2.2.1], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/core` [2.2.0 ~> 2.2.1]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.2.0 ~> 2.2.1], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/core` [2.2.0 ~> 2.2.1]).
 
 ## [3.4.0] - 2023-09-08
 
 ### Changed
 
-* Updated d3 dependencies to resolve peerDependencies mismatch.
+- Updated d3 dependencies to resolve peerDependencies mismatch.
 
 ## [3.3.1] - 2023-08-08
 
 ### Changed
 
-* Added `exports` fields for better nextjs support.
+- Added `exports` fields for better nextjs support.
 
 ## [3.3.0] - 2023-08-07
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/animation` [2.1.0 ~> 2.2.0], `@semcore/utils` [4.0.0 ~> 4.1.0]).
+- Version minor update due to children dependencies update (`@semcore/animation` [2.1.0 ~> 2.2.0], `@semcore/utils` [4.0.0 ~> 4.1.0]).
 
 ## [3.2.0] - 2023-08-01
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/animation` [2.0.0 ~> 2.1.0], `@semcore/flex-box` [5.0.0 ~> 5.1.0]).
+- Version minor update due to children dependencies update (`@semcore/animation` [2.0.0 ~> 2.1.0], `@semcore/flex-box` [5.0.0 ~> 5.1.0]).
 
 ## [3.1.1] - 2023-07-31
 
 ### Fixed
 
-* Donut chart hover animation after chart resizing.
+- Donut chart hover animation after chart resizing.
 
 ## [3.1.0] - 2023-07-27
 
 ### Changed
 
-* Use `event.key` instead of `event.code` for better support of non QWERTY keyboard layouts.
+- Use `event.key` instead of `event.code` for better support of non QWERTY keyboard layouts.
 
 ## [3.0.2] - 2023-07-24
 
 ### Fixed
 
-* Broken tooltip styles.
+- Broken tooltip styles.
 
 ## [3.0.1] - 2023-07-18
 
 ### Fix
 
-* Removed ResizeObserver initiating during SSR.
+- Removed ResizeObserver initiating during SSR.
 
 ## [3.0.0] - 2023-07-17
 
 ### Break
 
-* Strict, backward incompatible typings.
+- Strict, backward incompatible typings.
 
 ### Changed
 
-* Deprecated `import { Tooltip } from '@semcore/ui/d3-chart` in favor of better typed Tooltips.
-* On type level made `name` property of `Donut.Pie` obligatory.
-* On type level made `name` property of `Venn.Circle` obligatory.
+- Deprecated `import { Tooltip } from '@semcore/ui/d3-chart` in favor of better typed Tooltips.
+- On type level made `name` property of `Donut.Pie` obligatory.
+- On type level made `name` property of `Venn.Circle` obligatory.
 
 ### Added
 
-* Typed `HoverLine.Tooltip`, `HoverRect.Tooltip`, `Radar.Tooltip`, `Bubble.Tooltip`, `Donut.Tooltip`, `ScatterPlot.Tooltip` and `Venn.Tooltip`.
+- Typed `HoverLine.Tooltip`, `HoverRect.Tooltip`, `Radar.Tooltip`, `Bubble.Tooltip`, `Donut.Tooltip`, `ScatterPlot.Tooltip` and `Venn.Tooltip`.
 
 ## [2.17.5] - 2023-06-30
 
@@ -580,115 +580,115 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Fixed
 
-* Fixed animation on hover when moving mouse quickly on border of `Donut` chart.
+- Fixed animation on hover when moving mouse quickly on border of `Donut` chart.
 
 ## [2.17.3] - 2023-06-27
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.19 ~> 1.10.20], `@semcore/utils` [3.53.4 ~> 3.54.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.19 ~> 1.10.20], `@semcore/utils` [3.53.4 ~> 3.54.0]).
 
 ## [2.17.2] - 2023-06-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.18 ~> 1.10.19], `@semcore/utils` [3.53.3 ~> 3.53.4]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.18 ~> 1.10.19], `@semcore/utils` [3.53.3 ~> 3.53.4]).
 
 ## [2.17.1] - 2023-06-14
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.18 ~> 1.10.19], `@semcore/utils` [3.53.3 ~> 3.53.4]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.18 ~> 1.10.19], `@semcore/utils` [3.53.3 ~> 3.53.4]).
 
 ## [2.17.0] - 2023-06-12
 
 ### Added
 
-* Swedish (`sv`) locale support.
+- Swedish (`sv`) locale support.
 
 ## [2.16.2] - 2023-06-12
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.17 ~> 1.10.18], `@semcore/utils` [3.53.2 ~> 3.53.3]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.17 ~> 1.10.18], `@semcore/utils` [3.53.2 ~> 3.53.3]).
 
 ## [2.16.1] - 2023-06-09
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.16 ~> 1.10.17], `@semcore/utils` [3.53.1 ~> 3.53.2]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.16 ~> 1.10.17], `@semcore/utils` [3.53.1 ~> 3.53.2]).
 
 ## [2.16.0] - 2023-06-09
 
 ### Added
 
-* Polish (`pl`) locale support.
+- Polish (`pl`) locale support.
 
 ## [2.15.5] - 2023-06-07
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.15 ~> 1.10.16], `@semcore/popper` [4.17.17 ~> 4.19.0], `@semcore/utils` [3.53.0 ~> 3.53.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.15 ~> 1.10.16], `@semcore/popper` [4.17.17 ~> 4.19.0], `@semcore/utils` [3.53.0 ~> 3.53.1]).
 
 ## [2.15.4] - 2023-06-02
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.14 ~> 1.10.15]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.14 ~> 1.10.15]).
 
 ## [2.15.3] - 2023-05-31
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.13 ~> 1.10.14], `@semcore/utils` [3.52.0 ~> 3.53.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.13 ~> 1.10.14], `@semcore/utils` [3.52.0 ~> 3.53.0]).
 
 ## [2.15.2] - 2023-05-29
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.12 ~> 1.10.13]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.12 ~> 1.10.13]).
 
 ## [2.15.1] - 2023-05-25
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.11 ~> 1.10.12], `@semcore/utils` [3.51.1 ~> 3.52.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.11 ~> 1.10.12], `@semcore/utils` [3.51.1 ~> 3.52.0]).
 
 ## [2.15.0] - 2023-05-24
 
 ### Changed
 
-* Improved support of `zh` and `ja` locales in vertical titles.
+- Improved support of `zh` and `ja` locales in vertical titles.
 
 ## [2.14.10] - 2023-05-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.9 ~> 1.10.10], `@semcore/utils` [3.50.7 ~> 3.51.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.9 ~> 1.10.10], `@semcore/utils` [3.50.7 ~> 3.51.0]).
 
 ## [2.14.9] - 2023-05-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/popper` [4.17.10 ~> 4.17.11]).
+- Version patch update due to children dependencies update (`@semcore/popper` [4.17.10 ~> 4.17.11]).
 
 ## [2.14.8] - 2023-05-12
 
 ### Fixed
 
-* Fixed radial tree icons displaying.
+- Fixed radial tree icons displaying.
 
 ## [2.14.7] - 2023-05-11
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.8 ~> 1.10.9], `@semcore/utils` [3.50.6 ~> 3.50.7]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.8 ~> 1.10.9], `@semcore/utils` [3.50.6 ~> 3.50.7]).
 
 ## [2.14.6] - 2023-05-04
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.7 ~> 1.10.8], `@semcore/utils` [3.50.5 ~> 3.50.6]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.7 ~> 1.10.8], `@semcore/utils` [3.50.5 ~> 3.50.6]).
 
 ## [2.14.3] - 2023-05-02
 
@@ -696,139 +696,139 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Fixed
 
-* Fixed warnings in development mode.
+- Fixed warnings in development mode.
 
 ## [2.14.0] - 2023-04-19
 
 ### Added
 
-* Added automatic conversion of react components to text for accessibility titles.
+- Added automatic conversion of react components to text for accessibility titles.
 
 ## [2.13.13] - 2023-04-18
 
 ### Fixed
 
-* Fixed calculating height of `StackBar` and `HorizontalBar` components.
+- Fixed calculating height of `StackBar` and `HorizontalBar` components.
 
 ## [2.13.12] - 2023-04-18
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.1 ~> 1.10.2], `@semcore/utils` [3.50.0 ~> 3.50.3]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.1 ~> 1.10.2], `@semcore/utils` [3.50.0 ~> 3.50.3]).
 
 ## [2.13.8] - 2023-03-31
 
 ### Fixed
 
-* Fixed calculating width of `HorizontalBar` component.
+- Fixed calculating width of `HorizontalBar` component.
 
 ## [2.13.7] - 2023-03-31
 
 ### Fixed
 
-* Fixed display `Line.Null`.
+- Fixed display `Line.Null`.
 
 ## [2.13.6] - 2023-03-31
 
 ### Fixed
 
-* Fixed adding custom styles for `Radar` chart.
+- Fixed adding custom styles for `Radar` chart.
 
 ## [2.13.5] - 2023-03-29
 
 ### Fixed
 
-* Fixed calculating height of `Bar` component.
+- Fixed calculating height of `Bar` component.
 
 ## [2.13.4] - 2023-03-28
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.9.9 ~> 1.10.0], `@semcore/utils` [3.49.1 ~> 3.50.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.9.9 ~> 1.10.0], `@semcore/utils` [3.49.1 ~> 3.50.0]).
 
 ## [2.13.3] - 2023-03-27
 
 ### Fixed
 
-* Added correct display when there is no data in a11y table.
+- Added correct display when there is no data in a11y table.
 
 ## [2.13.2] - 2023-03-24
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.9.7 ~> 1.9.8], `@semcore/popper` [4.16.9 ~> 4.16.10], `@semcore/utils` [3.48.1 ~> 3.49.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.9.7 ~> 1.9.8], `@semcore/popper` [4.16.9 ~> 4.16.10], `@semcore/utils` [3.48.1 ~> 3.49.0]).
 
 ## [2.13.0] - 2023-03-23
 
 ### Added
 
-* Added `additionalFields` in `a11yAltTextConfig` for extra text description to the data when using a screen reader
+- Added `additionalFields` in `a11yAltTextConfig` for extra text description to the data when using a screen reader
 
 ## [2.12.2] - 2023-03-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.9.4 ~> 1.9.5], `@semcore/utils` [3.47.3 ~> 3.47.4]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.9.4 ~> 1.9.5], `@semcore/utils` [3.47.3 ~> 3.47.4]).
 
 ## [2.12.1] - 2023-03-21
 
 ### Fixed
 
-* Fixed `Radar` chart with negative rotation hover handling.
+- Fixed `Radar` chart with negative rotation hover handling.
 
 ## [2.12.0] - 2023-03-16
 
 ### Added
 
-* Add `angleOffset` parameter to `Radar` chart.
+- Add `angleOffset` parameter to `Radar` chart.
 
 ## [2.11.1] - 2023-03-16
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.9.3 ~> 1.9.4], `@semcore/utils` [3.47.2 ~> 3.47.3]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.9.3 ~> 1.9.4], `@semcore/utils` [3.47.2 ~> 3.47.3]).
 
 ## [2.11.0] - 2023-03-13
 
 ### Changed
 
-* Much improved a11y summary generation for `Radar` chart.
+- Much improved a11y summary generation for `Radar` chart.
 
 ## [2.10.0] - 2023-03-07
 
 ### Added
 
-* Added footer in `Tooltip`.
+- Added footer in `Tooltip`.
 
 ## [2.9.1] - 2023-03-06
 
 ### Fixed
 
-* Added backward compatibility with react 16.9.
+- Added backward compatibility with react 16.9.
 
 ## [2.9.0] - 2023-03-06
 
 ### Added
 
-* Added a new chart type `Radar`.
+- Added a new chart type `Radar`.
 
 ## [2.8.19] - 2023-03-01
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/popper` [4.16.3 ~> 4.16.4]).
+- Version patch update due to children dependencies update (`@semcore/popper` [4.16.3 ~> 4.16.4]).
 
 ## [2.8.18] - 2023-02-28
 
 ### Fixed
 
-* Fixed summary generation was broken after i18n enhancement release.
+- Fixed summary generation was broken after i18n enhancement release.
 
 ## [2.8.17] - 2023-02-28
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.9.1 ~> 1.9.2]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.9.1 ~> 1.9.2]).
 
 ## [2.8.16] - 2023-02-22
 
@@ -836,67 +836,67 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.9.0 ~> 1.9.1], `@semcore/utils` [3.47.0 ~> 3.47.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.9.0 ~> 1.9.1], `@semcore/utils` [3.47.0 ~> 3.47.1]).
 
 ## [2.8.14] - 2023-02-11
 
 ### Fixed
 
-* Added check for the presence of DON at start of animation for `RadialTree`.
+- Added check for the presence of DON at start of animation for `RadialTree`.
 
 ## [2.8.13] - 2023-02-10
 
 ### Fixed
 
-* Fixed display of `Bar` with height 0 - it is should not be rendered.
+- Fixed display of `Bar` with height 0 - it is should not be rendered.
 
 ## [2.8.12] - 2023-02-09
 
 ### Changed
 
-* Renamed rounding design token (`--intergalactic-rounded-medium` -> `--intergalactic-popper-rounded`).
+- Renamed rounding design token (`--intergalactic-rounded-medium` -> `--intergalactic-popper-rounded`).
 
 ## [2.8.11] - 2023-01-27
 
 ### Fixed
 
-* Fixed animation for `Donut`.
+- Fixed animation for `Donut`.
 
 ## [2.8.10] - 2023-01-26
 
 ### Changed
 
-* Changed minimum height in types for `Bar`.
+- Changed minimum height in types for `Bar`.
 
 ## [2.8.9] - 2023-01-25
 
 ### Fixed
 
-* Fixed and changed minimum height of `Bar`.
+- Fixed and changed minimum height of `Bar`.
 
 ## [2.8.8] - 2023-01-23
 
 ### Fixed
 
-* Fixed definition of users locale.
+- Fixed definition of users locale.
 
 ## [2.8.7] - 2023-01-19
 
 ### Fixed
 
-* Fixed animation in React strict mode for `RadialTree` and `Donut`.
+- Fixed animation in React strict mode for `RadialTree` and `Donut`.
 
 ## [2.8.6] - 2023-01-19
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.8.8 ~> 1.8.9], `@semcore/utils` [3.44.3 ~> 3.45.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.8.8 ~> 1.8.9], `@semcore/utils` [3.44.3 ~> 3.45.0]).
 
 ## [2.8.3] - 2022-01-10
 
 ### Fixed
 
-* Added prop `transparent` for all charts opacity
+- Added prop `transparent` for all charts opacity
 
 ## [2.8.2] - 2023-01-10
 
@@ -904,525 +904,525 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.8.5 ~> 1.8.6], `@semcore/utils` [3.44.1 ~> 3.44.2]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.8.5 ~> 1.8.6], `@semcore/utils` [3.44.1 ~> 3.44.2]).
 
 ## [2.8.0] - 2022-01-05
 
 ### Added
 
-* Added prop `transparent` for charts opacity
+- Added prop `transparent` for charts opacity
 
 ## [2.7.2] - 2022-12-27
 
 ### Fixed
 
-* Fixed `Donut` chart rendering when hovering over a chart while it is loading.
+- Fixed `Donut` chart rendering when hovering over a chart while it is loading.
 
 ## [2.7.1] - 2022-12-19
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.8.4 ~> 1.8.5], `@semcore/utils` [3.44.0 ~> 3.44.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.8.4 ~> 1.8.5], `@semcore/utils` [3.44.0 ~> 3.44.1]).
 
 ## [2.7.0] - 2022-12-14
 
 ### Changed
 
-* Supported semi-async internationalization of text in a11y module.
+- Supported semi-async internationalization of text in a11y module.
 
 ## [2.6.1] - 2022-12-13
 
 ### Changed
 
-* Added `react-dom` to peer dependencies.
+- Added `react-dom` to peer dependencies.
 
 ## [2.6.0] - 2022-12-12
 
 ### Added
 
-* Design tokens based theming.
+- Design tokens based theming.
 
 ## [2.5.2] - 2022-11-11
 
 ### Fixed
 
-* Allowed to pass any svg attributes.
+- Allowed to pass any svg attributes.
 
 ## [2.5.1] - 2022-11-11
 
 ### Fixed
 
-* Fixed `Bar` click handler typings.
+- Fixed `Bar` click handler typings.
 
 ## [2.5.0] - 2022-11-10
 
 ### Fixed
 
-* Fixed support handling of bars event handling with `paddingOuter`.
+- Fixed support handling of bars event handling with `paddingOuter`.
 
 ### Added
 
-* `Bar` component now supports `onClick` handler with bar data in callback.
+- `Bar` component now supports `onClick` handler with bar data in callback.
 
 ## [2.4.10] - 2022-11-03
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/popper` [4.13.3 ~> 4.13.4]).
+- Version patch update due to children dependencies update (`@semcore/popper` [4.13.3 ~> 4.13.4]).
 
 ## [2.4.9] - 2022-11-03
 
 ### Fixed
 
-* Fixed hover and active animated for `Donut` chart.
+- Fixed hover and active animated for `Donut` chart.
 
 ## [2.4.8] - 2022-11-02
 
 ### Fixed
 
-* Fixed display of minimum bar size in `StackBar`.
+- Fixed display of minimum bar size in `StackBar`.
 
 ### Added
 
-* Added display of minimum bar size in `HorizontalBar`.
+- Added display of minimum bar size in `HorizontalBar`.
 
 ## [2.4.7] - 2022-11-01
 
 ### Fixed
 
-* Fixed inner radius for `Donut` chart. It began to equal what is indicated in the `innerRadius` prop.
+- Fixed inner radius for `Donut` chart. It began to equal what is indicated in the `innerRadius` prop.
 
 ## [2.4.6] - 2022-10-31
 
 ### Fixed
 
-* Fixed reference lines were missing dashed style.
+- Fixed reference lines were missing dashed style.
 
 ## [2.4.5] - 2022-10-28
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.7.0 ~> 1.7.1], `@semcore/utils` [3.40.0 ~> 3.40.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.7.0 ~> 1.7.1], `@semcore/utils` [3.40.0 ~> 3.40.0]).
 
 ## [2.4.3] - 2022-10-20
 
 ### Fixed
 
-* Fixed typings of render functions.
+- Fixed typings of render functions.
 
 ## [2.4.2] - 2022-10-20
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.6.1 ~> 1.6.2], `@semcore/utils` [3.39.0 ~> 3.39.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.6.1 ~> 1.6.2], `@semcore/utils` [3.39.0 ~> 3.39.1]).
 
 ## [2.4.0] - 2022-10-10
 
 ### Changed
 
-* Added support for React 18 🔥
+- Added support for React 18 🔥
 
 ## [2.3.8] - 2022-10-10
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/popper` [4.11.31 ~> 4.12.0]).
+- Version patch update due to children dependencies update (`@semcore/popper` [4.11.31 ~> 4.12.0]).
 
 ## [2.3.7] - 2022-10-05
 
 ### Fixed
 
-* Ensured a11y module do not break mouse interactions.
+- Ensured a11y module do not break mouse interactions.
 
 ## [2.3.6] - 2022-10-04
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.5.10 ~> 1.5.11], `@semcore/utils` [3.37.1 ~> 3.37.2]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.5.10 ~> 1.5.11], `@semcore/utils` [3.37.1 ~> 3.37.2]).
 
 ## [2.3.5] - 2022-09-23
 
 ### Fixed
 
-* Fixed issue with uninitialized styles in some charts.
+- Fixed issue with uninitialized styles in some charts.
 
 ## [2.3.4] - 2022-09-21
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/popper` [4.11.29 ~> 4.11.30]).
+- Version patch update due to children dependencies update (`@semcore/popper` [4.11.29 ~> 4.11.30]).
 
 ## [2.3.3] - 2022-09-13
 
 ### Fixed
 
-* Changed paths in css files to relative.
+- Changed paths in css files to relative.
 
 ## [2.3.2] - 2022-08-30
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.5.9 ~> 1.5.10], `@semcore/utils` [3.37.0 ~> 3.37.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.5.9 ~> 1.5.10], `@semcore/utils` [3.37.0 ~> 3.37.1]).
 
 ## [2.3.0] - 2022-08-22
 
 ### Added
 
-* Introduced charts accessibility module.
+- Introduced charts accessibility module.
 
 ## [2.2.7] - 2022-08-18
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.5.7 ~> 1.5.8], `@semcore/utils` [3.36.0 ~> 3.37.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.5.7 ~> 1.5.8], `@semcore/utils` [3.36.0 ~> 3.37.0]).
 
 ## [2.2.5] - 2022-08-04
 
 ### Fixed
 
-* Fixed `ResponsiveContainer` memory leak on unmount.
+- Fixed `ResponsiveContainer` memory leak on unmount.
 
 ## [2.2.4] - 2022-08-02
 
 ### Fixed
 
-* `Venn` chart was not mentioned in exported types.
+- `Venn` chart was not mentioned in exported types.
 
 ## [2.2.3] - 2022-07-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.5.4 ~> 1.5.5], `@semcore/utils` [3.34.0 ~> 3.35.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.5.4 ~> 1.5.5], `@semcore/utils` [3.34.0 ~> 3.35.0]).
 
 ## [2.2.2] - 2022-07-20
 
 ### Fixed
 
-* Fixed ability to change `tag` in render(prop) functions.
-* Fixed `RadialTree` typings.
-* Fixed `RadialTree` rendering in Safari.
-* Fixed `RadialTree` radian labels rendering.
+- Fixed ability to change `tag` in render(prop) functions.
+- Fixed `RadialTree` typings.
+- Fixed `RadialTree` rendering in Safari.
+- Fixed `RadialTree` radian labels rendering.
 
 ## [2.2.1] - 2022-07-07
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.5.3 ~> 1.5.4], `@semcore/utils` [3.33.0 ~> 3.34.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.5.3 ~> 1.5.4], `@semcore/utils` [3.33.0 ~> 3.34.0]).
 
 ## [2.2.0] - 2022-06-30
 
 ### Added
 
-* Added index to Bubble chart
-* Added property minimal height `hMin` for Bar (`<Bar hMin={...}/>`)
-* Added property `active` for `Donut.Pie`
+- Added index to Bubble chart
+- Added property minimal height `hMin` for Bar (`<Bar hMin={...}/>`)
+- Added property `active` for `Donut.Pie`
 
 ### Fixed
 
-* Exclude props from html for `Tooltip.Dot`
-* Recalculate position for `Dot` after update scale
-* Optimization render `Dot`
+- Exclude props from html for `Tooltip.Dot`
+- Recalculate position for `Dot` after update scale
+- Optimization render `Dot`
 
 ## [2.1.0] - 2022-06-01
 
 ### Changed
 
-* Changed type names from 'ITooltipProps' to 'ITooltipChartProps' so that there are no intersections with other components.
-* Changed type names from 'ITooltipContext' to 'ITooltipChartContext' so that there are no intersections with other components.
+- Changed type names from 'ITooltipProps' to 'ITooltipChartProps' so that there are no intersections with other components.
+- Changed type names from 'ITooltipContext' to 'ITooltipChartContext' so that there are no intersections with other components.
 
 ## [2.0.10] - 2022-05-31
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.5.1 ~> 1.5.2], `@semcore/utils` [3.32.1 ~> 3.32.2], `@semcore/button` [4.0.4 ~> 4.0.5], `@semcore/checkbox` [6.0.3 ~> 6.0.4]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.5.1 ~> 1.5.2], `@semcore/utils` [3.32.1 ~> 3.32.2], `@semcore/button` [4.0.4 ~> 4.0.5], `@semcore/checkbox` [6.0.3 ~> 6.0.4]).
 
 ## [2.0.7] - 2022-05-25
 
 ### Fixed
 
-* Fixed position title for axis.
+- Fixed position title for axis.
 
 ## [2.0.6] - 2022-05-23
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [2.25.1 ~> 2.26.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [2.25.1 ~> 2.26.0]).
 
 ## [2.0.0] - 2022-05-17
 
 ### BREAK
 
-* Updated styles according to the library redesign policy.
+- Updated styles according to the library redesign policy.
 
 ## [1.9.0] - 2022-04-14
 
 ### Added
 
-* Added `<RadialTree />` chart.
+- Added `<RadialTree />` chart.
 
 ## [1.8.0] - 2022-04-11
 
 ### Fixed
 
-* Fixed left and right `<Axis.Title />` unexpected horizontal transition based on title characters count.
+- Fixed left and right `<Axis.Title />` unexpected horizontal transition based on title characters count.
 
 ## [1.7.1] - 2022-04-03
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.5.0 ~> 1.5.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.5.0 ~> 1.5.0]).
 
 ## [1.7.0] - 2022-03-28
 
 ### Fixed
 
-* Left and bottom plot titles now do not overlap axis ticks.
+- Left and bottom plot titles now do not overlap axis ticks.
 
 ## [1.6.9] - 2022-03-14
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.31.2 ~> 3.31.2], `@semcore/animation` [1.4.1 ~> 1.4.2]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.31.2 ~> 3.31.2], `@semcore/animation` [1.4.1 ~> 1.4.2]).
 
 ## [1.6.8] - 2022-03-10
 
 ### Fixed
 
-* Fixed figure cut on right or bottom edges when left or top margin is positive.
+- Fixed figure cut on right or bottom edges when left or top margin is positive.
 
 ## [1.6.7] - 2022-03-05
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.4.0 ~> 1.4.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.4.0 ~> 1.4.1]).
 
 ## [1.6.5] - 2022-02-24
 
 ### Added
 
-* Added repository field to package.json file.
+- Added repository field to package.json file.
 
 ## [1.6.4] - 2022-02-10
 
 ### Fixed
 
-* Fixed animation display when resizing.
+- Fixed animation display when resizing.
 
 ## [1.6.3] - 2022-01-26
 
 ### Changed
 
-* Revert function `findComponent` for check children in `Tooltip`, because it's valid for children `() => ({})`.
+- Revert function `findComponent` for check children in `Tooltip`, because it's valid for children `() => ({})`.
 
 ## [1.6.2] - 2022-01-25
 
 ### Changed
 
-* Replaced function `findComponent` to `isAdvanceMode` for check children in `Tooltip`.
+- Replaced function `findComponent` to `isAdvanceMode` for check children in `Tooltip`.
 
 ## [1.6.1] - 2021-01-21
 
 ### Added
 
-* Added Bubble and Scatter plot charts
+- Added Bubble and Scatter plot charts
 
 ### Changed
 
-* Tooltip font size changed
+- Tooltip font size changed
 
 ## [1.5.6] - 2021-12-08
 
 ### Changed
 
-* Moved chart colors vars to style
+- Moved chart colors vars to style
 
 ## [1.5.5] - 2021-12-06
 
 ### Fixed
 
-* Calculate correct border radius for Bar.
+- Calculate correct border radius for Bar.
 
 ## [1.5.4] - 2021-11-24
 
 ### Fixed
 
-* Fixed set `scale` for `Area, Line`.
+- Fixed set `scale` for `Area, Line`.
 
 ## [1.5.3] - 2021-10-27
 
 ### Fixed
 
-* Returned data `(x, y, width, height)` in render function for `Bar, Horizontalbar`.
+- Returned data `(x, y, width, height)` in render function for `Bar, Horizontalbar`.
 
 ## [1.5.2] - 2021-10-22
 
 ### Fixed
 
-* Fixed field `e.currentTarget` for events in `eventEmitter`.
+- Fixed field `e.currentTarget` for events in `eventEmitter`.
 
 ## [1.5.1] - 2021-10-19
 
 ### Fixed
 
-* Fixed hide tooltip.
+- Fixed hide tooltip.
 
 ## [1.5.0] - 2021-10-15
 
 ### Added
 
-* Added prop `outerRadius` for `Donut` chart.
+- Added prop `outerRadius` for `Donut` chart.
 
 ### Changed
 
-* Fixed call animation for hover in sector `Donut` chart.
-* Fixed animation show `Dot` in `Line` chart.
+- Fixed call animation for hover in sector `Donut` chart.
+- Fixed animation show `Dot` in `Line` chart.
 
 ## [1.4.1] - 2021-10-13
 
 ### Fixed
 
-* Fixed react key-related warning for `Bar`.
+- Fixed react key-related warning for `Bar`.
 
 ## [1.4.0] - 2021-10-12
 
 ### Added
 
-* Added new event `onMouseMoveChart, onMouseLeaveChart` for eventEmitter.
+- Added new event `onMouseMoveChart, onMouseLeaveChart` for eventEmitter.
 
 ### Fixed
 
-* Fixed show/hide components `Hover, Dots`.
+- Fixed show/hide components `Hover, Dots`.
 
 ## [1.3.1] - 2021-10-06
 
 ### Fixed
 
-* Fixed dependencies in package.json.
+- Fixed dependencies in package.json.
 
 ## [1.3.0] - 2021-09-30
 
 ### Added
 
-* Added radius of curvature for `Bar, HorizontalBar`.
-* Added dynamic position tooltip for `HoverRect, HoverLine`.
-* Added hover for `Donut.Pie`.
+- Added radius of curvature for `Bar, HorizontalBar`.
+- Added dynamic position tooltip for `HoverRect, HoverLine`.
+- Added hover for `Donut.Pie`.
 
 ## [1.2.0] - 2021-09-24
 
 ### Added
 
-* The ability to pass "undefined" to skip some of the data.
+- The ability to pass "undefined" to skip some of the data.
 
 ## [1.1.0] - 2021-09-14
 
 ### Added
 
-* Display 1% of the sector as the minimum value for Donut chart
+- Display 1% of the sector as the minimum value for Donut chart
 
 ## [1.0.0] - 2021-09-08
 
 ### Added
 
-* Added animation for all charts.
+- Added animation for all charts.
 
 ## [1.0.0-15] - 2021-08-26
 
 ### Changed
 
-* Add 'sideEffect=false' for more optimal build via webpack
+- Add 'sideEffect=false' for more optimal build via webpack
 
 ## [1.0.0-14] - 2021-08-02
 
 ### Fixed
 
-* [ts] correct types.
+- [ts] correct types.
 
 ## [1.0.0-13] - 2021-06-18
 
 ### BREAK
 
-* Revert area for stack area chart.
-* Change data for Venn chart.
+- Revert area for stack area chart.
+- Change data for Venn chart.
 
 ### Changed
 
-* Add default ticks for Axis.
+- Add default ticks for Axis.
 
 ## [1.0.0-12] - 2021-06-02
 
 ### Added
 
-* Added Venn chart.
+- Added Venn chart.
 
 ## [1.0.0-11] - 2021-05-12
 
 ### Fixed
 
-* Fix TS type
+- Fix TS type
 
 ## [1.0.0-9] - 2021-04-26
 
 ### Changed
 
-* Version of dependence `@semcore/core` has been changed to `1.11`.
-* Improved performance. Removed one component wrapper.
-* The style processing system has been changed.
-* Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
+- Version of dependence `@semcore/core` has been changed to `1.11`.
+- Improved performance. Removed one component wrapper.
+- The style processing system has been changed.
+- Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
 
 ## [1.0.0-8] - 2021-04-20
 
 ### Fixed
 
-* Fixed version dependency for package `@semcore/popper`.
+- Fixed version dependency for package `@semcore/popper`.
 
 ## [1.0.0-7] - 2021-04-15
 
 ### Fixed
 
-* Fixed Plot naming.
+- Fixed Plot naming.
 
 ## [1.0.0-6] - 2021-04-15
 
 ### Added
 
-* Added Donut and Semi-donut charts.
+- Added Donut and Semi-donut charts.
 
 ## [1.0.0-5] - 2021-03-31
 
 ### Fixed
 
-* [TS] Fixed types for `Line` and `Area`.
+- [TS] Fixed types for `Line` and `Area`.
 
 ## [1.0.0-4] - 2021-03-30
 
 ### Added
 
-* Added Area and Stacked Area charts.
+- Added Area and Stacked Area charts.
 
 ## [1.0.0-3] - 2021-03-29
 
 ### Added
 
-* [TS] Added types for `Bar.Background, HorizontalBar.Background`.
+- [TS] Added types for `Bar.Background, HorizontalBar.Background`.
 
 ## [1.0.0-2] - 2021-03-18
 
 ### Fixed
 
-* Fixed calculate coordinates for `Hover` and `Tooltip` components.
+- Fixed calculate coordinates for `Hover` and `Tooltip` components.
 
 ## [1.0.0-1] - 2021-03-10
 
 ### Added
 
-* Added support property `tag` for all components.
+- Added support property `tag` for all components.
 
 ### Fixed
 
-* Fixed hover for `svg` element inside `XYPlot`.
+- Fixed hover for `svg` element inside `XYPlot`.
 
 ## [1.0.0-prerelease.10] - 2021-02-11
 
 ### Added
 
-* Initial release.
+- Initial release.

--- a/semcore/d3-chart/src/Bubble.jsx
+++ b/semcore/d3-chart/src/Bubble.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { transition } from 'd3-transition';
 import { Component, Root, sstyled } from '@semcore/core';
-import canUseDOM from '@semcore/utils/lib/canUseDOM';
 import uniqueIDEnhancement from '@semcore/utils/lib/uniqueID';
 import createElement from './createElement';
-import { getBubbleChartValueScale, CONSTANT, measureText } from './utils';
+import { getBubbleChartValueScale, measureText } from './utils';
 import Tooltip from './Tooltip';
 import { PatternFill } from './Pattern';
 
@@ -21,17 +20,16 @@ class BubbleRoot extends Component {
     markedCross: true,
   };
 
-  virtualElement = canUseDOM() ? document.createElement('div') : {};
-
   generateGetBoundingClientRect(x = 0, y = 0) {
     return () => ({ width: 0, height: 0, top: y, right: x, bottom: y, left: x });
   }
 
-  bindHandlerTooltip = (visible, props, tooltipProps) => ({ clientX: x, clientY: y }) => {
+  bindHandlerTooltip = (visible, props, tooltipProps) => ({ clientX, clientY }) => {
     const { eventEmitter } = this.asProps;
-    this.virtualElement.getBoundingClientRect = this.generateGetBoundingClientRect(x, y);
-    this.virtualElement[CONSTANT.VIRTUAL_ELEMENT] = true;
-    eventEmitter.emit('onTooltipVisible', visible, props, tooltipProps, this.virtualElement);
+
+    eventEmitter.emit('setTooltipPosition', clientX, clientY);
+    eventEmitter.emit('setTooltipRenderingProps', props, tooltipProps);
+    eventEmitter.emit('setTooltipVisible', visible);
   };
 
   animationCircle() {

--- a/semcore/d3-chart/src/Donut.jsx
+++ b/semcore/d3-chart/src/Donut.jsx
@@ -7,7 +7,7 @@ import canUseDOM from '@semcore/utils/lib/canUseDOM';
 import getOriginChildren from '@semcore/utils/lib/getOriginChildren';
 import uniqueIDEnhancement from '@semcore/utils/lib/uniqueID';
 import createElement from './createElement';
-import { CONSTANT, getChartDefaultColorName } from './utils';
+import { getChartDefaultColorName } from './utils';
 import Tooltip from './Tooltip';
 import { PatternFill } from './Pattern';
 
@@ -171,11 +171,12 @@ class DonutRoot extends Component {
     return d3Pie(pieData);
   }
 
-  bindHandlerTooltip = (visible, props, tooltipProps) => ({ clientX: x, clientY: y }) => {
+  bindHandlerTooltip = (visible, props, tooltipProps) => ({ clientX, clientY }) => {
     const { eventEmitter } = this.asProps;
-    this.virtualElement.getBoundingClientRect = this.generateGetBoundingClientRect(x, y);
-    this.virtualElement[CONSTANT.VIRTUAL_ELEMENT] = true;
-    eventEmitter.emit('onTooltipVisible', visible, props, tooltipProps, this.virtualElement);
+
+    eventEmitter.emit('setTooltipPosition', clientX, clientY);
+    eventEmitter.emit('setTooltipRenderingProps', props, tooltipProps);
+    eventEmitter.emit('setTooltipVisible', visible);
   };
 
   animationActivePie = ({ data, active, selector, element }) => {

--- a/semcore/d3-chart/src/Hover.jsx
+++ b/semcore/d3-chart/src/Hover.jsx
@@ -3,14 +3,7 @@ import { Component, sstyled, Root } from '@semcore/core';
 import canUseDOM from '@semcore/utils/lib/canUseDOM';
 import trottle from '@semcore/utils/lib/rafTrottle';
 import createElement from './createElement';
-import {
-  scaleOfBandwidth,
-  getIndexFromData,
-  eventToPoint,
-  invert,
-  CONSTANT,
-  scaleToBand,
-} from './utils';
+import { scaleOfBandwidth, getIndexFromData, eventToPoint, invert, scaleToBand } from './utils';
 
 import style from './style/hover.shadow.css';
 import Tooltip from './Tooltip';
@@ -25,10 +18,6 @@ class Hover extends Component {
 
   virtualElement = canUseDOM() ? document.createElement('div') : {};
 
-  generateGetBoundingClientRect(x = 0, y = 0) {
-    return () => ({ width: 0, height: 0, top: y, right: x, bottom: y, left: x });
-  }
-
   handlerMouseMoveRoot = trottle((e) => {
     const { eventEmitter, data, scale, x, y, rootRef, patterns } = this.asProps;
     const { clientX, clientY } = e;
@@ -41,20 +30,11 @@ class Hover extends Component {
     const yIndex =
       y === undefined || vY === undefined ? null : getIndexFromData(data, yScale, y, vY);
     const state = { xIndex, yIndex, patterns };
-    this.virtualElement.getBoundingClientRect = this.generateGetBoundingClientRect(
-      clientX,
-      clientY,
-    );
-    this.virtualElement[CONSTANT.VIRTUAL_ELEMENT] = true;
 
     this.setState(state, () => {
-      eventEmitter.emit(
-        'onTooltipVisible',
-        xIndex !== null || yIndex !== null,
-        {},
-        state,
-        this.virtualElement,
-      );
+      eventEmitter.emit('setTooltipPosition', clientX, clientY);
+      eventEmitter.emit('setTooltipRenderingProps', {}, state);
+      eventEmitter.emit('setTooltipVisible', xIndex !== null || yIndex !== null);
     });
   });
 
@@ -65,7 +45,7 @@ class Hover extends Component {
       patterns: this.asProps.patterns,
     };
     this.setState(state, () => {
-      this.asProps.eventEmitter.emit('onTooltipVisible', false, {}, state);
+      this.asProps.eventEmitter.emit('setTooltipVisible', false);
     });
   });
 
@@ -111,6 +91,7 @@ class HoverLineRoot extends Hover {
 
     return sstyled(styles)(
       <>
+        hi
         {xIndex !== null ? (
           <SHoverLine
             aria-hidden

--- a/semcore/d3-chart/src/Hover.jsx
+++ b/semcore/d3-chart/src/Hover.jsx
@@ -91,7 +91,6 @@ class HoverLineRoot extends Hover {
 
     return sstyled(styles)(
       <>
-        hi
         {xIndex !== null ? (
           <SHoverLine
             aria-hidden

--- a/semcore/d3-chart/src/ScatterPlot.jsx
+++ b/semcore/d3-chart/src/ScatterPlot.jsx
@@ -4,7 +4,7 @@ import { Component, Root, sstyled } from '@semcore/core';
 import canUseDOM from '@semcore/utils/lib/canUseDOM';
 import uniqueIDEnhancement from '@semcore/utils/lib/uniqueID';
 import createElement from './createElement';
-import { CONSTANT, getScatterPlotRadius } from './utils';
+import { getScatterPlotRadius } from './utils';
 import Tooltip from './Tooltip';
 import { PatternFill } from './Pattern';
 
@@ -26,11 +26,12 @@ class ScatterPlotRoot extends Component {
     return () => ({ width: 0, height: 0, top: y, right: x, bottom: y, left: x });
   }
 
-  bindHandlerTooltip = (visible, props, tooltipProps) => ({ clientX: x, clientY: y }) => {
+  bindHandlerTooltip = (visible, props, tooltipProps) => ({ clientX, clientY }) => {
     const { eventEmitter } = this.asProps;
-    this.virtualElement.getBoundingClientRect = this.generateGetBoundingClientRect(x, y);
-    this.virtualElement[CONSTANT.VIRTUAL_ELEMENT] = true;
-    eventEmitter.emit('onTooltipVisible', visible, props, tooltipProps, this.virtualElement);
+
+    eventEmitter.emit('setTooltipPosition', clientX, clientY);
+    eventEmitter.emit('setTooltipRenderingProps', props, tooltipProps);
+    eventEmitter.emit('setTooltipVisible', visible);
   };
 
   animationCircle() {

--- a/semcore/d3-chart/src/Venn.jsx
+++ b/semcore/d3-chart/src/Venn.jsx
@@ -4,7 +4,7 @@ import { Component, Root, sstyled } from '@semcore/core';
 import canUseDOM from '@semcore/utils/lib/canUseDOM';
 import { FadeInOut } from '@semcore/animation';
 import createElement from './createElement';
-import { CONSTANT, getChartDefaultColorName } from './utils';
+import { getChartDefaultColorName } from './utils';
 import Tooltip from './Tooltip';
 import { PatternFill } from './Pattern';
 import uniqueIDEnhancement from '@semcore/utils/lib/uniqueID';
@@ -28,11 +28,12 @@ class VennRoot extends Component {
     return () => ({ width: 0, height: 0, top: y, right: x, bottom: y, left: x });
   }
 
-  bindHandlerTooltip = (visible, props, tooltipProps) => ({ clientX: x, clientY: y }) => {
+  bindHandlerTooltip = (visible, props, tooltipProps) => ({ clientX, clientY }) => {
     const { eventEmitter } = this.asProps;
-    this.virtualElement.getBoundingClientRect = this.generateGetBoundingClientRect(x, y);
-    this.virtualElement[CONSTANT.VIRTUAL_ELEMENT] = true;
-    eventEmitter.emit('onTooltipVisible', visible, props, tooltipProps, this.virtualElement);
+
+    eventEmitter.emit('setTooltipPosition', clientX, clientY);
+    eventEmitter.emit('setTooltipRenderingProps', props, tooltipProps);
+    eventEmitter.emit('setTooltipVisible', visible);
   };
 
   getVennData() {

--- a/semcore/d3-chart/src/index.js
+++ b/semcore/d3-chart/src/index.js
@@ -31,6 +31,7 @@ export {
   getBubbleChartValueScale,
   getScatterPlotRadius,
   calculateBubbleDomain,
+  PlotEventEmitter,
 } from './utils';
 export { colors } from './color';
 

--- a/semcore/d3-chart/src/types/Plot.d.ts
+++ b/semcore/d3-chart/src/types/Plot.d.ts
@@ -3,6 +3,7 @@ import { UnknownProperties, Intergalactic } from '@semcore/core';
 import { Context } from './context';
 import { DataStructureHints } from './a11y/hints';
 import { PatternsConfig } from './Pattern';
+import { PlotEventEmitter } from './utils';
 
 /** @deprecated */
 export interface IPlotProps extends PlotProps, UnknownProperties {}
@@ -31,8 +32,7 @@ export type PlotProps = Context &
     /** Enables charts patterns that enhances charts accessibility */
     patterns?: PatternsConfig;
 
-    /** @deprecated */
-    eventEmitter?: unknown;
+    eventEmitter?: PlotEventEmitter;
   };
 
 export type PlotSummarizerConfig = {

--- a/semcore/d3-chart/src/types/Plot.d.ts
+++ b/semcore/d3-chart/src/types/Plot.d.ts
@@ -32,7 +32,7 @@ export type PlotProps = Context &
     /** Enables charts patterns that enhances charts accessibility */
     patterns?: PatternsConfig;
 
-    eventEmitter?: PlotEventEmitter;
+    eventEmitter?: InstanceType<typeof PlotEventEmitter>;
   };
 
 export type PlotSummarizerConfig = {

--- a/semcore/d3-chart/src/types/index.d.ts
+++ b/semcore/d3-chart/src/types/index.d.ts
@@ -1,6 +1,6 @@
 // Utils
 // @ts-ignore
-import { interpolateValue as intValue } from './utils';
+import { interpolateValue as intValue, PlotEventEmitter } from './utils';
 
 export declare const interpolateValue: typeof intValue;
 export declare function minMax(data: any, key: string | number): any;
@@ -9,6 +9,7 @@ export declare function calculateBubbleDomain(
   key: 'x' | 'y',
   range: [number, number],
 ): [min: number, max: number];
+export { PlotEventEmitter };
 
 export { makeDataHintsContainer } from './a11y/hints';
 

--- a/semcore/d3-chart/src/utils.ts
+++ b/semcore/d3-chart/src/utils.ts
@@ -343,10 +343,7 @@ interface PlotEventEmitterSubscribe {
   (event: 'setTooltipVisible', callback: (visible: boolean) => void): Unsubscribe;
   (event: 'setTooltipPosition', callback: (x: number, y: number) => void): Unsubscribe;
 }
-type PlotEventEmitter = {
-  new (): {
-    emit: PlotEventEmitterEmit;
-    subscribe: PlotEventEmitterSubscribe;
-  };
-};
-export const PlotEventEmitter = EventEmitter as any as PlotEventEmitter;
+export const PlotEventEmitter = EventEmitter as typeof EventEmitter<
+  PlotEventEmitterEmit,
+  PlotEventEmitterSubscribe
+>;

--- a/semcore/d3-chart/src/utils.ts
+++ b/semcore/d3-chart/src/utils.ts
@@ -1,3 +1,4 @@
+import EventEmitter from '@semcore/utils/lib/eventEmitter';
 import { extent, bisector, Numeric } from 'd3-array';
 import {
   scaleQuantize,
@@ -11,12 +12,6 @@ import {
   scaleSqrt,
 } from 'd3-scale';
 import React from 'react';
-
-const CONSTANT = {
-  VIRTUAL_ELEMENT: Symbol('VIRTUAL_ELEMENT'),
-} as const;
-
-export { CONSTANT };
 
 export const eventToPoint = (event: React.MouseEvent<HTMLElement>, svgRoot: SVGElement) => {
   const node = (event.currentTarget || event.target) as HTMLElement;
@@ -338,3 +333,20 @@ export const calculateBubbleDomain = (
 
   return [min, max];
 };
+
+interface PlotEventEmitterEmit {
+  (event: 'setTooltipVisible', visible: boolean): void;
+  (event: 'setTooltipPosition', x: number, y: number): void;
+}
+type Unsubscribe = () => void;
+interface PlotEventEmitterSubscribe {
+  (event: 'setTooltipVisible', callback: (visible: boolean) => void): Unsubscribe;
+  (event: 'setTooltipPosition', callback: (x: number, y: number) => void): Unsubscribe;
+}
+type PlotEventEmitter = {
+  new (): {
+    emit: PlotEventEmitterEmit;
+    subscribe: PlotEventEmitterSubscribe;
+  };
+};
+export const PlotEventEmitter = EventEmitter as any as PlotEventEmitter;

--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.28.0] - 2024-04-16
+
+### Added
+
+- Low level `explicitTriggerSet` api for more granular control over which element will be used as popper trigger.
+
 ## [5.27.1] - 2024-04-15
 
 ### Changed

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -370,7 +370,7 @@ class Popper extends Component {
   };
 
   getTriggerProps() {
-    const { visible, interaction, disableEnforceFocus } = this.asProps;
+    const { visible, interaction, disableEnforceFocus, explicitTriggerSet } = this.asProps;
     // @ts-ignore
     const { onKeyDown, ...interactionProps } = this.handlersFromInteraction(
       interaction,
@@ -378,7 +378,7 @@ class Popper extends Component {
       visible,
     );
     return {
-      ref: this.createTriggerRef,
+      ref: explicitTriggerSet ? undefined : this.createTriggerRef,
       active: visible,
       interaction,
       ...interactionProps,

--- a/semcore/popper/src/index.d.ts
+++ b/semcore/popper/src/index.d.ts
@@ -88,6 +88,10 @@ export type PopperProps = OutsideClickProps &
      * @default `true` (`false` in Tooltip)
      */;
     focusLoop?: boolean;
+    /**
+     * If enabled, you will need to use setTrigger function from children rendering function to set popper trigger.
+     */
+    explicitTriggerSet?: boolean;
   };
 
 /** @deprecated */

--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.23.2] - 2024-04-17
+
+### Fixed
+
+- Typings of event emitter util.
+
 ## [4.23.1] - 2024-04-15
 
 ### Fixed

--- a/semcore/utils/src/eventEmitter.ts
+++ b/semcore/utils/src/eventEmitter.ts
@@ -1,24 +1,30 @@
-export default class EventEmitter {
+type DefaultEmit = (eventName: string, ...args: any[]) => void;
+type DefaultSubscribe = (eventName: string, fn: any) => () => void;
+
+export default class EventEmitter<Emit = DefaultEmit, Subscribe = DefaultSubscribe> {
   private events: any = {};
+  constructor() {
+    this.emit = ((eventName: string, ...args: any[]) => {
+      const event = this.events[eventName];
+      if (event) {
+        event.forEach((fn: any) => {
+          fn.call(null, ...args);
+        });
+      }
+    }) as any;
+    this.subscribe = ((eventName: string, fn: any) => {
+      if (!this.events[eventName]) {
+        this.events[eventName] = [];
+      }
 
-  emit(...args: any[]) {
-    const eventName: string = args[0];
-    const event = this.events[eventName];
-    if (event) {
-      event.forEach((fn: any) => {
-        fn.call(null, ...args.slice(1));
-      });
-    }
+      this.events[eventName].push(fn);
+      return () => {
+        this.events[eventName] = this.events[eventName].filter((eventFn: any) => fn !== eventFn);
+      };
+    }) as any;
   }
 
-  subscribe(eventName: string, fn: any) {
-    if (!this.events[eventName]) {
-      this.events[eventName] = [];
-    }
+  emit: Emit;
 
-    this.events[eventName].push(fn);
-    return () => {
-      this.events[eventName] = this.events[eventName].filter((eventFn: any) => fn !== eventFn);
-    };
-  }
+  subscribe: Subscribe;
 }

--- a/tools/playground/src/App.tsx
+++ b/tools/playground/src/App.tsx
@@ -58,13 +58,13 @@ export const PlaygroundWrapper: React.FC = () => {
 
 export const App: React.FC = () => {
   return (
-    <StrictMode>
-      <div>
-        <Nav />
-        <main className='intergalactic-playground_playground-view'>
-          <PlaygroundWrapper />
-        </main>
-      </div>
-    </StrictMode>
+    // <StrictMode>
+    <div>
+      <Nav />
+      <main className='intergalactic-playground_playground-view'>
+        <PlaygroundWrapper />
+      </main>
+    </div>
+    // </StrictMode>
   );
 };

--- a/tools/playground/src/App.tsx
+++ b/tools/playground/src/App.tsx
@@ -58,13 +58,13 @@ export const PlaygroundWrapper: React.FC = () => {
 
 export const App: React.FC = () => {
   return (
-    // <StrictMode>
-    <div>
-      <Nav />
-      <main className='intergalactic-playground_playground-view'>
-        <PlaygroundWrapper />
-      </main>
-    </div>
-    // </StrictMode>
+    <StrictMode>
+      <div>
+        <Nav />
+        <main className='intergalactic-playground_playground-view'>
+          <PlaygroundWrapper />
+        </main>
+      </div>
+    </StrictMode>
   );
 };

--- a/website/docs/data-display/d3-chart/d3-chart-code.md
+++ b/website/docs/data-display/d3-chart/d3-chart-code.md
@@ -210,7 +210,7 @@ Refer to [Chart legend](/data-display/chart-legend/chart-legend), for a guide on
 
 ## Synchronous charts
 
-You can pass a common `eventEmitter` to synchronize the charts.
+You can pass a single `eventEmitter` to synchronize the charts.
 
 ::: tip
 Be careful when choosing the `scale` for the axis, since it's common across different charts.
@@ -220,6 +220,18 @@ Be careful when choosing the `scale` for the axis, since it's common across diff
 
 <script lang="tsx">
   export Demo from './examples/synchronous-charts.tsx';
+</script>
+
+:::
+
+## Tooltip control
+
+To control over tooltip visibility and targeted position, imperatively call plot's event emitter.
+
+::: sandbox
+
+<script lang="tsx">
+  export Demo from './examples/tooltip-control.tsx';
 </script>
 
 :::

--- a/website/docs/data-display/d3-chart/examples/synchronous-charts.tsx
+++ b/website/docs/data-display/d3-chart/examples/synchronous-charts.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
 import { scaleLinear, scaleBand } from 'd3-scale';
-import { Bar, HoverLine, HoverRect, Line, XAxis, Plot, YAxis } from 'intergalactic/d3-chart';
-import EventEmitter from 'intergalactic/utils/lib/eventEmitter';
+import {
+  Bar,
+  HoverLine,
+  HoverRect,
+  Line,
+  XAxis,
+  Plot,
+  YAxis,
+  PlotEventEmitter,
+} from 'intergalactic/d3-chart';
 
-const eventEmitter = new EventEmitter();
+const eventEmitter = new PlotEventEmitter();
 
 const Demo = () => {
   const [width, height] = [600, 300];

--- a/website/docs/data-display/d3-chart/examples/tooltip-control.tsx
+++ b/website/docs/data-display/d3-chart/examples/tooltip-control.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import {
+  Plot,
+  Line,
+  XAxis,
+  YAxis,
+  HoverLine,
+  minMax,
+  PlotEventEmitter,
+} from 'intergalactic/d3-chart';
+import { Flex } from 'intergalactic/flex-box';
+import { Text } from 'intergalactic/typography';
+import { scaleLinear, scaleTime } from 'd3-scale';
+
+function formatDate(value, options) {
+  return new Intl.DateTimeFormat('en', options).format(value);
+}
+
+const eventEmitter = new PlotEventEmitter();
+
+const Demo = () => {
+  const MARGIN = 40;
+  const width = 500;
+  const height = 300;
+  const plotRef = React.useRef(null);
+
+  const xScale = scaleTime()
+    .range([MARGIN, width - MARGIN])
+    .domain(minMax(data, 'time'));
+
+  const yScale = scaleLinear()
+    .range([height - MARGIN, MARGIN])
+    .domain([0, 10]);
+
+  React.useEffect(() => {
+    const unsubscribe = eventEmitter.subscribe('setTooltipPosition', (x, y) => {
+      const plotRect = plotRef.current?.getBoundingClientRect();
+      if (x - plotRect.x < 150) {
+        eventEmitter.emit('setTooltipPosition', plotRect.x + 150, y);
+      }
+      if (x - plotRect.x > 200) {
+        eventEmitter.emit('setTooltipPosition', plotRect.x + 200, y);
+      }
+    });
+    return () => unsubscribe();
+  }, []);
+
+  return (
+    <Plot
+      ref={plotRef}
+      data={data}
+      scale={[xScale, yScale]}
+      width={width}
+      height={height}
+      eventEmitter={eventEmitter}
+    >
+      <YAxis>
+        <YAxis.Ticks />
+        <YAxis.Grid />
+      </YAxis>
+      <XAxis>
+        <XAxis.Ticks>
+          {({ value }) => ({
+            children: formatDate(value, {
+              month: 'short',
+              day: 'numeric',
+            }),
+          })}
+        </XAxis.Ticks>
+      </XAxis>
+      <Line x='time' y='line'>
+        <Line.Dots display />
+      </Line>
+      <HoverLine.Tooltip x='time' wMin={100}>
+        {({ xIndex }) => {
+          return {
+            children: (
+              <>
+                <HoverLine.Tooltip.Title>
+                  {formatDate(data[xIndex].time, {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}
+                </HoverLine.Tooltip.Title>
+                <Flex justifyContent='space-between'>
+                  <HoverLine.Tooltip.Dot mr={4}>Line</HoverLine.Tooltip.Dot>
+                  <Text bold>{data[xIndex].line}</Text>
+                </Flex>
+                <HoverLine.Tooltip.Footer>
+                  This tooltip is under your control!
+                </HoverLine.Tooltip.Footer>
+              </>
+            ),
+          };
+        }}
+      </HoverLine.Tooltip>
+    </Plot>
+  );
+};
+
+const date = new Date();
+const data = Array(10)
+  .fill({})
+  .map((d, i) => {
+    return {
+      time: new Date(date.setDate(date.getDate() + 5)),
+      line: Math.random() * 10,
+    };
+  });
+
+export default Demo;


### PR DESCRIPTION
## Motivation and Context

In this PR I'm attempted to provide an api to control over d3 chart tooltip position.

I've considered use common React approach when tooltip position is stored in React state, but then preferred imperative api with event's emitter as React state updated might be too slow and requite too much computations to handle popper position.
 
Current api allows developers to control tooltip visibility and position but it require for them to know and update component internal state, so I've split events into more specific ones and exposed only high level `setTooltipVisible` and `setTooltipPosition`. 

I've also found that currently d3 tooltip reinitializes popper instance on every mousemove. To fix it, I also needed to introduce small change into popper.

## How has this been tested?

Manually on all affected chart types.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
