### PR TITLE
Fix ReferenceLine color token and example

### DIFF
--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.38.1] - 2024-04-16
+
+### Fixed
+
+- stroke color for ReferenceLine from `--intergalactic-chart-grid-x-axis` to `--intergalactic-chart-grid-y-accent-hover-line`.
+
 ## [3.38.0] - 2024-04-12
 
 ### Added

--- a/semcore/d3-chart/src/style/reference-line.shadow.css
+++ b/semcore/d3-chart/src/style/reference-line.shadow.css
@@ -1,6 +1,6 @@
 SReferenceLine {
   fill: none;
-  stroke: var(--chart-grid-y-accent-hover-line, #a9abb6);
+  stroke: var(--intergalactic-chart-grid-y-accent-hover-line, #a9abb6);
 }
 
 STitle {

--- a/semcore/d3-chart/src/style/reference-line.shadow.css
+++ b/semcore/d3-chart/src/style/reference-line.shadow.css
@@ -1,6 +1,6 @@
 SReferenceLine {
   fill: none;
-  stroke: var(--intergalactic-chart-grid-x-axis, #c4c7cf);
+  stroke: var(--chart-grid-y-accent-hover-line, #a9abb6);
 }
 
 STitle {

--- a/website/docs/data-display/d3-chart/examples/reference-line.tsx
+++ b/website/docs/data-display/d3-chart/examples/reference-line.tsx
@@ -29,11 +29,7 @@ const Demo = () => {
       <ReferenceLine title='Right data' position='right' value={dataBar[1].category} />
       <ReferenceLine title='Top data' position='top' value={9} />
       <ReferenceLine title='Bottom data' position='bottom' value={3} />
-      <ReferenceLine
-        value={dataBar[3].category}
-        strokeDasharray='3 3'
-        width='100'
-      >
+      <ReferenceLine value={dataBar[3].category} strokeDasharray='3 3' width='100'>
         <ReferenceLine.Background endValue={dataBar[4].category} />
       </ReferenceLine>
     </Plot>

--- a/website/docs/data-display/d3-chart/examples/reference-line.tsx
+++ b/website/docs/data-display/d3-chart/examples/reference-line.tsx
@@ -32,7 +32,6 @@ const Demo = () => {
       <ReferenceLine
         value={dataBar[3].category}
         strokeDasharray='3 3'
-        strokeWidth='0.5'
         width='100'
       >
         <ReferenceLine.Background endValue={dataBar[4].category} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

1. ReferenceLine component was using the wrong color token `x-axis`. Changed it to `y-accent-hover-line` to comply with the design.
2. Example in docs used 0.5px line width, and because of this the line in the example appeared lighter that it should've been.

## How has this been tested?

Tested manually (see screenshots).

## Screenshots (if appropriate):
<img width="777" alt="image" src="https://github.com/semrush/intergalactic/assets/166654065/b9ae1a0b-99c5-4647-af35-6ce8781d1d11">
<img width="776" alt="image" src="https://github.com/semrush/intergalactic/assets/166654065/b4533f4b-8fed-40a0-8d72-33bacd08b8a1">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
