### PR TITLE
[data-table] fix tabIndex conditional error

### DIFF
--- a/semcore/data-table/src/Head.tsx
+++ b/semcore/data-table/src/Head.tsx
@@ -98,7 +98,7 @@ class Head extends Component<AsProps> {
         borderRight={isGroup ? false : column.borderRight}
         active={isGroup ? false : column.active}
         group={isGroup}
-        tabIndex={column.sortable && 0}
+        tabIndex={column.sortable ? 0 : undefined}
         __excludeProps={['hidden']}
         {...column.props}
         ref={this.refColumn(column.props)}


### PR DESCRIPTION
tabIndex error with conditional sortable parameter

## Motivation and Context

Sometimes we need to disable sorting in columns

```
  <DataTable.Column
           name='keyword'
           children='Keyword'
           justifyContent='left'
           sortable={isSortable}
         />
```
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):
<img width="792" alt="Screenshot 2024-04-17 at 21 03 30" src="https://github.com/semrush/intergalactic/assets/12624143/97a5dd92-8e22-4756-bd08-d13a9bf2c285">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
