### PR TITLE
Add stripe color token for diagonal chart grid pattern

### DIFF
--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.24.0] - 2024-04-17
+
+### Added
+
+- New token for the color of stripes in the diagonal chart grid pattern: `--intergalactic-chart-grid-period-pattern`.
+
 ## [4.23.2] - 2024-04-17
 
 ### Fixed

--- a/semcore/utils/src/themes/auto.css
+++ b/semcore/utils/src/themes/auto.css
@@ -695,8 +695,10 @@
   --intergalactic-chart-grid-bar-chart-hover: rgba(196, 199, 207, 0.3);
   /* Default background color of a bar in the BarChart. */
   --intergalactic-chart-grid-bar-chart-base-bg: #e0e1e9;
-  /* Use for highlighting the period on the chart grid. */
+  /* Use for highlighting a period on the chart grid. */
   --intergalactic-chart-grid-period-bg: rgba(196, 199, 207, 0.2);
+  /* Stripe color for diagonal pattern background. */
+  --intergalactic-chart-grid-period-pattern: rgba(25, 27, 35, 0.15);
   /* Border for distinguishing data sets and chart dots on the chart grid. */
   --intergalactic-chart-grid-border: #ffffff;
   /* Background color for the clickable date on the X-axis of the chart grid. */

--- a/semcore/utils/src/themes/default.css
+++ b/semcore/utils/src/themes/default.css
@@ -695,8 +695,10 @@
   --intergalactic-chart-grid-bar-chart-hover: rgba(196, 199, 207, 0.3);
   /* Default background color of a bar in the BarChart. */
   --intergalactic-chart-grid-bar-chart-base-bg: #e0e1e9;
-  /* Use for highlighting the period on the chart grid. */
+  /* Use for highlighting a period on the chart grid. */
   --intergalactic-chart-grid-period-bg: rgba(196, 199, 207, 0.2);
+  /* Stripe color for diagonal pattern background. */
+  --intergalactic-chart-grid-period-pattern: rgba(25, 27, 35, 0.15);
   /* Border for distinguishing data sets and chart dots on the chart grid. */
   --intergalactic-chart-grid-border: #ffffff;
   /* Background color for the clickable date on the X-axis of the chart grid. */

--- a/semcore/utils/src/themes/default.json
+++ b/semcore/utils/src/themes/default.json
@@ -354,6 +354,7 @@
   "--intergalactic-chart-grid-bar-chart-hover": "rgba(196, 199, 207, 0.3)",
   "--intergalactic-chart-grid-bar-chart-base-bg": "#e0e1e9",
   "--intergalactic-chart-grid-period-bg": "rgba(196, 199, 207, 0.2)",
+  "--intergalactic-chart-grid-period-pattern": "rgba(25, 27, 35, 0.15)",
   "--intergalactic-chart-grid-border": "#ffffff",
   "--intergalactic-chart-x-axis-accent-period-active": "#6c6e79",
   "--intergalactic-chart-x-axis-accent-data-start-tracking": "rgba(0, 159, 129, 0.2)",

--- a/semcore/utils/src/themes/light.css
+++ b/semcore/utils/src/themes/light.css
@@ -695,8 +695,10 @@
   --intergalactic-chart-grid-bar-chart-hover: rgba(196, 199, 207, 0.3);
   /* Default background color of a bar in the BarChart. */
   --intergalactic-chart-grid-bar-chart-base-bg: #e0e1e9;
-  /* Use for highlighting the period on the chart grid. */
+  /* Use for highlighting a period on the chart grid. */
   --intergalactic-chart-grid-period-bg: rgba(196, 199, 207, 0.2);
+  /* Stripe color for diagonal pattern background. */
+  --intergalactic-chart-grid-period-pattern: rgba(25, 27, 35, 0.15);
   /* Border for distinguishing data sets and chart dots on the chart grid. */
   --intergalactic-chart-grid-border: #ffffff;
   /* Background color for the clickable date on the X-axis of the chart grid. */

--- a/semcore/utils/src/themes/light.json
+++ b/semcore/utils/src/themes/light.json
@@ -354,6 +354,7 @@
   "--intergalactic-chart-grid-bar-chart-hover": "rgba(196, 199, 207, 0.3)",
   "--intergalactic-chart-grid-bar-chart-base-bg": "#e0e1e9",
   "--intergalactic-chart-grid-period-bg": "rgba(196, 199, 207, 0.2)",
+  "--intergalactic-chart-grid-period-pattern": "rgba(25, 27, 35, 0.15)",
   "--intergalactic-chart-grid-border": "#ffffff",
   "--intergalactic-chart-x-axis-accent-period-active": "#6c6e79",
   "--intergalactic-chart-x-axis-accent-data-start-tracking": "rgba(0, 159, 129, 0.2)",

--- a/semcore/utils/theme/light.json
+++ b/semcore/utils/theme/light.json
@@ -2289,7 +2289,12 @@
         "period-bg": {
           "value": "rgba({gray.200}, 0.2)",
           "type": "color",
-          "description": "Use for highlighting the period on the chart grid."
+          "description": "Use for highlighting a period on the chart grid."
+        },
+        "period-pattern": {
+          "value": "rgba({gray.800}, 0.15)",
+          "type": "color",
+          "description": "Stripe color for diagonal pattern background."
         },
         "border": {
           "value": "{gray.white}",

--- a/website/docs/style/design-tokens/design-tokens.json
+++ b/website/docs/style/design-tokens/design-tokens.json
@@ -3336,7 +3336,15 @@
     "type": "color",
     "rawValue": "rgba({gray.200}, 0.2)",
     "computedValue": "rgba(196, 199, 207, 0.2)",
-    "description": "Use for highlighting the period on the chart grid.",
+    "description": "Use for highlighting a period on the chart grid.",
+    "components": ["d3-chart"]
+  },
+  {
+    "name": "--intergalactic-chart-grid-period-pattern",
+    "type": "color",
+    "rawValue": "rgba({gray.800}, 0.15)",
+    "computedValue": "rgba(25, 27, 35, 0.15)",
+    "description": "Stripe color for diagonal pattern background.",
     "components": ["d3-chart"]
   },
   {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Added a new token `--intergalactic-chart-grid-period-pattern` to use as the color of stripes in the diagonal pattern for highlighting periods on a chart grid.

## How has this been tested?

Manually checked that the new token was added to the list in documentation.

## Screenshots (if appropriate):

<img width="765" alt="image" src="https://github.com/semrush/intergalactic/assets/166654065/b8d5c953-a2cb-417f-9c5e-b8159ab13fdc">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
