### PR TITLE
[86bydr5qr][tooltip, typography] renamed HintProps to TooltipHintProps and TypographyHintProps to fix displaying in docs

### DIFF
--- a/semcore/tooltip/CHANGELOG.md
+++ b/semcore/tooltip/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [6.27.0] - 2024-04-22
+
+### Changed
+
+- Renamed types `HintProps` to `TooltipHintProps` and `HintPopperProps` to `TooltipHintPopperProps`. Old names are preserved and deprecated.
+
 ## [6.26.1] - 2024-04-16
 
 ### Changed

--- a/semcore/tooltip/src/index.d.ts
+++ b/semcore/tooltip/src/index.d.ts
@@ -45,7 +45,10 @@ declare const Tooltip: Intergalactic.Component<'div', TooltipProps, TooltipConte
   Popper: Intergalactic.Component<'div', TooltipProps, TooltipContext>;
 };
 
-export type HintProps = Intergalactic.InternalTypings.EfficientOmit<PopperProps, 'interaction'> &
+export type TooltipHintProps = Intergalactic.InternalTypings.EfficientOmit<
+  PopperProps,
+  'interaction'
+> &
   PopperTriggerProps & {
     /**
      * Tooltip text
@@ -63,7 +66,15 @@ export type HintProps = Intergalactic.InternalTypings.EfficientOmit<PopperProps,
      */
     interaction?: 'hover' | 'focus';
   };
-export type HintPopperProps = Intergalactic.InternalTypings.EfficientOmit<HintProps, 'title'>;
+export type TooltipHintPopperProps = Intergalactic.InternalTypings.EfficientOmit<
+  HintProps,
+  'title'
+>;
+
+/** @deprecated, use `TooltipHintProps` instead */
+export type HintProps = TooltipHintProps;
+/** @deprecated, use `TooltipHintPopperProps` instead */
+export type HintPopperProps = TooltipHintPopperProps;
 
 declare const Hint: Intergalactic.Component<'div', HintProps, TooltipTriggerContext> & {
   Trigger: Intergalactic.Component<'div', PopperTriggerProps, TooltipTriggerContext>;

--- a/semcore/typography/CHANGELOG.md
+++ b/semcore/typography/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.31.0] - 2024-04-22
+
+### Changed
+
+- Renamed types `HintProps` to `TypographyHintProps`. Old name is preserved and deprecated.
+
 ## [5.30.1] - 2024-04-16
 
 ### Changed

--- a/semcore/typography/src/index.d.ts
+++ b/semcore/typography/src/index.d.ts
@@ -73,7 +73,7 @@ export type ListContext = {
 
 /** @deprecated */
 export interface IHintProps extends HintProps, UnknownProperties {}
-export type HintProps = TextProps &
+export type TypographyHintProps = TextProps &
   KeyboardFocusProps & {
     /** The value responsible for the activity of the element
      * @default false
@@ -86,6 +86,9 @@ export type HintProps = TextProps &
     /** Right addon hint  */
     addonRight?: React.ElementType;
   };
+
+/** @deprecated use `TypographyHintProps` instead */
+export type HintProps = TypographyHintProps;
 
 /** @deprecated */
 export interface IBlockquoteProps extends BlockquoteProps, UnknownProperties {}

--- a/website/docs/components/tooltip/tooltip-api.md
+++ b/website/docs/components/tooltip/tooltip-api.md
@@ -16,7 +16,7 @@ import { Hint } from 'intergalactic/tooltip';
 <Hint />;
 ```
 
-<TypesView type="HintProps" :types={...types} />
+<TypesView type="TooltipHintProps" :types={...types} />
 
 ```jsx
 import { DescriptionTooltip } from 'intergalactic/tooltip';

--- a/website/docs/style/typography/typography-api.md
+++ b/website/docs/style/typography/typography-api.md
@@ -62,7 +62,7 @@ import { Hint } from 'intergalactic/typography';
 </Hint>;
 ```
 
-<TypesView type="HintProps" :types={...types} />
+<TypesView type="TypographyHintProps" :types={...types} />
 
 ## FormatText
 


### PR DESCRIPTION
## Motivation and Context

Our documentation collects types to display in global scope. So, duplication was causing displaying typography props api on the page of tooltip props api. This PR fixes it. 

## How has this been tested?

I've checked locally that now correct api props are displayed on corresponding pages.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
