### PR TITLE
[86by4t5vq][widget-empty] added role status and removed aria-hidden from image

### DIFF
--- a/semcore/widget-empty/CHANGELOG.md
+++ b/semcore/widget-empty/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.24.0] - 2024-04-22
+
+### Changed
+
+- Removed `aria-hidden=true` from image wrapper (as image has `alt=""` and already hidden from screen readers).
+- Added role `status`.
+
 ## [4.23.1] - 2024-04-16
 
 ### Changed

--- a/semcore/widget-empty/CHANGELOG.md
+++ b/semcore/widget-empty/CHANGELOG.md
@@ -6,7 +6,6 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-- Removed `aria-hidden=true` from image wrapper (as image has `alt=""` and already hidden from screen readers).
 - Added role `status`.
 
 ## [4.23.1] - 2024-04-16

--- a/semcore/widget-empty/src/WidgetEmpty.jsx
+++ b/semcore/widget-empty/src/WidgetEmpty.jsx
@@ -18,11 +18,9 @@ class WidgetEmpty extends Component {
     const SImage = 'div';
 
     return sstyled(styles)(
-      <SWidgetEmpty render={Flex}>
+      <SWidgetEmpty render={Flex} role='status'>
         {isNode(icon) && (
-          <SImage aria-hidden='true'>
-            {typeof icon === 'string' ? <img src={icon} alt='' /> : icon}
-          </SImage>
+          <SImage>{typeof icon === 'string' ? <img src={icon} alt='' /> : icon}</SImage>
         )}
         <Children />
       </SWidgetEmpty>,

--- a/semcore/widget-empty/src/WidgetEmpty.jsx
+++ b/semcore/widget-empty/src/WidgetEmpty.jsx
@@ -20,7 +20,9 @@ class WidgetEmpty extends Component {
     return sstyled(styles)(
       <SWidgetEmpty render={Flex} role='status'>
         {isNode(icon) && (
-          <SImage>{typeof icon === 'string' ? <img src={icon} alt='' /> : icon}</SImage>
+          <SImage aria-hidden='true'>
+            {typeof icon === 'string' ? <img src={icon} alt='' /> : icon}
+          </SImage>
         )}
         <Children />
       </SWidgetEmpty>,


### PR DESCRIPTION
## Motivation and Context

`WidgetEmpty` image already has `alt=""`, so we can safely remove `aria-hidden`. 

Adding role `status` will make `WidgetEmpty` content be announced for screen reader users.

## How has this been tested?

Manually with VO.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
