### PR TITLE
[86byg5qph][animation] added fallback for `onAnimationEnd` callback to be triggered even if the environment doesn't support animations

### DIFF
--- a/semcore/animation/CHANGELOG.md
+++ b/semcore/animation/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.25.0] - 2024-04-29
+
+### Changed
+
+- Added fallback for `onAnimationEnd` callback to be triggered even if the environment doesn't support animations.
+
 ## [2.24.0] - 2024-05-16
+
+### Changed
+
+- Version minor update due to children dependencies update (`@semcore/utils` [4.23.2 ~> 4.24.0]).
+
+## [2.23.0] - 2024-04-29
 
 ### Changed
 

--- a/semcore/animation/src/Animation.jsx
+++ b/semcore/animation/src/Animation.jsx
@@ -52,10 +52,11 @@ class Animation extends Component {
     render: this.props.visible || this.props.preserveNode,
     wasInvisible: !this.props.visible,
   };
-
+  animationSupported = false;
   animationContext = makeAnimationContextValue();
 
   onAnimationStart = () => {
+    this.animationSupported = true;
     const { animationsDisabled, parentAnimationContext } = this.asProps;
     const duration = animationsDisabled ? [0, 0] : propToArray(this.asProps.duration);
     const animationContext = parentAnimationContext ?? this.animationContext;
@@ -63,6 +64,7 @@ class Animation extends Component {
   };
 
   onAnimationEnd = (event) => {
+    this.animationSupported = true;
     event.stopPropagation();
     if (!this.asProps.visible && !this.props.preserveNode) {
       this.setState({ render: false });
@@ -71,6 +73,26 @@ class Animation extends Component {
     const animationContext = parentAnimationContext ?? this.animationContext;
     animationContext.onAnimationEndSubscribers.forEach((callback) => callback());
   };
+
+  animationEventFallback = () => {
+    if (!this.state.render) return;
+    if (this.animationSupported) return;
+    const delayArr = this.asProps.animationsDisabled ? [0, 0] : propToArray(this.asProps.delay);
+    const delay = this.asProps.visible ? delayArr[0] : delayArr[1];
+    const duration = this.asProps.animationsDisabled ? 0 : this.asProps.duration + 100;
+    setTimeout(() => {
+      if (this.animationSupported) return;
+      this.onAnimationEnd({ stopPropagation: () => {} });
+    }, duration + delay);
+  };
+  componentDidMount() {
+    this.animationEventFallback();
+  }
+  componentDidUpdate(prevProps, prevState) {
+    if (prevProps.visible !== this.props.visible || prevState.render !== this.state.render) {
+      this.animationEventFallback();
+    }
+  }
 
   render() {
     const SAnimation = Root;

--- a/semcore/animation/src/Animation.jsx
+++ b/semcore/animation/src/Animation.jsx
@@ -65,7 +65,9 @@ class Animation extends Component {
 
   onAnimationEnd = (event) => {
     this.animationSupported = true;
-    event.stopPropagation();
+    this.handleAnimationEnd();
+  };
+  handleAnimationEnd = () => {
     if (!this.asProps.visible && !this.props.preserveNode) {
       this.setState({ render: false });
     }
@@ -82,7 +84,7 @@ class Animation extends Component {
     const duration = this.asProps.animationsDisabled ? 0 : this.asProps.duration + 100;
     setTimeout(() => {
       if (this.animationSupported) return;
-      this.onAnimationEnd({ stopPropagation: () => {} });
+      this.handleAnimationEnd();
     }, duration + delay);
   };
   componentDidMount() {

--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.31.0] - 2024-04-29
+
+### Changed
+
+- Added mechanism to return focus to the trigger after closing the dropdown menu after item's interaction.
+
 ## [4.30.0] - 2024-05-16
 
 ### Changed

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -50,20 +50,7 @@ class DropdownMenuRoot extends Component {
   uncontrolledProps() {
     return {
       highlightedIndex: null,
-      visible: [
-        null,
-        (visible) => {
-          if (!visible) {
-            this.ignoreTriggerKeyboardFocusUntil = Date.now() + 100;
-          } else {
-            setTimeout(() => {
-              const selectedItemIndex = this.itemProps.findIndex((item) => item.selected);
-              if (selectedItemIndex === -1 || this.asProps.highlightedIndex !== null) return;
-              this.handlers.highlightedIndex(selectedItemIndex);
-            }, 0);
-          }
-        },
-      ],
+      visible: null,
     };
   }
 
@@ -399,10 +386,22 @@ class DropdownMenuRoot extends Component {
     }
   }
 
-  componentDidUpdate() {
-    if (!this.asProps.visible) {
-      this.handlers.highlightedIndex(null);
-      this.highlightedItemRef.current = null;
+  componentDidUpdate(prevProps) {
+    if (this.asProps.visible !== prevProps.visible) {
+      if (!this.asProps.visible) {
+        this.handlers.highlightedIndex(null);
+        this.highlightedItemRef.current = null;
+        this.ignoreTriggerKeyboardFocusUntil = Date.now() + 100;
+        if (document.activeElement === document.body || isFocusInside(this.popperRef.current)) {
+          setFocus(this.triggerRef.current);
+        }
+      } else {
+        setTimeout(() => {
+          const selectedItemIndex = this.itemProps.findIndex((item) => item.selected);
+          if (selectedItemIndex === -1 || this.asProps.highlightedIndex !== null) return;
+          this.handlers.highlightedIndex(selectedItemIndex);
+        }, 0);
+      }
     }
     if (
       (this.state.focusLockItemIndex !== this.asProps.highlightedIndex || !this.asProps.visible) &&

--- a/semcore/modal/__tests__/index.test.tsx
+++ b/semcore/modal/__tests__/index.test.tsx
@@ -29,6 +29,50 @@ describe('Modal', () => {
     expect(spy).toBeCalledWith('onCloseClick', expect.anything());
   });
 
+  test.sequential('should mount on open', () => {
+    const spy = vi.fn();
+    const Component = () => {
+      const [visible, setVisible] = React.useState(false);
+      return (
+        <React.Fragment>
+          <Button onClick={() => setVisible(true)} data-testid='open-modal'>
+            Open modal
+          </Button>
+          <Modal visible={visible} onClose={spy}>
+            <div data-testid='modal-content'>Hello world</div>
+          </Modal>
+        </React.Fragment>
+      );
+    };
+    const { getByTestId } = render(<Component />);
+    fireEvent.click(getByTestId('open-modal'));
+    expect(getByTestId('modal-content')).toBeTruthy();
+  });
+
+  test.sequential('should unmount on close', async () => {
+    const spy = vi.fn();
+    const Component = () => {
+      const [visible, setVisible] = React.useState(true);
+      return (
+        <React.Fragment>
+          <Button onClick={() => setVisible(true)} data-testid='open-modal'>
+            Open modal
+          </Button>
+          <Modal visible={visible} onClose={spy} animationsDisabled>
+            <div data-testid='modal-content'>Hello world</div>
+            <Button onClick={() => setVisible(false)} data-testid='close-modal'>
+              Close modal
+            </Button>
+          </Modal>
+        </React.Fragment>
+      );
+    };
+    const { getByTestId, queryByText } = render(<Component />);
+    fireEvent.click(getByTestId('close-modal'));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(queryByText('Hello world')).toBeNull();
+  });
+
   test.concurrent('should support onClose for OutsideClick', async ({ expect }) => {
     const spy = vi.fn();
     const { getByTestId } = render(

--- a/semcore/popper/__tests__/index.test.jsx
+++ b/semcore/popper/__tests__/index.test.jsx
@@ -233,6 +233,8 @@ describe('focus control', () => {
       </div>,
     );
 
+    await new Promise((r) => setTimeout(r, 0));
+
     const popperElement = getByTestId('popper');
     const div1Element = getByTestId('div-1');
     const div2Element = getByTestId('div-2');
@@ -280,6 +282,10 @@ describe('focus control', () => {
       </div>,
     );
 
+    act(() => {
+      vi.runAllTimers();
+    });
+
     expect(getByTestId('popper')).toHaveFocus();
 
     act(() => {
@@ -291,11 +297,8 @@ describe('focus control', () => {
     act(() => {
       vi.runAllTimers();
     });
+    expect(getByTestId('focusable-in-popper')).toHaveFocus();
     act(() => hidePopper());
-    act(() => {
-      vi.runAllTimers();
-    });
-    fireEvent.animationEnd(getByTestId('popper'));
     act(() => {
       vi.runAllTimers();
     });
@@ -324,8 +327,14 @@ describe('focus control', () => {
     expect(getByTestId('input-before-popper')).toHaveFocus();
     vi.useFakeTimers();
     fireEvent.keyDown(getByTestId('input-before-popper'), { key: 'Tab' });
+    act(() => {
+      vi.runAllTimers();
+    });
     act(() => getByTestId('focusable-in-trigger').focus());
-    fireEvent.focusIn(getByTestId('input-before-popper'));
+    expect(getByTestId('focusable-in-trigger')).toHaveFocus();
+    act(() => {
+      vi.runAllTimers();
+    });
     act(() => {
       vi.runAllTimers();
     });
@@ -336,11 +345,11 @@ describe('focus control', () => {
     act(() => {
       vi.runAllTimers();
     });
-    act(() => fireEvent.animationEnd(getByTestId('popper')));
     act(() => {
       vi.runAllTimers();
     });
-    expect(document.activeElement.nodeName).toBe('DIV');
+
+    expect(getByTestId('focusable-in-trigger')).toHaveFocus();
     vi.useRealTimers();
   });
 });

--- a/semcore/select/CHANGELOG.md
+++ b/semcore/select/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.41.0] - 2024-04-29
+
+### Changed
+
+- Removed mechanism that returns focus to the trigger after items selecting as it was moved to underlying `DropdownMenu`.
+
 ## [4.40.0] - 2024-05-16
 
 ### Changed
@@ -9,6 +15,12 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 - Version minor update due to children dependencies update (`@semcore/dropdown-menu` [4.29.2 ~> 4.30.0], `@semcore/popper` [5.31.0 ~> 5.32.0]).
 
 ## [4.39.3] - 2024-05-16
+
+### Changed
+
+- Version patch update due to children dependencies update (`@semcore/dropdown-menu` [4.28.0 ~> 4.29.0], `@semcore/popper` [5.29.0 ~> 5.30.0], `@semcore/input` [4.24.0 ~> 4.24.1]).
+
+## [4.39.1] - 2024-05-10
 
 ### Changed
 

--- a/semcore/select/__tests__/index.test.tsx
+++ b/semcore/select/__tests__/index.test.tsx
@@ -333,9 +333,6 @@ describe('Select Trigger', () => {
       vi.runAllTimers();
     });
     act(() => {
-      fireEvent.animationEnd(getByTestId('menu'));
-    });
-    act(() => {
       vi.runAllTimers();
     });
     expect(getByTestId('trigger')).toHaveFocus();
@@ -343,8 +340,38 @@ describe('Select Trigger', () => {
     vi.useRealTimers();
   });
 
-  test.concurrent(
+  test.sequential(
     'focus position preserve with mouse navigation and interaction=focus',
+    async () => {
+      vi.useFakeTimers();
+      const { getByTestId } = render(
+        <Select value={['2']} disablePortal interaction='focus'>
+          <Select.Trigger aria-label='Select trigger' data-testid='trigger' tag='input' />
+          <Select.Menu data-testid='menu'>
+            <Select.Option value='1'>Option 1</Select.Option>
+            <Select.Option value='2' data-testid='option-2'>
+              Option 2
+            </Select.Option>
+          </Select.Menu>
+        </Select>,
+      );
+      act(() => getByTestId('trigger').focus());
+      act(() => {
+        vi.runAllTimers();
+      });
+      act(() => getByTestId('option-2').focus());
+      fireEvent.click(getByTestId('option-2'));
+      act(() => {
+        vi.runAllTimers();
+      });
+      expect(getByTestId('trigger')).toHaveFocus();
+
+      vi.useRealTimers();
+    },
+  );
+
+  test.sequential(
+    'focus position preserve with keyboard navigation and interaction=focus',
     async () => {
       vi.useFakeTimers();
       const { getByTestId } = render(
@@ -360,65 +387,28 @@ describe('Select Trigger', () => {
           </Select.Menu>
         </Select>,
       );
+      act(() => {
+        vi.runAllTimers();
+      });
+      fireEvent.keyDown(document.body, { key: 'Tab' });
       act(() => getByTestId('input-in-trigger').focus());
       act(() => {
         vi.runAllTimers();
       });
-      act(() => getByTestId('option-2').focus());
-      fireEvent.click(getByTestId('option-2'));
+      fireEvent.keyDown(getByTestId('input-in-trigger'), { key: 'ArrowDown' });
+      fireEvent.keyDown(getByTestId('input-in-trigger'), { key: 'Enter' });
       act(() => {
         vi.runAllTimers();
       });
       act(() => {
-        fireEvent.animationEnd(getByTestId('menu'));
-      });
-      act(() => {
         vi.runAllTimers();
       });
-      expect(document.activeElement?.tagName).toBe('BUTTON');
+
+      expect(getByTestId('input-in-trigger')).toHaveFocus();
 
       vi.useRealTimers();
     },
   );
-
-  test('focus position preserve with keyboard navigation and interaction=focus', async () => {
-    vi.useFakeTimers();
-    const { getByTestId } = render(
-      <Select value={['2']} disablePortal interaction='focus'>
-        <Select.Trigger aria-label='Select trigger' data-testid='trigger'>
-          <input data-testid='input-in-trigger' />
-        </Select.Trigger>
-        <Select.Menu data-testid='menu'>
-          <Select.Option value='1'>Option 1</Select.Option>
-          <Select.Option value='2' data-testid='option-2'>
-            Option 2
-          </Select.Option>
-        </Select.Menu>
-      </Select>,
-    );
-    act(() => {
-      vi.runAllTimers();
-    });
-    fireEvent.keyDown(document.body, { key: 'Tab' });
-    act(() => getByTestId('input-in-trigger').focus());
-    act(() => {
-      vi.runAllTimers();
-    });
-    fireEvent.keyDown(getByTestId('input-in-trigger'), { key: 'ArrowDown' });
-    fireEvent.keyDown(getByTestId('input-in-trigger'), { key: 'Enter' });
-    act(() => {
-      vi.runAllTimers();
-    });
-    act(() => {
-      fireEvent.animationEnd(getByTestId('menu'));
-    });
-    act(() => {
-      vi.runAllTimers();
-    });
-    expect(document.activeElement?.tagName).toBe('INPUT');
-
-    vi.useRealTimers();
-  });
 });
 
 describe('Option.Checkbox', () => {
@@ -476,13 +466,13 @@ describe('InputSearch', () => {
   test.concurrent('should renders correctly', async ({ task }) => {
     const component = (
       <div style={{ width: 200 }}>
-        <Select>
+        <Select visible disablePortal>
           <InputSearch />
         </Select>
-        <Select>
+        <Select visible disablePortal>
           <InputSearch defaultValue='test' />
         </Select>
-        <Select size='l'>
+        <Select size='l' visible disablePortal>
           <InputSearch />
         </Select>
       </div>

--- a/semcore/select/src/Select.jsx
+++ b/semcore/select/src/Select.jsx
@@ -211,12 +211,6 @@ class RootSelect extends Component {
     this.handlers.value(newValue, e);
     if (!multiselect) {
       this.handlers.visible(false);
-      setTimeout(() => {
-        if (interaction !== 'focus') {
-          setFocus(this.triggerRef.current);
-          return;
-        }
-      }, 0);
     }
   };
 

--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.26.0] - 2024-04-29
+
+### Fixed
+
+- In some cases focus was not returned after focus lock was released.
+
 ## [4.25.0] - 2024-05-15
 
 ### Added

--- a/semcore/utils/src/use/useFocusLock.ts
+++ b/semcore/utils/src/use/useFocusLock.ts
@@ -172,21 +172,16 @@ const useFocusLockHook = (
   const returnFocus = React.useCallback(() => {
     const trapNode = trapRef.current;
     if (trapNode && !isFocusInside(trapNode)) return;
-    const focusMastersStackCount = focusMastersStack.length;
     if (typeof returnFocusTo === 'object' && returnFocusTo?.current) {
       const returnFocusNode = returnFocusTo?.current;
       setTimeout(() => {
-        if (focusMastersStackCount !== focusMastersStack.length) {
-          setFocus(returnFocusNode, trapNode);
-        }
+        setFocus(returnFocusNode, trapNode);
       }, 0);
     }
     if (returnFocusTo === 'auto' && autoTriggerRef.current) {
       const autoTrigger = autoTriggerRef.current;
       setTimeout(() => {
-        if (focusMastersStackCount !== focusMastersStack.length) {
-          setFocus(autoTrigger, trapNode);
-        }
+        setFocus(autoTrigger, trapNode);
       }, 0);
     }
   }, [returnFocusTo]);
@@ -217,12 +212,14 @@ const useFocusLockHook = (
     document.body.addEventListener('keydown', handleKeyboardEvent);
     document.body.addEventListener(syntheticEvents.keydown, handleKeyboardEvent);
 
-    if (autoFocus)
-      setFocus(
-        trapRef.current,
-        typeof returnFocusTo === 'object' ? returnFocusTo?.current : document.body,
-      );
-
+    if (autoFocus) {
+      setTimeout(() => {
+        setFocus(
+          trapRef.current!,
+          typeof returnFocusTo === 'object' ? returnFocusTo?.current : document.body,
+        );
+      }, 0);
+    }
     return () => {
       document.body.removeEventListener('focusout', handleFocusOut as any);
       document.body.removeEventListener(syntheticEvents.blur, handleFocusOut as any);

--- a/semcore/utils/src/use/useFocusLock.ts
+++ b/semcore/utils/src/use/useFocusLock.ts
@@ -172,16 +172,21 @@ const useFocusLockHook = (
   const returnFocus = React.useCallback(() => {
     const trapNode = trapRef.current;
     if (trapNode && !isFocusInside(trapNode)) return;
+    const focusMastersStackCount = focusMastersStack.length;
     if (typeof returnFocusTo === 'object' && returnFocusTo?.current) {
       const returnFocusNode = returnFocusTo?.current;
       setTimeout(() => {
-        setFocus(returnFocusNode, trapNode);
+        if (focusMastersStackCount !== focusMastersStack.length) {
+          setFocus(returnFocusNode, trapNode);
+        }
       }, 0);
     }
     if (returnFocusTo === 'auto' && autoTriggerRef.current) {
       const autoTrigger = autoTriggerRef.current;
       setTimeout(() => {
-        setFocus(autoTrigger, trapNode);
+        if (focusMastersStackCount !== focusMastersStack.length) {
+          setFocus(autoTrigger, trapNode);
+        }
       }, 0);
     }
   }, [returnFocusTo]);


### PR DESCRIPTION
## Motivation and Context

Our fade out mechanisms (e.g. in Modal) relies on `onAimationEnd` to be called. It's never called in tests, so in tests our Modals never closes. This PR fixes it.

## How has this been tested?

I tested manually that in browser the fallback is never called.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [x] I have added new unit tests on added of fixed functionality.
