### PR TITLE
[86byq668u][date-picker] added showError prop to inputs in comapre components

### DIFF
--- a/semcore/date-picker/CHANGELOG.md
+++ b/semcore/date-picker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.40.0] - 2024-05-09
+
+### Added
+
+- `showError` property to `*Comparator.ValueDateRange` and `*Comparator.CompareDateRange` components.
+
 ## [4.39.0] - 2024-04-29
 
 ### Changed

--- a/semcore/date-picker/CHANGELOG.md
+++ b/semcore/date-picker/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 ### Added
 
 - `showError` property to `*Comparator.ValueDateRange` and `*Comparator.CompareDateRange` components.
+- Render children in `MonthDateRangeComparator.RangeCalendar`.
 
 ## [4.39.0] - 2024-04-29
 

--- a/semcore/date-picker/src/MonthDateRangeComparator.jsx
+++ b/semcore/date-picker/src/MonthDateRangeComparator.jsx
@@ -182,7 +182,12 @@ function CompareDateRange(props) {
 }
 
 function RangeCalendar(props) {
-  const { Root: SRangeCalendar, styles } = props;
+  const { Root: SRangeCalendar, styles, Children, children: hasChildren } = props;
+
+  if (hasChildren) {
+    return <Children />;
+  }
+
   return sstyled(styles)(
     <SRangeCalendar render={Flex} gap={8}>
       <Flex direction='column'>

--- a/semcore/date-picker/src/components/InputTrigger.jsx
+++ b/semcore/date-picker/src/components/InputTrigger.jsx
@@ -77,6 +77,7 @@ class SingleDateInputRoot extends Component {
       </>
     ),
     defaultDisabledDateInputAttempt: false,
+    showError: true,
   };
   state = {
     errorText: null,
@@ -115,8 +116,16 @@ class SingleDateInputRoot extends Component {
   };
 
   getMaskedInputProps() {
-    const { value, onChange, onDisplayedPeriodChange, locale, w, ariaHasPopup, ...otherProps } =
-      this.asProps;
+    const {
+      value,
+      onChange,
+      onDisplayedPeriodChange,
+      locale,
+      w,
+      ariaHasPopup,
+      showError,
+      ...otherProps
+    } = this.asProps;
 
     return {
       date: value,
@@ -130,8 +139,9 @@ class SingleDateInputRoot extends Component {
   }
 
   render() {
-    const { Children, forwardRef, styles, state } = this.asProps;
-    const { errorText, showError } = this.state;
+    const { Children, forwardRef, styles, state, showError: showErrorProps } = this.asProps;
+    const { errorText, showError: showErrorState } = this.state;
+    const showError = showErrorState && showErrorProps;
     const SSingleDateInput = Root;
 
     return sstyled(styles)(
@@ -166,6 +176,7 @@ class DateRangeRoot extends Component {
       </>
     ),
     defaultDisabledDateInputAttempt: false,
+    showError: true,
   };
   state = {
     containerFocused: false,
@@ -273,14 +284,8 @@ class DateRangeRoot extends Component {
   };
 
   getFromMaskedInputProps() {
-    const {
-      value,
-      locale,
-      onDisplayedPeriodChange,
-      ariaHasPopup,
-
-      ...otherProps
-    } = this.asProps;
+    const { value, locale, onDisplayedPeriodChange, ariaHasPopup, showError, ...otherProps } =
+      this.asProps;
 
     return assignProps(
       {
@@ -299,8 +304,15 @@ class DateRangeRoot extends Component {
     );
   }
   getToMaskedInputProps() {
-    const { value, locale, onDisplayedPeriodChange, ariaHasPopup, inputId, ...otherProps } =
-      this.asProps;
+    const {
+      value,
+      locale,
+      onDisplayedPeriodChange,
+      ariaHasPopup,
+      inputId,
+      showError,
+      ...otherProps
+    } = this.asProps;
     const ariaLabel = this.asProps.getI18nText('toDate', {
       date: this.asProps.getI18nText('input'),
     });
@@ -338,8 +350,9 @@ class DateRangeRoot extends Component {
 
   render() {
     const SDateRange = Root;
-    const { Children, styles, w, state } = this.asProps;
-    const { errorText, showError, lastChangedInput } = this.state;
+    const { Children, styles, w, state, showError: showErrorProps } = this.asProps;
+    const { errorText, lastChangedInput, showError: showErrorState } = this.state;
+    const showError = showErrorState && showErrorProps;
 
     return sstyled(styles)(
       <SDateRange

--- a/semcore/date-picker/src/index.d.ts
+++ b/semcore/date-picker/src/index.d.ts
@@ -293,11 +293,12 @@ export type BaseInputTriggerProps = InputProps &
     locale?: string;
     onDisplayedPeriodChange?: (date: Date) => void;
   };
-export type InputTriggerProps = BaseInputTriggerProps &
-  TooltipProps & {
-    value?: Date;
-    onChange?: (date: Date, event: ChangeEvent) => void;
-  };
+export type InputTriggerProps = BaseInputTriggerProps & {
+  value?: Date;
+  onChange?: (date: Date, event: ChangeEvent) => void;
+  /** Flag to show or hide error state (and tooltip with error message) on Input */
+  showError?: boolean;
+};
 
 export type RangeInputTriggerProps = BaseInputTriggerProps & {
   value?: Date[];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
* For hide Error tooltip in some cases, I've added `showError` prop to all inputs in all *Compare components
* Added render children in `MonthDateRangeComparator.RangeCalendar`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
