### PR TITLE
[86bz02uet][date-picker] fixed that some dates might shift the month when entered in the input trigger

### DIFF
--- a/semcore/date-picker/CHANGELOG.md
+++ b/semcore/date-picker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.46.2] - 2024-05-30
+
+### Fixed
+
+- Some dates might shift the month when entered in the input trigger.
+
 ## [4.46.1] - 2024-05-28
 
 ### Changed

--- a/semcore/date-picker/src/components/InputTrigger.jsx
+++ b/semcore/date-picker/src/components/InputTrigger.jsx
@@ -642,9 +642,11 @@ const MaskedInput = ({
 
       if (fulfilled) {
         const date = new Date(0, 0, 0, 0, 0, 0, 0);
-        date.setFullYear(allowedParts.year ? parseInt(year, 10) : 0);
-        date.setMonth(allowedParts.month ? parseInt(month, 10) - 1 : 0);
-        date.setDate(allowedParts.day ? parseInt(day, 10) : 1);
+        const yearParsed = allowedParts.year ? parseInt(year, 10) : 0;
+        const monthParsed = allowedParts.month ? parseInt(month, 10) - 1 : 0;
+        const dayParsed = allowedParts.day ? parseInt(day, 10) : 1;
+
+        date.setFullYear(yearParsed, monthParsed, dayParsed);
 
         if (disabledDates?.some(includesDate(dayjs(date), 'date'))) {
           onMaskPipeBlock?.(date);
@@ -694,9 +696,11 @@ const MaskedInput = ({
       const fulfilled = yearFulfilled && monthFulfilled && dayFulfilled;
       if (fulfilled) {
         const date = new Date(0, 0, 0, 0, 0, 0, 0);
-        date.setFullYear(allowedParts.year ? parseInt(year, 10) : 0);
-        date.setMonth(allowedParts.month ? parseInt(month, 10) - 1 : 0);
-        date.setDate(allowedParts.day ? parseInt(day, 10) : 1);
+        const yearParsed = allowedParts.year ? parseInt(year, 10) : 0;
+        const monthParsed = allowedParts.month ? parseInt(month, 10) - 1 : 0;
+        const dayParsed = allowedParts.day ? parseInt(day, 10) : 1;
+
+        date.setFullYear(yearParsed, monthParsed, dayParsed);
 
         onDateChange(date);
         lastKnownOuterValue.current = { year, month, day };


### PR DESCRIPTION
## Motivation and Context

Found that 

```
date.setFullYear(year);
date.setMonth(month);
date.setDate(day);
``` 

works differently from the `date.setFullYear(year, month, day);`.

And when year is 2024, month is 3 (zero-based) and day is 30, it was creating a date of May 30, 2024.

## How has this been tested?

Manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
