### PR TITLE
[86bz1pmnz][input-number] fixed value format in onChange method in input number

### DIFF
--- a/semcore/input-number/CHANGELOG.md
+++ b/semcore/input-number/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 ### Fixed
 
 - Incorrect increment/dicrement in formatted Number Inputs.
+- Removed onChange handler for the value that ends with `-` and `.` as in native input with `type="number"`.
 
 ## [5.29.2] - 2024-05-14
 

--- a/semcore/input-number/CHANGELOG.md
+++ b/semcore/input-number/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.29.3] - 2024-06-03
+
+### Fixed
+
+- Incorrect increment/dicrement in formatted Number Inputs.
+
 ## [5.29.2] - 2024-05-14
 
 ### Fixed

--- a/semcore/input-number/CHANGELOG.md
+++ b/semcore/input-number/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 ### Fixed
 
 - Incorrect increment/dicrement in formatted Number Inputs.
-- Removed onChange handler for the value that ends with `-` and `.` as in native input with `type="number"`.
+- Removed onChange handler call for the value that ends with `-` and `.` as in native input with `type="number"`.
 
 ## [5.29.2] - 2024-05-14
 

--- a/semcore/input-number/__tests__/index.test.tsx
+++ b/semcore/input-number/__tests__/index.test.tsx
@@ -143,7 +143,7 @@ describe('InputNumber', () => {
     expect(spy).lastCalledWith('-1', expect.anything());
   });
 
-  test.concurrent('Should support inputs up/down buttons click with formatted number', async () => {
+  test('Should support inputs up/down buttons click with formatted number', async () => {
     const spy = vi.fn();
     const { getByTestId } = render(
       <InputNumber>

--- a/semcore/input-number/__tests__/index.test.tsx
+++ b/semcore/input-number/__tests__/index.test.tsx
@@ -167,6 +167,55 @@ describe('InputNumber', () => {
     expect(input.value).toBe('12,344');
   });
 
+  test.concurrent('Should not call onChange if the value ends with `-`', async () => {
+    const spy = vi.fn();
+    render(
+      <InputNumber>
+        <InputNumber.Value defaultValue={'0'} onChange={spy} />
+      </InputNumber>,
+    );
+
+    await userEvent.keyboard('[Tab]');
+
+    await userEvent.keyboard('-');
+    expect(spy).not.toBeCalled();
+
+    await userEvent.keyboard('1');
+    expect(spy).lastCalledWith('-1', expect.anything());
+
+    await userEvent.keyboard('[Backspace]');
+    expect(spy).toBeCalledTimes(1);
+
+    await userEvent.keyboard('[Backspace]');
+    expect(spy).lastCalledWith('', expect.anything());
+  });
+
+  test.concurrent('Should not call onChange if the value ends with `.`', async () => {
+    const spy = vi.fn();
+    render(
+      <InputNumber>
+        <InputNumber.Value defaultValue={'0'} onChange={spy} />
+      </InputNumber>,
+    );
+
+    await userEvent.keyboard('[Tab]');
+
+    await userEvent.keyboard('1');
+    expect(spy).lastCalledWith('1', expect.anything());
+
+    await userEvent.keyboard('.');
+    expect(spy).toBeCalledTimes(1);
+
+    await userEvent.keyboard('2');
+    expect(spy).lastCalledWith('1.2', expect.anything());
+
+    await userEvent.keyboard('[Backspace]');
+    expect(spy).toBeCalledTimes(2);
+
+    await userEvent.keyboard('[Backspace]');
+    expect(spy).lastCalledWith('1', expect.anything());
+  });
+
   test.concurrent('Should support sizes', async ({ task }) => {
     const component = (
       <React.Fragment>

--- a/semcore/input-number/__tests__/index.test.tsx
+++ b/semcore/input-number/__tests__/index.test.tsx
@@ -33,7 +33,7 @@ describe('InputNumber', () => {
     expect(spy).toBeCalledWith('123.4', expect.anything());
   });
 
-  test.concurrent('Should accept format in int numbers', () => {
+  test.concurrent('Should accept format in int numbers', async () => {
     const spy = vi.fn();
     const { getByTestId } = render(
       <InputNumber>
@@ -42,8 +42,10 @@ describe('InputNumber', () => {
     );
 
     const input = getByTestId('input3') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: '12345' } });
-    expect(spy).toBeCalledWith('12345', expect.anything());
+    await userEvent.keyboard('[Tab]');
+    await userEvent.keyboard('12345');
+
+    expect(spy).lastCalledWith('12345', expect.anything());
     expect(input.value).toBe('12,345');
   });
 
@@ -139,6 +141,30 @@ describe('InputNumber', () => {
     fireEvent.click(arrowDown); // 0
     fireEvent.click(arrowDown); // -1
     expect(spy).lastCalledWith('-1', expect.anything());
+  });
+
+  test.concurrent('Should support inputs up/down buttons click with formatted number', async () => {
+    const spy = vi.fn();
+    const { getByTestId } = render(
+      <InputNumber>
+        <InputNumber.Value data-testid='input11' defaultValue={'0'} onChange={spy} />
+        <InputNumber.Controls data-testid='controls2' />
+      </InputNumber>,
+    );
+    const controls = getByTestId('controls2');
+    const input = getByTestId('input11') as HTMLInputElement;
+
+    await userEvent.keyboard('[Tab]');
+    await userEvent.keyboard('12345');
+
+    const arrowUp = controls.querySelectorAll('button')[0];
+    await userEvent.click(arrowUp);
+    expect(spy).lastCalledWith('12346', expect.anything());
+    const arrowDown = controls.querySelectorAll('button')[1];
+    await userEvent.click(arrowDown); // 12345
+    await userEvent.click(arrowDown); // 12344
+    expect(spy).lastCalledWith('12344', expect.anything());
+    expect(input.value).toBe('12,344');
   });
 
   test.concurrent('Should support sizes', async ({ task }) => {

--- a/semcore/input-number/__tests__/index.test.tsx
+++ b/semcore/input-number/__tests__/index.test.tsx
@@ -167,7 +167,7 @@ describe('InputNumber', () => {
     expect(input.value).toBe('12,344');
   });
 
-  test.concurrent('Should not call onChange if the value ends with `-`', async () => {
+  test('Should not call onChange if the value ends with `-`', async () => {
     const spy = vi.fn();
     render(
       <InputNumber>
@@ -190,7 +190,7 @@ describe('InputNumber', () => {
     expect(spy).lastCalledWith('', expect.anything());
   });
 
-  test.concurrent('Should not call onChange if the value ends with `.`', async () => {
+  test('Should not call onChange if the value ends with `.`', async () => {
     const spy = vi.fn();
     render(
       <InputNumber>

--- a/semcore/input-number/src/InputNumber.jsx
+++ b/semcore/input-number/src/InputNumber.jsx
@@ -235,13 +235,17 @@ class Value extends Component {
 
   handleChange = (event) => {
     const value = this.getFormattedValue(event.currentTarget.value);
+
+    if (value.endsWith('.') || value.endsWith('-')) {
+      this.handlers.displayValue(value);
+      return false;
+    }
+
     const digits = /[0-9.-]+/.test(value);
 
     if (digits || value === '') {
       this.handlers.value(value, event);
     }
-
-    return false;
   };
 
   handleKeyUp = (event) => {

--- a/semcore/input-number/src/InputNumber.jsx
+++ b/semcore/input-number/src/InputNumber.jsx
@@ -115,12 +115,16 @@ class Value extends Component {
     return numberFormatter.format(1111).replace(/\d/g, '');
   }
 
+  getFormattedValue = (value) => {
+    return value
+      .replace(new RegExp(`[${this.separatorThousands}]`, 'g'), '')
+      .replace(this.separatorDecimal, '.');
+  };
+
   valueParser = (value, prevValue, prevDisplayValue) => {
     const { numberFormatter } = this.props;
 
-    const stringNumber = String(value)
-      .replace(new RegExp(`[${this.separatorThousands}]`, 'g'), '')
-      .replace(this.separatorDecimal, '.');
+    const stringNumber = this.getFormattedValue(String(value));
 
     if (
       stringNumber[stringNumber.length - 1] === '.' &&
@@ -230,8 +234,8 @@ class Value extends Component {
   };
 
   handleChange = (event) => {
-    const value = event.currentTarget.value;
-    const digits = /[0-9,.-]+/.test(value);
+    const value = this.getFormattedValue(event.currentTarget.value);
+    const digits = /[0-9.-]+/.test(value);
 
     if (digits || value === '') {
       this.handlers.value(value, event);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
It was incorrect value in `onChange` handler and in stepUp/stepDown handlers if value has more then 4 digits.
I've fixed it by adding formatting to outcoming value.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually and with new test
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [X] I have added new unit tests on added of fixed functionality.
