### PR TITLE
[86bz2ddmq][input, feedback-form] fixed some types

### DIFF
--- a/semcore/feedback-form/CHANGELOG.md
+++ b/semcore/feedback-form/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [6.29.3] - 2024-06-05
+
+### Fixed
+
+- Children type for `FeedbackForm.Item`.
+
 ## [6.29.2] - 2024-05-30
 
 ### Added

--- a/semcore/feedback-form/src/index.d.ts
+++ b/semcore/feedback-form/src/index.d.ts
@@ -1,4 +1,10 @@
-import { FormProps, FieldProps } from 'react-final-form';
+import {
+  FormProps,
+  FieldProps,
+  FieldInputProps,
+  FieldMetaState,
+  FieldRenderProps,
+} from 'react-final-form';
 
 import { Intergalactic } from '@semcore/core';
 import Button from '@semcore/button';
@@ -27,7 +33,11 @@ export type FeedbackFormProps = FormProps & {
 };
 
 declare const FeedbackForm: Intergalactic.Component<'form', FeedbackFormProps> & {
-  Item: Intergalactic.Component<'div', FieldProps<any, any>>;
+  Item: Intergalactic.Component<
+    'div',
+    FieldProps<any, any>,
+    { input: FieldInputProps<any> & { state: 'normal' | 'invalid' }; meta: FieldMetaState<any> }
+  >;
   Success: typeof Box;
   Submit: typeof Button;
   Cancel: typeof Button;

--- a/semcore/input/CHANGELOG.md
+++ b/semcore/input/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.28.2] - 2024-06-04
+
+### Fixed
+
+- Type definition for Input's `placeholder` prop.
+
 ## [4.28.1] - 2024-05-28
 
 ### Changed

--- a/semcore/input/src/index.d.ts
+++ b/semcore/input/src/index.d.ts
@@ -57,6 +57,10 @@ export type InputValueProps = BoxProps &
      * @default m
      */
     size?: InputSize;
+    /**
+     * Placeholder for input
+     */
+    placeholder?: string;
   };
 
 /** @deprecated */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
From 18.3.3 in @types/react there are no `placeholder` in HTMLAttributes interface. So, we need to add this prop manually.

Also, I've fixed types for children render function in FeedbackForm.Item
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
