### PR TITLE
[global] added filter for tasks to close

### DIFF
--- a/.ci/lint-commit-message.ts
+++ b/.ci/lint-commit-message.ts
@@ -2,18 +2,12 @@
 
 import fs from 'fs/promises';
 import pc from 'picocolors';
+import { allowedScopes } from '../tools/continuous-delivery/src/utils/allowedScopes';
 
 const commitMessageFilePath = [...process.argv].pop();
 const commitMessage = await fs.readFile(commitMessageFilePath, 'utf-8');
 
 const commitTitle = commitMessage.split('\n')[0];
-
-const filterFsEntries = (scopeName: string) =>
-  !scopeName.startsWith('.') && !scopeName.startsWith('@');
-const semcoreComponents = (await fs.readdir('./semcore')).filter(filterFsEntries);
-const toolsComponents = (await fs.readdir('./tools')).filter(filterFsEntries);
-const specialScopes = ['global', 'chore', 'ci', 'website', 'docs', 'tests'];
-const allowedScopes = [...specialScopes, ...semcoreComponents, ...toolsComponents];
 
 const outputError = (message: string) => {
   // biome-ignore lint/suspicious/noConsoleLog:
@@ -73,10 +67,13 @@ if (!description) {
   outputError('Got empty description in message of format "[scope] change description"');
 }
 
+const { specialScopes, semcoreComponents, toolsComponents } = await allowedScopes();
+const allAllowedScopes = [...specialScopes, ...semcoreComponents, ...toolsComponents];
+
 const allProvidedScopes = scope.includes(',')
   ? scope.split(',').map((scope) => scope.trim())
   : [scope];
-const unknownScope = allProvidedScopes.find((scope) => !allowedScopes.includes(scope));
+const unknownScope = allProvidedScopes.find((scope) => !allAllowedScopes.includes(scope));
 
 if (unknownScope) {
   outputError(

--- a/tools/continuous-delivery/src/utils/allowedScopes.ts
+++ b/tools/continuous-delivery/src/utils/allowedScopes.ts
@@ -1,0 +1,15 @@
+import fs from 'fs/promises';
+
+export const allowedScopes = async () => {
+  const filterFsEntries = (scopeName: string) =>
+    !scopeName.startsWith('.') && !scopeName.startsWith('@');
+  const semcoreComponents = (await fs.readdir('./semcore')).filter(filterFsEntries);
+  const toolsComponents = (await fs.readdir('./tools')).filter(filterFsEntries);
+  const specialScopes = ['global', 'chore', 'ci', 'website', 'docs', 'tests'];
+
+  return {
+    specialScopes,
+    semcoreComponents,
+    toolsComponents,
+  };
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
In the previous release we've had too much task ids to close, so, I've added a little filter
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
