### PR TITLE
[scroll-area] hotfix auto resizing

### DIFF
--- a/semcore/scroll-area/CHANGELOG.md
+++ b/semcore/scroll-area/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.30.1] - 2024-06-10
+
+### Fixed
+
+- Auto resizing for `ScrollArea` should work only if pass prop `wMax` or `hMax` to the container.
+
 ## [5.30.0] - 2024-05-29
 
 ### Added

--- a/semcore/scroll-area/src/ScrollArea.jsx
+++ b/semcore/scroll-area/src/ScrollArea.jsx
@@ -92,7 +92,7 @@ class ScrollAreaRoot extends Component {
     let maxHeight = Number.parseInt(style.getPropertyValue('max-height'));
 
     if (maxWidth) {
-      if (parent.scrollWidth > parentRect.width) {
+      if (wMax && parent.scrollWidth > parentRect.width) {
         const diff = parent.scrollWidth - parentRect.width;
 
         if (diff < maxWidth) {
@@ -110,7 +110,7 @@ class ScrollAreaRoot extends Component {
     }
 
     if (maxHeight) {
-      if (parent.scrollHeight > parentRect.height) {
+      if (hMax && parent.scrollHeight > parentRect.height) {
         const diff = parent.scrollHeight - parentRect.height;
 
         if (diff < maxHeight) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fixed logic for recalculate ScrollArea container. We should do it once if not pass `wMax` or `hMax`.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
