### PR TITLE
[86bz0343c][notice-bubble] ref and focus api

### DIFF
--- a/semcore/notice-bubble/CHANGELOG.md
+++ b/semcore/notice-bubble/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.36.0] - 2024-06-11
+
+### Added
+
+- Notice bubble manager `.add()` method now returns `ref` and `focus()`.
+
 ## [5.35.0] - 2024-06-13
 
 ### Changed

--- a/semcore/notice-bubble/src/NoticeBubbleManager.js
+++ b/semcore/notice-bubble/src/NoticeBubbleManager.js
@@ -1,5 +1,7 @@
 import EventEmitter from '@semcore/utils/lib/eventEmitter';
 import { callAllEventHandlers } from '@semcore/utils/lib/assignProps';
+import { setFocus } from '@semcore/utils/lib/use/useFocusLock';
+import React from 'react';
 
 const EVENT_NAME = 'CHANGE';
 
@@ -34,9 +36,12 @@ class NoticeBubbleManager {
 
   add(props) {
     const uid = this.counter++;
+    const ref = React.createRef();
+    const focus = () => setTimeout(() => setFocus(ref.current), 0);
     const item = this.createItem({
       uid,
       visible: props.initialAnimation ? true : undefined,
+      forwardRef: ref,
       ...props,
     });
     this.items.push(item);
@@ -45,6 +50,8 @@ class NoticeBubbleManager {
       uid,
       update: this.update.bind(this, uid),
       remove: this.remove.bind(this, uid),
+      ref,
+      focus,
     };
   }
 

--- a/semcore/notice-bubble/src/index.d.ts
+++ b/semcore/notice-bubble/src/index.d.ts
@@ -118,6 +118,8 @@ declare class NoticeBubbleManager implements NoticeBubbleManagerClass {
     uid: string;
     update: (props: Partial<NoticeBubbleInfoProps> | Partial<NoticeBubbleWarningProps>) => boolean;
     remove: () => boolean;
+    ref: React.RefObject<HTMLDivElement>;
+    focus: () => void;
   };
   /**
    * Updates notice by uid.

--- a/semcore/notice-bubble/src/index.d.ts
+++ b/semcore/notice-bubble/src/index.d.ts
@@ -75,6 +75,8 @@ export type NoticeBubbleManagerClass = {
     uid: string;
     update: (props: Partial<NoticeBubbleInfoProps> | Partial<NoticeBubbleWarningProps>) => boolean;
     remove: () => boolean;
+    ref: React.RefObject<HTMLDivElement>;
+    focus: () => void;
   };
   /**
    * Updates notice by uid.

--- a/website/docs/components/notice-bubble/examples/reload_action.tsx
+++ b/website/docs/components/notice-bubble/examples/reload_action.tsx
@@ -7,7 +7,7 @@ const manager = new NoticeBubbleManager();
 
 const Demo = () => {
   const handleClick = () => {
-    manager.add({
+    const { focus } = manager.add({
       children: 'Data for 5 new profiles is ready. Please reload the page to view it.',
       action: (
         <Button theme='invert' addonLeft={ReloadM}>
@@ -17,6 +17,7 @@ const Demo = () => {
       initialAnimation: true,
       duration: 0,
     });
+    focus();
   };
 
   return (

--- a/website/docs/components/notice-bubble/examples/undo_action.tsx
+++ b/website/docs/components/notice-bubble/examples/undo_action.tsx
@@ -7,7 +7,7 @@ const manager = new NoticeBubbleManager();
 
 const Demo = () => {
   const handleClick = () => {
-    manager.add({
+    const { focus } = manager.add({
       children: (
         <>
           Link was moved to <Link href='#'>Cats from outer space group</Link>
@@ -17,6 +17,7 @@ const Demo = () => {
       initialAnimation: true,
       duration: 0,
     });
+    focus();
   };
 
   return (


### PR DESCRIPTION
## Motivation and Context

This PR simply adds essential apis to notice bubble – function that sets focus on it and ref, both returned by the `add()` method of notice bubble manager.

## How has this been tested?

Manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
