### PR TITLE
[85zt70g3k][notice-bubble] fixed not called mouse leave on bubble resize

### DIFF
--- a/semcore/notice-bubble/CHANGELOG.md
+++ b/semcore/notice-bubble/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.34.0] - 2024-06-10
+
+### Fixed
+
+- Fixed case when `NoticeBubble` was resized and mouse left it without any mouse move so `NoticeBubble` didn't hide automatically.
+
 ## [5.33.1] - 2024-05-28
 
 ### Changed

--- a/semcore/notice-bubble/src/utils.js
+++ b/semcore/notice-bubble/src/utils.js
@@ -3,16 +3,19 @@ class Timer {
     this.callback = callback;
     this.delay = delay;
     this.remaining = delay;
+    this.paused = false;
     this.resume();
   }
 
   pause() {
     clearTimeout(this.timerId);
     this.remaining -= Date.now() - this.start;
+    this.paused = true;
   }
 
   resume() {
     this.start = Date.now();
+    this.paused = false;
     clearTimeout(this.timerId);
     this.timerId = setTimeout(this.callback, this.remaining);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

This PR fixes a rare edge case with Notice global – if notice is resizing due to inner children unmount, the cursor might found itself out of notice but MouseLeave event will not be triggered.

https://github.com/semrush/intergalactic/assets/31261408/bade3a52-fc74-44a7-bab1-41f7de8c2583

To fix it, I've added listening to the body MouseMove event when notice disappear timer is paused.

## How has this been tested?

It's very hard to test, so only manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
