### PR TITLE
[86bz5pzaa][dropdown-menu] fixed unexpected autofocus

### DIFF
--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.33.8] - 2024-06-11
+
+### Fixed
+
+- DropdownMenu was getting unexpected autofocus if nothing else on page is focused.
+
 ## [4.33.7] - 2024-06-10
 
 ### Changed

--- a/semcore/dropdown-menu/__tests__/index.test.tsx
+++ b/semcore/dropdown-menu/__tests__/index.test.tsx
@@ -239,12 +239,7 @@ describe('DropdownMenu', () => {
     await expect(highlightedIndex).toBe(2);
   });
   test.sequential("doesn't autofocus trigger when closed on just rerender", async ({ expect }) => {
-    let rerender: (() => void) | undefined = undefined;
-
     const Component = () => {
-      const [, set] = React.useState(0);
-      rerender = () => set((v) => v + 1);
-
       return (
         <DropdownMenu>
           <DropdownMenu.Trigger tag='button' data-testid='dd-button-trigger'>
@@ -261,7 +256,7 @@ describe('DropdownMenu', () => {
     const component = render(<Component />);
 
     await new Promise((resolve) => setTimeout(resolve, 1));
-    rerender();
+    component.rerender(<Component />);
     await new Promise((resolve) => setTimeout(resolve, 1));
     expect(component.getByTestId('dd-button-trigger')).not.toHaveFocus();
   });

--- a/semcore/dropdown-menu/__tests__/index.test.tsx
+++ b/semcore/dropdown-menu/__tests__/index.test.tsx
@@ -238,6 +238,33 @@ describe('DropdownMenu', () => {
     await new Promise((resolve) => setTimeout(resolve, 1));
     await expect(highlightedIndex).toBe(2);
   });
+  test.sequential("doesn't autofocus trigger when closed on just rerender", async ({ expect }) => {
+    let rerender: (() => void) | undefined = undefined;
+
+    const Component = () => {
+      const [, set] = React.useState(0);
+      rerender = () => set((v) => v + 1);
+
+      return (
+        <DropdownMenu>
+          <DropdownMenu.Trigger tag='button' data-testid='dd-button-trigger'>
+            Trigger
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Menu>
+            <DropdownMenu.Item>Item 1</DropdownMenu.Item>
+            <DropdownMenu.Item>Item 2</DropdownMenu.Item>
+            <DropdownMenu.Item selected>Item 3</DropdownMenu.Item>
+          </DropdownMenu.Menu>
+        </DropdownMenu>
+      );
+    };
+    const component = render(<Component />);
+
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    rerender();
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    expect(component.getByTestId('dd-button-trigger')).not.toHaveFocus();
+  });
   test.sequential('arrows open/close', async ({ expect }) => {
     let visible = undefined;
     render(

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -387,7 +387,8 @@ class DropdownMenuRoot extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.asProps.visible !== prevProps.visible && prevProps.visible !== undefined) {
+    const visibilityChanged = this.asProps.visible !== prevProps.visible;
+    if (visibilityChanged && prevProps.visible !== undefined) {
       if (!this.asProps.visible) {
         this.handlers.highlightedIndex(null);
         this.highlightedItemRef.current = null;
@@ -397,7 +398,7 @@ class DropdownMenuRoot extends Component {
         }
       }
     }
-    if (this.asProps.visible !== prevProps.visible) {
+    if (visibilityChanged && this.asProps.visible) {
       setTimeout(() => {
         const selectedItemIndex = this.itemProps.findIndex((item) => item.selected);
         if (selectedItemIndex === -1 || this.asProps.highlightedIndex !== null) return;

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -395,13 +395,14 @@ class DropdownMenuRoot extends Component {
         if (document.activeElement === document.body || isFocusInside(this.popperRef.current)) {
           setFocus(this.triggerRef.current);
         }
-      } else {
-        setTimeout(() => {
-          const selectedItemIndex = this.itemProps.findIndex((item) => item.selected);
-          if (selectedItemIndex === -1 || this.asProps.highlightedIndex !== null) return;
-          this.handlers.highlightedIndex(selectedItemIndex);
-        }, 0);
       }
+    }
+    if (this.asProps.visible !== prevProps.visible) {
+      setTimeout(() => {
+        const selectedItemIndex = this.itemProps.findIndex((item) => item.selected);
+        if (selectedItemIndex === -1 || this.asProps.highlightedIndex !== null) return;
+        this.handlers.highlightedIndex(selectedItemIndex);
+      }, 0);
     }
     if (
       (this.state.focusLockItemIndex !== this.asProps.highlightedIndex || !this.asProps.visible) &&

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -387,7 +387,7 @@ class DropdownMenuRoot extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.asProps.visible !== prevProps.visible) {
+    if (this.asProps.visible !== prevProps.visible && prevProps.visible !== undefined) {
       if (!this.asProps.visible) {
         this.handlers.highlightedIndex(null);
         this.highlightedItemRef.current = null;


### PR DESCRIPTION
## Motivation and Context

DropdownMenu has a mechanism to focus the trigger after the change of visibility from visible to hidden. But it also happens on the component mount if it's just hidden and wasn't visible. This PR fixes it. 

## How has this been tested?

Manually and with added unit test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [x] I have added new unit tests on added of fixed functionality.
