### PR TITLE
[86bz53qtf][data-table] added passing ref to table.body to a scroll.container

### DIFF
--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.40.4] - 2024-06-14
+
+### Added
+
+- Possibility to pass `ref` property to `Datatable.Body` and set it to a real table body container - `Scroll.Containter`.
+
 ## [4.40.3] - 2024-06-13
 
 ### Fixed

--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Added
 
-- Possibility to pass `ref` property to `Datatable.Body` and set it to a real table body container - `Scroll.Containter`.
+- Possibility to pass `scrollContainerRef` property to `Datatable.Body` and set it to a real table body container - `Scroll.Containter`.
 
 ## [4.40.3] - 2024-06-13
 

--- a/semcore/data-table/src/Body.tsx
+++ b/semcore/data-table/src/Body.tsx
@@ -290,6 +290,7 @@ class Body extends Component<AsProps, State> {
       disabledScroll,
       renderRows,
       animationsDisabled,
+      forwardRef,
     } = this.asProps;
 
     const columnsInitialized = columns.reduce((sum, { width }) => sum + width, 0) > 0 || testEnv;
@@ -325,6 +326,11 @@ class Body extends Component<AsProps, State> {
       return <SBodyWrapper>{body}</SBodyWrapper>;
     }
 
+    const scrollContainerRefs = [$scrollRef, this.scrollContainerRef];
+    if (forwardRef) {
+      scrollContainerRefs.push(forwardRef);
+    }
+
     return (
       <SBodyWrapper>
         <ScrollArea
@@ -335,7 +341,7 @@ class Body extends Component<AsProps, State> {
           onScroll={callAllEventHandlers(onScroll, this.handleScrollAreaScroll)}
         >
           <ScrollArea.Container
-            ref={forkRef($scrollRef, this.scrollContainerRef)}
+            ref={forkRef(...scrollContainerRefs)}
             role='rowgroup'
             focusRingTopOffset={'3px'}
           >

--- a/semcore/data-table/src/Body.tsx
+++ b/semcore/data-table/src/Body.tsx
@@ -38,6 +38,7 @@ type AsProps = {
   disabledScroll?: boolean;
   uid?: string;
   animationsDisabled?: boolean;
+  scrollContainerRef: React.Ref<HTMLDivElement>;
 };
 
 type State = {
@@ -290,7 +291,7 @@ class Body extends Component<AsProps, State> {
       disabledScroll,
       renderRows,
       animationsDisabled,
-      forwardRef,
+      scrollContainerRef,
     } = this.asProps;
 
     const columnsInitialized = columns.reduce((sum, { width }) => sum + width, 0) > 0 || testEnv;
@@ -327,8 +328,8 @@ class Body extends Component<AsProps, State> {
     }
 
     const scrollContainerRefs = [$scrollRef, this.scrollContainerRef];
-    if (forwardRef) {
-      scrollContainerRefs.push(forwardRef);
+    if (scrollContainerRef) {
+      scrollContainerRefs.push(scrollContainerRef);
     }
 
     return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
I've added passing for datatable.body ref to a scroll.container

Could be useful to manually set focus on table body

```
...
someHandle = () => {
    const tableBody = this.bodyRef.current;

    if (tableBody) {
      tableBody.tabIndex = 0;
      tableBody.focus();
      tableBody.tabIndex = -1;
    }
  };
...
<DataTable.Body ref={this.bodyRef} />
...
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
