### PR TITLE
[86bz683f5][skeleton] fixed Error about foreignObject on elements other than svg

### DIFF
--- a/semcore/skeleton/CHANGELOG.md
+++ b/semcore/skeleton/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.28.1] - 2024-06-14
+
+### Fixed
+
+- Error about `foreignObject` on elements other than `svg`.
+
 ## [5.28.0] - 2024-06-13
 
 ### Changed

--- a/semcore/skeleton/src/Skeleton.jsx
+++ b/semcore/skeleton/src/Skeleton.jsx
@@ -23,9 +23,19 @@ class SkeletonRoot extends Component {
     duration: 2000,
   };
 
+  screenReaderContent() {
+    const { getI18nText } = this.asProps;
+
+    return (
+      <ScreenReaderOnly aria-live='polite' role='status' aria-atomic='true'>
+        {getI18nText('loading')}
+      </ScreenReaderOnly>
+    );
+  }
+
   render() {
     const SSkeleton = Root;
-    const { Children, styles, duration, hidden, getI18nText } = this.asProps;
+    const { Children, styles, duration, hidden, getI18nText, tag } = this.asProps;
 
     if (hidden) return null;
 
@@ -36,11 +46,13 @@ class SkeletonRoot extends Component {
         aria-busy='true'
         aria-label={getI18nText('loading')}
       >
-        <foreignObject x='0' y='0' width='0' height='0'>
-          <ScreenReaderOnly aria-live='polite' role='status' aria-atomic='true'>
-            {getI18nText('loading')}
-          </ScreenReaderOnly>
-        </foreignObject>
+        {tag === 'svg' ? (
+          <foreignObject x='0' y='0' width='0' height='0'>
+            {this.screenReaderContent()}
+          </foreignObject>
+        ) : (
+          this.screenReaderContent()
+        )}
         <Children />
       </SSkeleton>,
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Little fix on how we render screen reader text on elements other then svg in Skeleton
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
