### PR TITLE
[86bz79uec][popover, dropdown] Fix focusable popovers

### DIFF
--- a/semcore/dropdown/CHANGELOG.md
+++ b/semcore/dropdown/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.32.2] - 2024-06-14
+
+### Fixed
+
+- Dropdown with any `interaction` except `none` should be opened by pressing `Enter` or `Space`.
+
 ## [4.32.1] - 2024-06-14
 
 ### Fixed

--- a/semcore/dropdown/src/Dropdown.jsx
+++ b/semcore/dropdown/src/Dropdown.jsx
@@ -82,7 +82,7 @@ class Dropdown extends Component {
     if (e.key === ' ' && INTERACTION_TAGS.includes(e.target.tagName)) return;
     if (e.key === 'Enter' && e.target.tagName === 'TEXTAREA') return;
 
-    if (['Enter', ' '].includes(e.key) && interaction === 'click') {
+    if (['Enter', ' '].includes(e.key) && interaction !== 'none') {
       e.preventDefault();
       this.handlers.visible(true);
     }

--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.36.1] - 2024-06-14
+
+### Added
+
+- Possibility to open `focusable` popper by click on it (if the trigger is already focused).
+
 ## [5.36.0] - 2024-06-13
 
 ### Changed

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -114,7 +114,7 @@ class Popper extends Component {
       popper: [['onMouseEnter', 'onFocusCapture', 'onTouchStart'], ['onMouseLeave']],
     },
     focus: {
-      trigger: [['onFocus'], ['onBlur']],
+      trigger: [['onFocus', 'onClick'], ['onBlur']],
       // to intercept faster than onBlur on the trigger
       popper: [['onFocusCapture'], ['onBlur']],
     },

--- a/website/docs/components/counter/examples/counter_in_forms.tsx
+++ b/website/docs/components/counter/examples/counter_in_forms.tsx
@@ -42,7 +42,7 @@ const Demo = () => {
   return (
     <Flex direction='column' w={350}>
       <Flex mb={2} justifyContent='space-between'>
-        <Flex>
+        <Flex alignItems={'center'}>
           <Text size={200} tag='label' htmlFor='limited-text-field'>
             Project description
           </Text>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
I've added possibility to open `focusable` popper by click on it (if the trigger is already focused).
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
