### PR TITLE
[86bz5nx20][ellipsis] fixed incorrect calculation of text width with font settings

### DIFF
--- a/semcore/ellipsis/CHANGELOG.md
+++ b/semcore/ellipsis/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.29.1] - 2024-06-19
+
+### Fixed
+
+- Incorrect calculation of text width with font settings: `font-feature-settings` or `font-variant-numeric`.
+
 ## [2.29.0] - 2024-06-13
 
 ### Changed

--- a/semcore/ellipsis/src/Ellipsis.tsx
+++ b/semcore/ellipsis/src/Ellipsis.tsx
@@ -101,6 +101,9 @@ const createMeasurerElement = (element: HTMLDivElement) => {
   temporaryElement.style.fontFamily = styleElement.getPropertyValue('font-family');
   temporaryElement.style.fontSize = styleElement.getPropertyValue('font-size');
   temporaryElement.style.fontWeight = styleElement.getPropertyValue('font-weight');
+  temporaryElement.style.fontFeatureSettings =
+    styleElement.getPropertyValue('font-feature-settings');
+  temporaryElement.style.fontVariantNumeric = styleElement.getPropertyValue('font-variant-numeric');
 
   temporaryElement.innerHTML = element.innerHTML;
   return temporaryElement;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
We didn't include few font settings in calculation width login in `Ellipsis`. I've fixed it.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
