### PR TITLE
[86bz7edrx][spin, skeleton] rolled back and removed foregin object with aria-live element

### DIFF
--- a/semcore/skeleton/CHANGELOG.md
+++ b/semcore/skeleton/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.29.0] - 2024-06-20
+
+### Changed
+
+- Removed inner `foreignObject` element with `aria-live` element as it doesn't work properly with the newest screen readers.
+
 ## [5.28.1] - 2024-06-14
 
 ### Fixed

--- a/semcore/skeleton/src/Skeleton.jsx
+++ b/semcore/skeleton/src/Skeleton.jsx
@@ -4,7 +4,6 @@ import { Box } from '@semcore/flex-box';
 import uniqueIDEnhancement from '@semcore/utils/lib/uniqueID';
 import i18nEnhance from '@semcore/utils/lib/enhances/i18nEnhance';
 import { localizedMessages } from './translations/__intergalactic-dynamic-locales';
-import { ScreenReaderOnly } from '@semcore/utils/lib/ScreenReaderOnly';
 
 import style from './style/skeleton.shadow.css';
 
@@ -23,16 +22,6 @@ class SkeletonRoot extends Component {
     duration: 2000,
   };
 
-  screenReaderContent() {
-    const { getI18nText } = this.asProps;
-
-    return (
-      <ScreenReaderOnly aria-live='polite' role='status' aria-atomic='true'>
-        {getI18nText('loading')}
-      </ScreenReaderOnly>
-    );
-  }
-
   render() {
     const SSkeleton = Root;
     const { Children, styles, duration, hidden, getI18nText, tag } = this.asProps;
@@ -45,16 +34,7 @@ class SkeletonRoot extends Component {
         durationAnim={`${duration}ms`}
         aria-busy='true'
         aria-label={getI18nText('loading')}
-      >
-        {tag === 'svg' ? (
-          <foreignObject x='0' y='0' width='0' height='0'>
-            {this.screenReaderContent()}
-          </foreignObject>
-        ) : (
-          this.screenReaderContent()
-        )}
-        <Children />
-      </SSkeleton>,
+      />,
     );
   }
 }

--- a/semcore/spin/CHANGELOG.md
+++ b/semcore/spin/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.29.0] - 2024-06-20
+
+### Changed
+
+- Removed inner `foreignObject` element with `aria-live` element as it doesn't work properly with the newest screen readers.
+
 ## [5.28.0] - 2024-06-26
 
 ### Changed

--- a/semcore/spin/src/Spin.jsx
+++ b/semcore/spin/src/Spin.jsx
@@ -4,7 +4,6 @@ import { Box } from '@semcore/flex-box';
 import resolveColorEnhance from '@semcore/utils/lib/enhances/resolveColorEnhance';
 import i18nEnhance from '@semcore/utils/lib/enhances/i18nEnhance';
 import { localizedMessages } from './translations/__intergalactic-dynamic-locales';
-import { ScreenReaderOnly } from '@semcore/utils/lib/ScreenReaderOnly';
 
 import style from './style/spin.shadow.css';
 
@@ -29,11 +28,6 @@ class RootSpin extends Component {
         aria-busy='true'
         aria-label={getI18nText('loading')}
       >
-        <foreignObject x='0' y='0' width='0' height='0'>
-          <ScreenReaderOnly aria-live='polite' role='status' aria-atomic='true'>
-            {getI18nText('loading')}
-          </ScreenReaderOnly>
-        </foreignObject>
         <path d='M16.98 20.6256C17.5433 21.6013 18.8054 21.9477 19.6718 21.2274C21.567 19.6517 22.9447 17.5183 23.5911 15.1058C24.4148 12.0317 23.9836 8.75621 22.3923 6C20.801 3.24379 18.18 1.23261 15.1058 0.408891C12.6934 -0.237529 10.1569 -0.111098 7.84473 0.742337C6.78777 1.13246 6.45667 2.39867 7.02 3.37439V3.37439C7.58333 4.3501 8.83088 4.65471 9.91792 4.35856C11.2588 3.99325 12.6844 3.984 14.0498 4.34987C16.0788 4.89352 17.8087 6.2209 18.8589 8.04C19.9092 9.8591 20.1938 12.0209 19.6501 14.0498C19.2843 15.4153 18.5634 16.6453 17.5766 17.6239C16.7766 18.4172 16.4167 19.6499 16.98 20.6256V20.6256Z' />
         <Children />
       </SSpin>,


### PR DESCRIPTION
## Motivation and Context

It was found that latest screen reader doesn't announce aria-live elements on first mount. So, having `foreginObject` has no sense.

This PR should be merged alongside PR with documentation update that asks developers to wrap spinners and skeletons into aria-live containers.

## How has this been tested?

No testing required.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.
- [x] Rollback.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
