### PR TITLE
[86bz80nxv][website] added special handling of external types in api types preview modal

### DIFF
--- a/website/docs/.vitepress/theme/FormattedTypeString.vue
+++ b/website/docs/.vitepress/theme/FormattedTypeString.vue
@@ -9,6 +9,15 @@
 
   <dialog ref="dialog" @click="handleDialogClick">
     <TypesView :type="subTypeModal.referenceTo" :types="types" v-if="subTypeModal && types[subTypeModal.referenceTo]" />
+    <div v-if="subTypeModal && !types[subTypeModal.referenceTo]">
+      <h3 class="types-viewer-name">External type</h3>
+      <div>
+        Type <code>{{ subTypeModal.displayText }}</code> is external and not available in the documentation preview.
+      </div>
+      <div>
+        You still can inspect it in <a .href="`https://github.com/search?q=repo%3Asemrush%2Fintergalactic%20${encodeURIComponent(subTypeModal.referenceTo)}&type=code`" target="_blank">the source code</a>.
+      </div>
+    </div>
     <button @click="handleDialogClose" aria-label="close dialog" class="close-dialog">✕</button>
   </dialog>
 </template>


### PR DESCRIPTION
## Motivation and Context

Sometimes our types are referring to external types that our documentation should not traverse as it may take to much time to generate docs.

## How has this been tested?

On popper api page.

## Screenshots (if appropriate):

<img width="642" alt="Screenshot 2024-06-27 at 18 08 41" src="https://github.com/semrush/intergalactic/assets/31261408/a1201418-189f-4d3f-a37c-4c13f29b0ecd">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
