### PR TITLE
[86bzfnn98][breadcrumbs] fixed last item non focusable

### DIFF
--- a/semcore/breadcrumbs/CHANGELOG.md
+++ b/semcore/breadcrumbs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.34.2] - 2024-07-04
+
+### Fixed
+
+- Incorrect focus of the last item in Breadcrumbs.
+
 ## [5.34.1] - 2024-06-24
 
 ### Fixed

--- a/semcore/breadcrumbs/__tests__/index.test.tsx
+++ b/semcore/breadcrumbs/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { snapshot } from '@semcore/testing-utils/snapshot';
 import { expect, test, describe, beforeEach } from '@semcore/testing-utils/vitest';
-import { render, cleanup } from '@semcore/testing-utils/testing-library';
+import { render, cleanup, userEvent } from '@semcore/testing-utils/testing-library';
 import { axe } from '@semcore/testing-utils/axe';
 
 import Breadcrumbs from '../src';
@@ -61,6 +61,31 @@ describe('Breadcrumbs', () => {
     );
 
     await expect(await snapshot(component)).toMatchImageSnapshot(task);
+  });
+
+  test.concurrent('Should not be focusable last item', async ({ task }) => {
+    const component = (
+      <Breadcrumbs>
+        <Breadcrumbs.Item data-testid='dashboard'>Dashboard</Breadcrumbs.Item>
+        <Breadcrumbs.Item data-testid='projects'>Projects</Breadcrumbs.Item>
+        <Breadcrumbs.Item data-testid='site' active>
+          semrush.com
+        </Breadcrumbs.Item>
+      </Breadcrumbs>
+    );
+
+    const { getByTestId } = render(component);
+
+    await userEvent.keyboard('[Tab]');
+    expect(getByTestId('dashboard')).toHaveFocus();
+
+    await userEvent.keyboard('[Tab]');
+    expect(getByTestId('projects')).toHaveFocus();
+
+    await userEvent.keyboard('[Tab]');
+    expect(getByTestId('dashboard')).not.toHaveFocus();
+    expect(getByTestId('projects')).not.toHaveFocus();
+    expect(getByTestId('site')).not.toHaveFocus();
   });
 
   test('a11y', async () => {

--- a/semcore/breadcrumbs/src/Breadcrumbs.jsx
+++ b/semcore/breadcrumbs/src/Breadcrumbs.jsx
@@ -51,7 +51,7 @@ class Item extends Component {
 
   render() {
     const SBreadcrumbsItem = Root;
-    const { styles, separator, active, disabled, href } = this.asProps;
+    const { styles, separator, active, disabled, href, tabIndex } = this.asProps;
     const SSeparator = 'div';
     const SListItem = 'li';
 
@@ -60,6 +60,7 @@ class Item extends Component {
         <SListItem>
           <SBreadcrumbsItem
             render={Box}
+            use:tabIndex={active || disabled ? -1 : tabIndex}
             use:href={!active && !disabled ? href : undefined}
             aria-current={active ? 'page' : undefined}
           />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
I've fixed `tabIndex` value for the last(active) item in Breadcrumbs.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually + added unit test
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [X] I have added new unit tests on added of fixed functionality.
