### PR TITLE
[86bzcvb1a][popper] fixed edge case when popper trigger contains mult…

### DIFF
--- a/semcore/accordion/__tests__/accordion.browser-test.tsx
+++ b/semcore/accordion/__tests__/accordion.browser-test.tsx
@@ -50,7 +50,7 @@ test.describe('Accordion', () => {
 
     await page.setContent(htmlContent);
 
-    const section1Header = await page.locator('text=Section 1');
+    const section1Header = await page.locator('text=Section 1', { hasNotText: 'Hello Section 1' });
 
     await expect(page).toHaveScreenshot();
 

--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.37.1] - 2024-07-04
+
+### Fixed
+
+- Fixed edge case when popper trigger contains multiple focusable elements and navigation between them was causing popper to close until browser focus wasn't moved out of trigger.
+
 ## [5.37.0] - 2024-06-26
 
 ### Changed

--- a/semcore/popper/__tests__/popper.browser-test.tsx
+++ b/semcore/popper/__tests__/popper.browser-test.tsx
@@ -191,4 +191,39 @@ test.describe('Popper', () => {
       await expect(popperLocator).toHaveCount(1);
     });
   });
+  test('works well with multiple focusables inside of trigger', async ({ page }) => {
+    const standPath = 'semcore/popper/__tests__/stands/multiple-focusables-in-trigger.tsx';
+    const htmlContent = await e2eStandToHtml(standPath, 'en');
+
+    await page.setContent(htmlContent);
+
+    const firstInput = await page.locator('input[data-position="before"]');
+    const secondInput = await page.locator('input[data-position="after"]');
+    firstInput.focus();
+
+    const optionLocator = await page.locator('text=Option 1');
+    await expect(optionLocator).toHaveCount(0);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await page.keyboard.press('Tab');
+
+    await expect(optionLocator).toHaveCount(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await page.keyboard.press('Tab');
+
+    await expect(optionLocator).toHaveCount(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await page.keyboard.press('Tab');
+
+    await expect(optionLocator).toHaveCount(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await page.keyboard.press('Tab');
+
+    await expect(optionLocator).toHaveCount(0);
+
+    await expect(secondInput).toBeFocused();
+  });
 });

--- a/semcore/popper/__tests__/stands/multiple-focusables-in-trigger.tsx
+++ b/semcore/popper/__tests__/stands/multiple-focusables-in-trigger.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+// @ts-ignore
+import Select from 'intergalactic/select';
+// @ts-ignore
+import Input from 'intergalactic/input';
+// @ts-ignore
+import { Text } from 'intergalactic/typography';
+// @ts-ignore
+import { Box } from 'intergalactic/flex-box';
+
+const options = Array(5)
+  .fill(0)
+  .map((_, i) => ({
+    value: `Option ${i}`,
+    title: `Option ${i}`,
+  }));
+
+const Demo = () => {
+  const [value, setValue] = React.useState('');
+
+  return (
+    <>
+      <Text tag='label' size={200} htmlFor='release-time-picker'>
+        Select release time
+      </Text>
+      <Box mt={2}>
+        <input data-position='before' />
+        <Select interaction='focus' onChange={setValue} value={value}>
+          <Select.Trigger tag={Input}>
+            {() => (
+              <>
+                <Input.Value value={value} onChange={setValue} id='release-time-picker' />
+                <Input.Addon tabIndex={0}>Addon</Input.Addon>
+                <Input.Addon tabIndex={0}>Addon</Input.Addon>
+              </>
+            )}
+          </Select.Trigger>
+          <Select.Menu>
+            {options.map((option) => (
+              <Select.Option value={option.value} key={option.value}>
+                {option.title}
+              </Select.Option>
+            ))}
+          </Select.Menu>
+        </Select>
+        <input data-position='after' />
+      </Box>
+    </>
+  );
+};
+
+export default Demo;

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -312,8 +312,16 @@ class Popper extends Component {
 
   lastPopperClick = 0;
   bindHandlerChangeVisibleWithTimer = (visible, component, action) => (e) => {
+    const trigger = this.triggerRef.current;
+    if (component === 'trigger' && action === 'onBlur') {
+      const focused = e.relatedTarget;
+      const blurred = e.target;
+      if (focused && blurred && hasParent(focused, trigger) && hasParent(blurred, trigger)) {
+        return;
+      }
+    }
+
     if (component === 'trigger' && action === 'onClick') {
-      const trigger = this.triggerRef.current;
       const triggerClick = hasParent(e.target, trigger);
       const associatedLabels = [...(trigger?.labels || [])];
       const popperInsideOfLabel = associatedLabels.some((label) =>


### PR DESCRIPTION
…iple focusable elements and navigation between them was causing popper to close until browser focus wasn't moved out of trigger

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Before this update if combobox contains some focusable addons (for example, clear button) dropdown will close when user navigates to clear button with keyboard. This PR fixes it.

## How has this been tested?

Manually and with added test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [x] I have added new unit tests on added of fixed functionality.
