### PR TITLE
[86bz5nzey][illustration] added color prop that allow to change primary color of colorful illustrations

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1456,6 +1456,9 @@ importers:
       '@semcore/flex-box':
         specifier: 5.29.0
         version: link:../flex-box
+      colorjs.io:
+        specifier: 0.4.3
+        version: 0.4.3
       react:
         specifier: 16.8 - 18
         version: 18.2.0
@@ -12971,6 +12974,10 @@ packages:
 
   /colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  /colorjs.io@0.4.3:
+    resolution: {integrity: sha512-Jr6NiWFZCuSECl23Bhe4jvDldQsE0ErnWrdl3xIUFy+Bkp0l8r5qt/iZlNH47/xxGP5izcyC8InjoUoI4Po+Pg==}
+    dev: false
 
   /combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}

--- a/semcore/illustration/CHANGELOG.md
+++ b/semcore/illustration/CHANGELOG.md
@@ -8,6 +8,10 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 - `color` prop that allow to change primary color of colorful illustrations.
 
+### Fixed
+
+- Illustration components typings.
+
 ## [2.29.0] - 2024-06-26
 
 ### Changed

--- a/semcore/illustration/CHANGELOG.md
+++ b/semcore/illustration/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.30.0] - 2024-07-09
+
+### Added
+
+- `color` prop that allow to change primary color of colorful illustrations.
+
 ## [2.29.0] - 2024-06-26
 
 ### Changed

--- a/semcore/illustration/package.json
+++ b/semcore/illustration/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.9",
-    "@semcore/flex-box": "5.29.0"
+    "@semcore/flex-box": "5.29.0",
+    "colorjs.io": "0.4.3"
   },
   "peerDependencies": {
     "@semcore/core": "^2.17.5",

--- a/semcore/illustration/transform.ts
+++ b/semcore/illustration/transform.ts
@@ -3,6 +3,8 @@ import { resolve as resolvePath } from 'path';
 import svgToJsx from 'svg-to-jsx';
 import { Window } from 'happy-dom';
 import esbuild from 'esbuild';
+import ColorJSIO from 'colorjs.io';
+const Color = ColorJSIO;
 
 const illustrations = await fs.readdir('svg');
 
@@ -28,6 +30,26 @@ await Promise.all(
       document.getElementById(oldId).setAttribute('id', newId);
       idReplacements[oldId] = newId;
     }
+    let illustrationColor: undefined | string;
+    const traverseSvgChildren = (element: Element) => {
+      if (element.tagName === 'MASK') return;
+      for (let i = 0; i < element.children.length; i++) {
+        const child = element.children[i];
+        traverseSvgChildren(child);
+      }
+      const color = element.getAttribute('fill') || element.getAttribute('stroke');
+      if (color === 'none' || !color) return;
+      const saturation = new Color(color).to('hsl').coords[1];
+      if (saturation < 20) return;
+      if (illustrationColor === undefined) {
+        illustrationColor = color;
+      } else if (illustrationColor !== color) {
+        throw new Error(
+          `Illustration ${illustration} has multiple fill colors: ${illustrationColor} and ${color}`,
+        );
+      }
+    };
+    traverseSvgChildren(document.querySelector('svg') as any);
 
     const {
       fill = 'none',
@@ -46,22 +68,40 @@ await Promise.all(
       }
     }
 
+    const props = [
+      `fill = '${fill}'`,
+      `width = '${width}'`,
+      `height = '${height}'`,
+      `viewBox = '${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}'`,
+    ];
+    if (illustrationColor) {
+      while (jsx.includes(`"${illustrationColor}"`)) {
+        jsx = jsx.replace(`"${illustrationColor}"`, '{resolvedColor}');
+      }
+      props.push(`color = '${illustrationColor}'`);
+    }
+
     const component = `
 import React from 'react';
 import { createBaseComponent } from '@semcore/core';
 import { Box } from '@semcore/flex-box';
+import { useColorResolver } from '@semcore/utils/lib/use/useColorResolver';
 
-const ${illustration} = ({fill = '${fill}', width = '${width}', height = '${height}', viewBox = '${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}', ...props}, ref) => (
-  <Box 
-    ref={ref}
-    width={width}
-    height={height}
-    viewBox={viewBox}
-    fill={fill}
-    tag="svg"
-    {...props}
-  >${jsx}</Box>
-);
+const ${illustration} = ({${props.join(', ')}, ...props}, ref) => {
+  const colorResolver = useColorResolver();
+  const resolvedColor = colorResolver(color);
+  return (
+    <Box 
+      ref={ref}
+      width={width}
+      height={height}
+      viewBox={viewBox}
+      fill={fill}
+      tag="svg"
+      {...props}
+    >${jsx}</Box>
+  );
+}
 
 ${illustration}.displayName = '${illustration}'
 
@@ -74,8 +114,14 @@ declare const _default: typeof Box;
 export default _default;    
 `;
 
-    const { code: cjs } = await esbuild.transform(component, { format: 'cjs', loader: 'tsx' });
-    const { code: esm } = await esbuild.transform(component, { format: 'esm', loader: 'tsx' });
+    const { code: cjs } = await esbuild.transform(component, {
+      format: 'cjs',
+      loader: 'tsx',
+    });
+    const { code: esm } = await esbuild.transform(component, {
+      format: 'esm',
+      loader: 'tsx',
+    });
 
     try {
       await fs.access(illustration);

--- a/website/docs/style/illustration/examples/basic-usage.tsx
+++ b/website/docs/style/illustration/examples/basic-usage.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import MailSentReact from 'intergalactic/illustration/MailSent';
+import MailSent from 'intergalactic/illustration/MailSent';
 
 const Demo = () => {
-  return <MailSentReact />;
+  return <MailSent />;
 };
 
 export default Demo;

--- a/website/docs/style/illustration/examples/custom-color.tsx
+++ b/website/docs/style/illustration/examples/custom-color.tsx
@@ -6,8 +6,8 @@ const Demo = () => {
   return (
     <Flex gap={5}>
       <Feedback width={100} height={100} />
-      <Feedback width={100} height={100} color='orange' />
-      <Feedback width={100} height={100} color='bg-primary-success' />
+      <Feedback width={100} height={100} color='#ff7ad1' />
+      <Feedback width={100} height={100} color='green-200' />
     </Flex>
   );
 };

--- a/website/docs/style/illustration/examples/custom-color.tsx
+++ b/website/docs/style/illustration/examples/custom-color.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import Feedback from 'intergalactic/illustration/Feedback';
+import MailSent from 'intergalactic/illustration/MailSent';
 import { Flex } from 'intergalactic/flex-box';
 
 const Demo = () => {
   return (
     <Flex gap={5}>
-      <Feedback width={100} height={100} />
-      <Feedback width={100} height={100} color='#ff7ad1' />
-      <Feedback width={100} height={100} color='green-200' />
+      <MailSent />
+      <MailSent color='#ff7ad1' />
+      <MailSent color='violet-300' />
     </Flex>
   );
 };

--- a/website/docs/style/illustration/examples/custom-color.tsx
+++ b/website/docs/style/illustration/examples/custom-color.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Feedback from 'intergalactic/illustration/Feedback';
+import { Flex } from 'intergalactic/flex-box';
+
+const Demo = () => {
+  return (
+    <Flex gap={5}>
+      <Feedback width={100} height={100} />
+      <Feedback width={100} height={100} color='orange' />
+      <Feedback width={100} height={100} color='bg-primary-success' />
+    </Flex>
+  );
+};
+
+export default Demo;

--- a/website/docs/style/illustration/illustration-api.md
+++ b/website/docs/style/illustration/illustration-api.md
@@ -5,6 +5,15 @@ tabs: Design('illustration'), A11y('illustration-a11y'), API('illustration-api')
 
 ## Illustration
 
+```jsx
+import Select from 'intergalactic/select';
+<Select />;
+```
+
+<TypesView type="IllustrationProps" :types={...types} />
+
+## Direct link
+
 Any illustration can be obtained using a template.
 
 ```js
@@ -14,3 +23,5 @@ import IllustrationName from 'intergalactic/illustration/illustrationName';
 ## getIllustrationPath
 
 To obtain any illustration, you can use the `getIllustrationPath` function, which returns the URL in the format `https://static.semrush.com/ui-kit/illustration/${version}/${name}.svg`.
+
+<script setup>import { data as types } from '@types.data.ts';</script>

--- a/website/docs/style/illustration/illustration-code.md
+++ b/website/docs/style/illustration/illustration-code.md
@@ -12,3 +12,16 @@ tabs: Design('illustration'), A11y('illustration-a11y'), API('illustration-api')
 </script>
 
 :::
+
+## Custom color
+
+For colorful illustrations, you can use the `color` prop to change the color of the illustration.
+
+
+::: sandbox
+
+<script lang="tsx">
+  export Demo from './examples/custom-color.tsx';
+</script>
+
+:::


### PR DESCRIPTION
## Motivation and Context

I've allowed to customize primary color of colorful illustrations with design tokens support.

## How has this been tested?

Manually on added example.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
