### PR TITLE
[86bzjpwd7][table,skeleton] fixed bottom scroll in table, added resizeObserver for the parent element in skeleton

### DIFF
--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.40.8] - 2024-07-12
+
+### Fixed
+
+- View of Bottom horizontal scroll in table body.
+
 ## [4.40.7] - 2024-07-03
 
 ### Fixed

--- a/semcore/data-table/src/Body.tsx
+++ b/semcore/data-table/src/Body.tsx
@@ -351,7 +351,12 @@ class Body extends Component<AsProps, State> {
           <div style={displayContents} role='rowgroup'>
             <div style={displayContents} role='row'>
               <div style={displayContents} role='cell'>
-                <ScrollArea.Bar orientation='horizontal' position={'sticky'} bottom={0} />
+                <ScrollArea.Bar
+                  orientation='horizontal'
+                  position={'sticky'}
+                  bottom={0}
+                  container={this.scrollContainerRef}
+                />
                 <ScrollArea.Bar orientation='vertical' w={'12px'} zIndex={2} />
               </div>
             </div>

--- a/semcore/skeleton/CHANGELOG.md
+++ b/semcore/skeleton/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.30.0] - 2024-07-12
+
+### Added
+
+- `observeParentSize` property to observe changes in parent element.
+
 ## [5.29.0] - 2024-06-20
 
 ### Changed

--- a/semcore/skeleton/src/Skeleton.jsx
+++ b/semcore/skeleton/src/Skeleton.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import createComponent, { Component, sstyled, Root } from '@semcore/core';
 import { Box } from '@semcore/flex-box';
 import uniqueIDEnhancement from '@semcore/utils/lib/uniqueID';
+import canUseDOM from '@semcore/utils/lib/canUseDOM';
 import i18nEnhance from '@semcore/utils/lib/enhances/i18nEnhance';
 import { localizedMessages } from './translations/__intergalactic-dynamic-locales';
 
@@ -49,6 +50,33 @@ class SkeletonSVG extends Component {
     duration: 2000,
   };
 
+  svgRef = React.createRef();
+
+  constructor(props) {
+    super(props);
+
+    if (canUseDOM() && props.observeParentSize) {
+      this.observer = new ResizeObserver(this.handleResize.bind(this));
+    }
+  }
+
+  componentDidMount() {
+    this.observer?.observe(this.svgRef.current?.parentElement);
+  }
+
+  componentWillUnmount() {
+    this.observer?.disconnect();
+  }
+
+  handleResize(data) {
+    const target = data[0].target;
+    const svg = this.svgRef.current;
+
+    if (target && svg) {
+      svg.setAttribute('width', '100%');
+    }
+  }
+
   setContext() {
     const { theme } = this.asProps;
     return {
@@ -64,6 +92,7 @@ class SkeletonSVG extends Component {
       <SSkeletonSVG
         render={Skeleton}
         tag='svg'
+        ref={this.svgRef}
         preserveAspectRatio='none'
         theme={theme}
         durationAnim={`${duration}ms`}

--- a/semcore/skeleton/src/index.d.ts
+++ b/semcore/skeleton/src/index.d.ts
@@ -22,6 +22,12 @@ export type SkeletonProps = BoxProps &
     theme?: 'dark' | 'invert';
 
     locale?: string;
+
+    /**
+     * Enable ResizeObserver for parent Element to recalculate skeleton size.
+     * @default false
+     */
+    observeParentSize?: boolean;
   };
 
 /** @deprecated */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fixed displaying of bottom scroll in the table.
Added logic to automatically recalculate the skeleton width when the parent size changes.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
