### PR TITLE
[illustration] added secondary color support

### DIFF
--- a/semcore/illustration/CHANGELOG.md
+++ b/semcore/illustration/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Added
 
-- `color` prop that allow to change primary color of colorful illustrations.
+- `primaryColor` and `secondaryColor` prop that allow to change primary color of illustrations.
 
 ### Fixed
 

--- a/website/docs/style/illustration/examples/custom-color.tsx
+++ b/website/docs/style/illustration/examples/custom-color.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import MailSent from 'intergalactic/illustration/MailSent';
+import Congrats from 'intergalactic/illustration/Congrats';
 import { Flex } from 'intergalactic/flex-box';
 
 const Demo = () => {
   return (
     <Flex gap={5}>
       <MailSent />
-      <MailSent color='#ff7ad1' />
-      <MailSent color='violet-300' />
+      <MailSent primaryColor='#ff7ad1' />
+      <MailSent primaryColor='violet-300' />
+      <Congrats primaryColor='#ff7ad1' secondaryColor='#000' />
     </Flex>
   );
 };

--- a/website/docs/style/illustration/illustration-code.md
+++ b/website/docs/style/illustration/illustration-code.md
@@ -15,9 +15,6 @@ tabs: Design('illustration'), A11y('illustration-a11y'), API('illustration-api')
 
 ## Custom color
 
-For colorful illustrations, you can use the `color` prop to change the color of the illustration.
-
-
 ::: sandbox
 
 <script lang="tsx">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

This PR tries to catch on adding secondary color prop to illustration in before the upcoming release.

## How has this been tested?

Manually on added example.

## Screenshots:

<img width="740" alt="Screenshot 2024-07-12 at 17 14 14" src="https://github.com/user-attachments/assets/1d5afbdd-e97c-4092-b545-a002e648a415">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- x ] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
