### PR TITLE
[86bzkeag6][tooltip] added aria-controls to description tooltip trigger

### DIFF
--- a/semcore/inline-edit/CHANGELOG.md
+++ b/semcore/inline-edit/CHANGELOG.md
@@ -6,397 +6,397 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/animation` [2.29.0 ~> 2.30.0], `@semcore/flex-box` [5.29.0 ~> 5.30.0], `@semcore/utils` [4.30.0 ~> 4.31.0], `@semcore/core` [2.27.0 ~> 2.28.0]).
+- Version minor update due to children dependencies update (`@semcore/animation` [2.29.0 ~> 2.30.0], `@semcore/flex-box` [5.29.0 ~> 5.30.0], `@semcore/utils` [4.30.0 ~> 4.31.0], `@semcore/core` [2.27.0 ~> 2.28.0]).
 
 ## [4.31.1] - 2024-07-05
 
 ### Fixed
 
-* `aria-hidden` was not removed from DOM if the value is `false`.
+- `aria-hidden` was not removed from DOM if the value is `false`.
 
 ## [4.31.0] - 2024-06-26
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/animation` [2.28.0 ~> 2.29.0], `@semcore/flex-box` [5.28.0 ~> 5.29.0], `@semcore/utils` [4.29.0 ~> 4.30.0], `@semcore/core` [2.26.0 ~> 2.27.0]).
+- Version minor update due to children dependencies update (`@semcore/animation` [2.28.0 ~> 2.29.0], `@semcore/flex-box` [5.28.0 ~> 5.29.0], `@semcore/utils` [4.29.0 ~> 4.30.0], `@semcore/core` [2.26.0 ~> 2.27.0]).
 
 ## [4.30.0] - 2024-06-13
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/animation` [2.27.2 ~> 2.28.0], `@semcore/flex-box` [5.27.2 ~> 5.28.0], `@semcore/utils` [4.28.2 ~> 4.29.0], `@semcore/core` [2.25.2 ~> 2.26.0]).
+- Version minor update due to children dependencies update (`@semcore/animation` [2.27.2 ~> 2.28.0], `@semcore/flex-box` [5.27.2 ~> 5.28.0], `@semcore/utils` [4.28.2 ~> 4.29.0], `@semcore/core` [2.25.2 ~> 2.26.0]).
 
 ## [4.29.2] - 2024-06-12
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [2.27.1 ~> 2.27.2], `@semcore/flex-box` [5.27.1 ~> 5.27.2], `@semcore/utils` [4.28.1 ~> 4.28.2], `@semcore/core` [2.25.1 ~> 2.25.2]).
+- Version patch update due to children dependencies update (`@semcore/animation` [2.27.1 ~> 2.27.2], `@semcore/flex-box` [5.27.1 ~> 5.27.2], `@semcore/utils` [4.28.1 ~> 4.28.2], `@semcore/core` [2.25.1 ~> 2.25.2]).
 
 ## [4.29.1] - 2024-05-28
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [2.27.0 ~> 2.27.1], `@semcore/flex-box` [5.27.0 ~> 5.27.1], `@semcore/utils` [4.28.0 ~> 4.28.1], `@semcore/core` [2.25.0 ~> 2.25.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [2.27.0 ~> 2.27.1], `@semcore/flex-box` [5.27.0 ~> 5.27.1], `@semcore/utils` [4.28.0 ~> 4.28.1], `@semcore/core` [2.25.0 ~> 2.25.1]).
 
 ## [4.29.0] - 2024-05-23
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/animation` [2.26.0 ~> 2.27.0], `@semcore/flex-box` [5.26.0 ~> 5.27.0], `@semcore/utils` [4.27.0 ~> 4.28.0], `@semcore/core` [2.24.0 ~> 2.25.0]).
+- Version minor update due to children dependencies update (`@semcore/animation` [2.26.0 ~> 2.27.0], `@semcore/flex-box` [5.26.0 ~> 5.27.0], `@semcore/utils` [4.27.0 ~> 4.28.0], `@semcore/core` [2.24.0 ~> 2.25.0]).
 
 ## [4.28.0] - 2024-05-22
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/animation` [2.25.1 ~> 2.26.0], `@semcore/flex-box` [5.25.1 ~> 5.26.0], `@semcore/utils` [4.26.2 ~> 4.27.0], `@semcore/core` [2.23.1 ~> 2.24.0]).
+- Version minor update due to children dependencies update (`@semcore/animation` [2.25.1 ~> 2.26.0], `@semcore/flex-box` [5.25.1 ~> 5.26.0], `@semcore/utils` [4.26.2 ~> 4.27.0], `@semcore/core` [2.23.1 ~> 2.24.0]).
 
 ## [4.27.1] - 2024-05-17
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [2.25.0 ~> 2.25.1], `@semcore/flex-box` [5.25.0 ~> 5.25.1], `@semcore/utils` [4.26.1 ~> 4.26.2], `@semcore/core` [2.23.0 ~> 2.23.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [2.25.0 ~> 2.25.1], `@semcore/flex-box` [5.25.0 ~> 5.25.1], `@semcore/utils` [4.26.1 ~> 4.26.2], `@semcore/core` [2.23.0 ~> 2.23.1]).
 
 ## [4.27.0] - 2024-05-17
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/animation` [2.24.0 ~> 2.25.0], `@semcore/flex-box` [5.24.0 ~> 5.25.0], `@semcore/utils` [4.25.0 ~> 4.26.1], `@semcore/core` [2.22.0 ~> 2.23.0]).
+- Version minor update due to children dependencies update (`@semcore/animation` [2.24.0 ~> 2.25.0], `@semcore/flex-box` [5.24.0 ~> 5.25.0], `@semcore/utils` [4.25.0 ~> 4.26.1], `@semcore/core` [2.22.0 ~> 2.23.0]).
 
 ## [4.26.0] - 2024-05-16
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/animation` [2.22.2 ~> 2.23.0], `@semcore/flex-box` [5.22.2 ~> 5.23.0], `@semcore/utils` [4.23.2 ~> 4.24.0], `@semcore/core` [2.20.2 ~> 2.21.0]).
+- Version minor update due to children dependencies update (`@semcore/animation` [2.22.2 ~> 2.23.0], `@semcore/flex-box` [5.22.2 ~> 5.23.0], `@semcore/utils` [4.23.2 ~> 4.24.0], `@semcore/core` [2.20.2 ~> 2.21.0]).
 
 ## [4.24.2] - 2024-04-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [2.22.1 ~> 2.22.2], `@semcore/flex-box` [5.22.1 ~> 5.22.2], `@semcore/utils` [4.23.1 ~> 4.23.2], `@semcore/core` [2.20.1 ~> 2.20.2]).
+- Version patch update due to children dependencies update (`@semcore/animation` [2.22.1 ~> 2.22.2], `@semcore/flex-box` [5.22.1 ~> 5.22.2], `@semcore/utils` [4.23.1 ~> 4.23.2], `@semcore/core` [2.20.1 ~> 2.20.2]).
 
 ## [4.24.1] - 2024-04-16
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [2.22.0 ~> 2.22.1], `@semcore/flex-box` [5.22.0 ~> 5.22.1], `@semcore/utils` [4.23.0 ~> 4.23.1], `@semcore/core` [2.20.0 ~> 2.20.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [2.22.0 ~> 2.22.1], `@semcore/flex-box` [5.22.0 ~> 5.22.1], `@semcore/utils` [4.23.0 ~> 4.23.1], `@semcore/core` [2.20.0 ~> 2.20.1]).
 
 ## [4.24.0] - 2024-04-15
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/animation` [2.21.2 ~> 2.22.0], `@semcore/flex-box` [5.21.2 ~> 5.22.0], `@semcore/utils` [4.22.2 ~> 4.23.0], `@semcore/core` [2.19.2 ~> 2.20.0]).
+- Version minor update due to children dependencies update (`@semcore/animation` [2.21.2 ~> 2.22.0], `@semcore/flex-box` [5.21.2 ~> 5.22.0], `@semcore/utils` [4.22.2 ~> 4.23.0], `@semcore/core` [2.19.2 ~> 2.20.0]).
 
 ## [4.23.2] - 2024-04-10
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [2.21.1 ~> 2.21.2], `@semcore/flex-box` [5.21.1 ~> 5.21.2], `@semcore/utils` [4.22.1 ~> 4.22.2], `@semcore/core` [2.19.1 ~> 2.19.2]).
+- Version patch update due to children dependencies update (`@semcore/animation` [2.21.1 ~> 2.21.2], `@semcore/flex-box` [5.21.1 ~> 5.21.2], `@semcore/utils` [4.22.1 ~> 4.22.2], `@semcore/core` [2.19.1 ~> 2.19.2]).
 
 ## [4.23.1] - 2024-04-09
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [2.21.0 ~> 2.21.1], `@semcore/flex-box` [5.21.0 ~> 5.21.1], `@semcore/utils` [4.22.0 ~> 4.22.1], `@semcore/core` [2.19.0 ~> 2.19.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [2.21.0 ~> 2.21.1], `@semcore/flex-box` [5.21.0 ~> 5.21.1], `@semcore/utils` [4.22.0 ~> 4.22.1], `@semcore/core` [2.19.0 ~> 2.19.1]).
 
 ## [4.23.0] - 2024-03-27
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/animation` [2.20.1 ~> 2.21.0], `@semcore/flex-box` [5.20.1 ~> 5.21.0], `@semcore/utils` [4.21.1 ~> 4.22.0], `@semcore/core` [2.18.1 ~> 2.19.0]).
+- Version minor update due to children dependencies update (`@semcore/animation` [2.20.1 ~> 2.21.0], `@semcore/flex-box` [5.20.1 ~> 5.21.0], `@semcore/utils` [4.21.1 ~> 4.22.0], `@semcore/core` [2.18.1 ~> 2.19.0]).
 
 ## [4.22.1] - 2024-03-26
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [2.20.0 ~> 2.20.1], `@semcore/flex-box` [5.20.0 ~> 5.20.1], `@semcore/utils` [4.21.0 ~> 4.21.1], `@semcore/core` [2.18.0 ~> 2.18.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [2.20.0 ~> 2.20.1], `@semcore/flex-box` [5.20.0 ~> 5.20.1], `@semcore/utils` [4.21.0 ~> 4.21.1], `@semcore/core` [2.18.0 ~> 2.18.1]).
 
 ## [4.22.0] - 2024-03-15
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/animation` [2.19.2 ~> 2.20.0], `@semcore/flex-box` [5.19.4 ~> 5.20.0], `@semcore/utils` [4.20.5 ~> 4.21.0], `@semcore/core` [2.17.5 ~> 2.18.0]).
+- Version minor update due to children dependencies update (`@semcore/animation` [2.19.2 ~> 2.20.0], `@semcore/flex-box` [5.19.4 ~> 5.20.0], `@semcore/utils` [4.20.5 ~> 4.21.0], `@semcore/core` [2.17.5 ~> 2.18.0]).
 
 ## [4.21.5] - 2024-03-07
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.19.1 ~> 2.19.2]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.19.1 ~> 2.19.2]).
 
 ## [4.21.4] - 2024-03-05
 
 ### Changed
 
-* Use `event.key` instead of `event.code`.
+- Use `event.key` instead of `event.code`.
 
 ## [4.21.3] - 2024-03-01
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.18.3 ~> 2.19.0], `@semcore/flex-box` [5.19.2 ~> 5.19.3], `@semcore/utils` [4.20.3 ~> 4.20.4], `@semcore/core` [2.17.3 ~> 2.17.4]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.18.3 ~> 2.19.0], `@semcore/flex-box` [5.19.2 ~> 5.19.3], `@semcore/utils` [4.20.3 ~> 4.20.4], `@semcore/core` [2.17.3 ~> 2.17.4]).
 
 ## [4.21.2] - 2024-02-21
 
 ### Changed
 
-* Version prerelease update due to children dependencies update (`@semcore/animation` [2.18.3-prerelease.10 ~> 2.18.3], `@semcore/flex-box` [5.19.2-prerelease.10 ~> 5.19.2], `@semcore/core` [2.17.3-prerelease.10 ~> 2.17.3]).
+- Version prerelease update due to children dependencies update (`@semcore/animation` [2.18.3-prerelease.10 ~> 2.18.3], `@semcore/flex-box` [5.19.2-prerelease.10 ~> 5.19.2], `@semcore/core` [2.17.3-prerelease.10 ~> 2.17.3]).
 
 ## [4.21.1] - 2024-02-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.18.2 ~> 2.18.3], `@semcore/flex-box` [5.19.1 ~> 5.19.2], `@semcore/utils` [4.20.2 ~> 4.20.3], `@semcore/core` [2.17.2 ~> 2.17.3]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.18.2 ~> 2.18.3], `@semcore/flex-box` [5.19.1 ~> 5.19.2], `@semcore/utils` [4.20.2 ~> 4.20.3], `@semcore/core` [2.17.2 ~> 2.17.3]).
 
 ## [4.21.0] - 2024-02-13
 
 ### Changed
 
-* `InlineEdit.View` are clickable by `Space` now (along with `Enter` as before).
+- `InlineEdit.View` are clickable by `Space` now (along with `Enter` as before).
 
 ## [4.20.2] - 2024-02-09
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.18.1 ~> 2.18.2], `@semcore/flex-box` [5.19.0 ~> 5.19.1], `@semcore/utils` [4.20.1 ~> 4.20.2], `@semcore/core` [2.17.1 ~> 2.17.2]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.18.1 ~> 2.18.2], `@semcore/flex-box` [5.19.0 ~> 5.19.1], `@semcore/utils` [4.20.1 ~> 4.20.2], `@semcore/core` [2.17.1 ~> 2.17.2]).
 
 ## [4.20.1] - 2024-02-06
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.18.0 ~> 2.18.1], `@semcore/flex-box` [5.18.0 ~> 5.19.0], `@semcore/utils` [4.20.0 ~> 4.20.1], `@semcore/core` [2.17.0 ~> 2.17.1]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.18.0 ~> 2.18.1], `@semcore/flex-box` [5.18.0 ~> 5.19.0], `@semcore/utils` [4.20.0 ~> 4.20.1], `@semcore/core` [2.17.0 ~> 2.17.1]).
 
 ## [4.20.0] - 2024-02-01
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.17.1 ~> 2.18.0], `@semcore/flex-box` [5.17.1 ~> 5.18.0], `@semcore/utils` [4.19.1 ~> 4.20.0], `@semcore/core` [2.16.1 ~> 2.17.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.17.1 ~> 2.18.0], `@semcore/flex-box` [5.17.1 ~> 5.18.0], `@semcore/utils` [4.19.1 ~> 4.20.0], `@semcore/core` [2.16.1 ~> 2.17.0]).
 
 ## [4.19.1] - 2024-02-01
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.17.0 ~> 2.17.1], `@semcore/flex-box` [5.17.0 ~> 5.17.1], `@semcore/utils` [4.19.0 ~> 4.19.1], `@semcore/core` [2.16.0 ~> 2.16.1]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.17.0 ~> 2.17.1], `@semcore/flex-box` [5.17.0 ~> 5.17.1], `@semcore/utils` [4.19.0 ~> 4.19.1], `@semcore/core` [2.16.0 ~> 2.16.1]).
 
 ## [4.19.0] - 2024-01-31
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.16.0 ~> 2.17.0], `@semcore/flex-box` [5.16.0 ~> 5.17.0], `@semcore/utils` [4.18.0 ~> 4.19.0], `@semcore/core` [2.15.0 ~> 2.16.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.16.0 ~> 2.17.0], `@semcore/flex-box` [5.16.0 ~> 5.17.0], `@semcore/utils` [4.18.0 ~> 4.19.0], `@semcore/core` [2.15.0 ~> 2.16.0]).
 
 ## [4.18.0] - 2024-01-19
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.15.0 ~> 2.16.0], `@semcore/flex-box` [5.15.0 ~> 5.16.0], `@semcore/utils` [4.17.0 ~> 4.18.0], `@semcore/core` [2.14.0 ~> 2.15.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.15.0 ~> 2.16.0], `@semcore/flex-box` [5.15.0 ~> 5.16.0], `@semcore/utils` [4.17.0 ~> 4.18.0], `@semcore/core` [2.14.0 ~> 2.15.0]).
 
 ## [4.17.0] - 2024-01-19
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.14.1 ~> 2.15.0], `@semcore/flex-box` [5.14.1 ~> 5.15.0], `@semcore/core` [2.13.1 ~> 2.14.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.14.1 ~> 2.15.0], `@semcore/flex-box` [5.14.1 ~> 5.15.0], `@semcore/core` [2.13.1 ~> 2.14.0]).
 
 ## [4.16.1] - 2024-01-10
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.14.0 ~> 2.14.1], `@semcore/flex-box` [5.14.0 ~> 5.14.1], `@semcore/utils` [4.16.0 ~> 4.16.2], `@semcore/core` [2.13.0 ~> 2.13.1]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.14.0 ~> 2.14.1], `@semcore/flex-box` [5.14.0 ~> 5.14.1], `@semcore/utils` [4.16.0 ~> 4.16.2], `@semcore/core` [2.13.0 ~> 2.13.1]).
 
 ## [4.16.0] - 2023-12-22
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.13.1 ~> 2.14.0], `@semcore/flex-box` [5.13.1 ~> 5.14.0], `@semcore/utils` [4.15.1 ~> 4.16.0], `@semcore/core` [2.12.1 ~> 2.13.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.13.1 ~> 2.14.0], `@semcore/flex-box` [5.13.1 ~> 5.14.0], `@semcore/utils` [4.15.1 ~> 4.16.0], `@semcore/core` [2.12.1 ~> 2.13.0]).
 
 ## [4.15.1] - 2023-12-19
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.13.0 ~> 2.13.1], `@semcore/flex-box` [5.13.0 ~> 5.13.1], `@semcore/utils` [4.15.0 ~> 4.15.1], `@semcore/core` [2.12.0 ~> 2.12.1]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.13.0 ~> 2.13.1], `@semcore/flex-box` [5.13.0 ~> 5.13.1], `@semcore/utils` [4.15.0 ~> 4.15.1], `@semcore/core` [2.12.0 ~> 2.12.1]).
 
 ## [4.15.0] - 2023-12-06
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.12.0 ~> 2.13.0], `@semcore/flex-box` [5.12.0 ~> 5.13.0], `@semcore/core` [2.11.0 ~> 2.12.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.12.0 ~> 2.13.0], `@semcore/flex-box` [5.12.0 ~> 5.13.0], `@semcore/core` [2.11.0 ~> 2.12.0]).
 
 ## [4.14.0] - 2023-12-04
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.11.0 ~> 2.12.0], `@semcore/flex-box` [5.11.0 ~> 5.12.0], `@semcore/utils` [4.13.0 ~> 4.14.0], `@semcore/core` [2.10.0 ~> 2.11.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.11.0 ~> 2.12.0], `@semcore/flex-box` [5.11.0 ~> 5.12.0], `@semcore/utils` [4.13.0 ~> 4.14.0], `@semcore/core` [2.10.0 ~> 2.11.0]).
 
 ## [4.13.0] - 2023-11-24
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.10.2 ~> 2.11.0], `@semcore/flex-box` [5.10.2 ~> 5.11.0], `@semcore/utils` [4.10.3 ~> 4.13.0], `@semcore/core` [2.9.2 ~> 2.10.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.10.2 ~> 2.11.0], `@semcore/flex-box` [5.10.2 ~> 5.11.0], `@semcore/utils` [4.10.3 ~> 4.13.0], `@semcore/core` [2.9.2 ~> 2.10.0]).
 
 ## [4.12.2] - 2023-11-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.10.1 ~> 2.10.2], `@semcore/flex-box` [5.10.1 ~> 5.10.2], `@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/core` [2.9.1 ~> 2.9.2]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.10.1 ~> 2.10.2], `@semcore/flex-box` [5.10.1 ~> 5.10.2], `@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/core` [2.9.1 ~> 2.9.2]).
 
 ## [4.12.1] - 2023-11-09
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.10.0 ~> 2.10.1], `@semcore/flex-box` [5.10.0 ~> 5.10.1], `@semcore/utils` [4.10.1 ~> 4.10.2], `@semcore/core` [2.9.0 ~> 2.9.1]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.10.0 ~> 2.10.1], `@semcore/flex-box` [5.10.0 ~> 5.10.1], `@semcore/utils` [4.10.1 ~> 4.10.2], `@semcore/core` [2.9.0 ~> 2.9.1]).
 
 ## [4.12.0] - 2023-11-06
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.9.0 ~> 2.10.0], `@semcore/flex-box` [5.9.0 ~> 5.10.0], `@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/core` [2.8.0 ~> 2.9.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.9.0 ~> 2.10.0], `@semcore/flex-box` [5.9.0 ~> 5.10.0], `@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/core` [2.8.0 ~> 2.9.0]).
 
 ## [4.11.0] - 2023-10-27
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.8.2 ~> 2.9.0], `@semcore/flex-box` [5.8.2 ~> 5.9.0], `@semcore/utils` [4.8.4 ~> 4.9.0], `@semcore/core` [2.7.7 ~> 2.8.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.8.2 ~> 2.9.0], `@semcore/flex-box` [5.8.2 ~> 5.9.0], `@semcore/utils` [4.8.4 ~> 4.9.0], `@semcore/core` [2.7.7 ~> 2.8.0]).
 
 ## [4.10.2] - 2023-10-24
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.8.1 ~> 2.8.2], `@semcore/flex-box` [5.8.1 ~> 5.8.2], `@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/core` [2.7.6 ~> 2.7.7]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.8.1 ~> 2.8.2], `@semcore/flex-box` [5.8.1 ~> 5.8.2], `@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/core` [2.7.6 ~> 2.7.7]).
 
 ## [4.10.1] - 2023-10-16
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.8.0 ~> 2.8.1], `@semcore/flex-box` [5.8.0 ~> 5.8.1], `@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/core` [2.7.5 ~> 2.7.6]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.8.0 ~> 2.8.1], `@semcore/flex-box` [5.8.0 ~> 5.8.1], `@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/core` [2.7.5 ~> 2.7.6]).
 
 ## [4.10.0] - 2023-10-10
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.7.5 ~> 2.8.0], `@semcore/flex-box` [5.7.5 ~> 5.8.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.7.5 ~> 2.8.0], `@semcore/flex-box` [5.7.5 ~> 5.8.0]).
 
 ## [4.9.0] - 2023-10-09
 
 ### Added
 
-* `nl` locale support.
+- `nl` locale support.
 
 ## [4.8.5] - 2023-10-06
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.4 ~> 2.7.5], `@semcore/flex-box` [5.7.4 ~> 5.7.5], `@semcore/utils` [4.8.1 ~> 4.8.2], `@semcore/core` [2.7.4 ~> 2.7.5]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.4 ~> 2.7.5], `@semcore/flex-box` [5.7.4 ~> 5.7.5], `@semcore/utils` [4.8.1 ~> 4.8.2], `@semcore/core` [2.7.4 ~> 2.7.5]).
 
 ## [4.8.4] - 2023-10-03
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.3 ~> 2.7.4], `@semcore/flex-box` [5.7.3 ~> 5.7.4], `@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/core` [2.7.3 ~> 2.7.4]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.3 ~> 2.7.4], `@semcore/flex-box` [5.7.3 ~> 5.7.4], `@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/core` [2.7.3 ~> 2.7.4]).
 
 ## [4.8.3] - 2023-10-02
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.2 ~> 2.7.3], `@semcore/flex-box` [5.7.2 ~> 5.7.3], `@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/core` [2.7.2 ~> 2.7.3]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.2 ~> 2.7.3], `@semcore/flex-box` [5.7.2 ~> 5.7.3], `@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/core` [2.7.2 ~> 2.7.3]).
 
 ## [4.8.2] - 2023-09-20
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.1 ~> 2.7.2], `@semcore/flex-box` [5.7.1 ~> 5.7.2], `@semcore/core` [2.7.1 ~> 2.7.2]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.1 ~> 2.7.2], `@semcore/flex-box` [5.7.1 ~> 5.7.2], `@semcore/core` [2.7.1 ~> 2.7.2]).
 
 ## [4.8.1] - 2023-09-20
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.0 ~> 2.7.1], `@semcore/flex-box` [5.7.0 ~> 5.7.1], `@semcore/utils` [4.7.0 ~> 4.7.1], `@semcore/core` [2.7.0 ~> 2.7.1]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.7.0 ~> 2.7.1], `@semcore/flex-box` [5.7.0 ~> 5.7.1], `@semcore/utils` [4.7.0 ~> 4.7.1], `@semcore/core` [2.7.0 ~> 2.7.1]).
 
 ## [4.8.0] - 2023-09-13
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.6.3 ~> 2.7.0], `@semcore/flex-box` [5.6.3 ~> 5.7.0], `@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.6.3 ~> 2.7.0], `@semcore/flex-box` [5.6.3 ~> 5.7.0], `@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
 
 ## [4.7.3] - 2023-09-12
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.6.2 ~> 2.6.3], `@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.6.2 ~> 2.6.3], `@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
 
 ## [4.7.2] - 2023-09-08
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.6.1 ~> 2.6.2], `@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.6.1 ~> 2.6.2], `@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
 
 ## [4.7.1] - 2023-09-05
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.6.0 ~> 2.6.1], `@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.6.0 ~> 2.6.1], `@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
 
 ## [4.7.0] - 2023-09-04
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.5.0 ~> 2.6.0], `@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.5.0 ~> 2.6.0], `@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
 
 ## [4.6.0] - 2023-08-28
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.4.1 ~> 2.5.0], `@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.4.1 ~> 2.5.0], `@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
 
 ## [4.5.1] - 2023-08-24
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.4.0 ~> 2.4.1], `@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.4.0 ~> 2.4.1], `@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
 
 ## [4.5.0] - 2023-08-23
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.3.1 ~> 2.4.0], `@semcore/flex-box` [5.3.1 ~> 5.4.0], `@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.3.1 ~> 2.4.0], `@semcore/flex-box` [5.3.1 ~> 5.4.0], `@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
 
 ## [4.4.1] - 2023-08-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.3.0 ~> 2.3.1], `@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.3.0 ~> 2.3.1], `@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
 
 ## [4.4.0] - 2023-08-18
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/animation` [2.2.1 ~> 2.3.0], `@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
+- Version preminor update due to children dependencies update (`@semcore/animation` [2.2.1 ~> 2.3.0], `@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
 
 ## [4.3.1] - 2023-08-16
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.2.0 ~> 2.2.1], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/core` [2.2.0 ~> 2.2.1]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.2.0 ~> 2.2.1], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/core` [2.2.0 ~> 2.2.1]).
 
 ## [4.3.0] - 2023-08-07
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/animation` [2.1.0 ~> 2.2.0], `@semcore/flex-box` [5.1.0 ~> 5.2.0], `@semcore/utils` [4.0.0 ~> 4.1.0]).
+- Version minor update due to children dependencies update (`@semcore/animation` [2.1.0 ~> 2.2.0], `@semcore/flex-box` [5.1.0 ~> 5.2.0], `@semcore/utils` [4.0.0 ~> 4.1.0]).
 
 ## [4.2.0] - 2023-08-01
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/animation` [2.0.0 ~> 2.1.0], `@semcore/flex-box` [5.0.0 ~> 5.1.0]).
+- Version minor update due to children dependencies update (`@semcore/animation` [2.0.0 ~> 2.1.0], `@semcore/flex-box` [5.0.0 ~> 5.1.0]).
 
 ## [4.1.0] - 2023-07-27
 
 ### Changed
 
-* Use `event.key` instead of `event.code` for better support of non QWERTY keyboard layouts.
+- Use `event.key` instead of `event.code` for better support of non QWERTY keyboard layouts.
 
 ## [4.0.0] - 2023-07-17
 
 ### Break
 
-* Strict, backward incompatible typings.
+- Strict, backward incompatible typings.
 
 ## [3.6.3] - 2023-06-30
 
@@ -404,91 +404,91 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.19 ~> 1.10.20], `@semcore/flex-box` [4.7.31 ~> 4.7.32], `@semcore/utils` [3.53.4 ~> 3.54.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.19 ~> 1.10.20], `@semcore/flex-box` [4.7.31 ~> 4.7.32], `@semcore/utils` [3.53.4 ~> 3.54.0]).
 
 ## [3.6.1] - 2023-06-14
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.18 ~> 1.10.19], `@semcore/flex-box` [4.7.30 ~> 4.7.31], `@semcore/utils` [3.53.3 ~> 3.53.4]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.18 ~> 1.10.19], `@semcore/flex-box` [4.7.30 ~> 4.7.31], `@semcore/utils` [3.53.3 ~> 3.53.4]).
 
 ## [3.6.0] - 2023-06-12
 
 ### Added
 
-* Swedish (`sv`) locale support.
+- Swedish (`sv`) locale support.
 
 ## [3.5.2] - 2023-06-12
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.17 ~> 1.10.18], `@semcore/flex-box` [4.7.29 ~> 4.7.30], `@semcore/utils` [3.53.2 ~> 3.53.3]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.17 ~> 1.10.18], `@semcore/flex-box` [4.7.29 ~> 4.7.30], `@semcore/utils` [3.53.2 ~> 3.53.3]).
 
 ## [3.5.1] - 2023-06-09
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.16 ~> 1.10.17], `@semcore/flex-box` [4.7.28 ~> 4.7.29], `@semcore/utils` [3.53.1 ~> 3.53.2]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.16 ~> 1.10.17], `@semcore/flex-box` [4.7.28 ~> 4.7.29], `@semcore/utils` [3.53.1 ~> 3.53.2]).
 
 ## [3.5.0] - 2023-06-09
 
 ### Added
 
-* Polish (`pl`) locale support.
+- Polish (`pl`) locale support.
 
 ## [2.4.26] - 2023-06-07
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.15 ~> 1.10.16], `@semcore/flex-box` [4.7.27 ~> 4.7.28], `@semcore/utils` [3.53.0 ~> 3.53.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.15 ~> 1.10.16], `@semcore/flex-box` [4.7.27 ~> 4.7.28], `@semcore/utils` [3.53.0 ~> 3.53.1]).
 
 ## [2.4.25] - 2023-06-02
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.14 ~> 1.10.15]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.14 ~> 1.10.15]).
 
 ## [2.4.24] - 2023-05-31
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.13 ~> 1.10.14], `@semcore/flex-box` [4.7.26 ~> 4.7.27], `@semcore/utils` [3.52.0 ~> 3.53.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.13 ~> 1.10.14], `@semcore/flex-box` [4.7.26 ~> 4.7.27], `@semcore/utils` [3.52.0 ~> 3.53.0]).
 
 ## [2.4.23] - 2023-05-29
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.12 ~> 1.10.13]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.12 ~> 1.10.13]).
 
 ## [2.4.22] - 2023-05-25
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.11 ~> 1.10.12], `@semcore/flex-box` [4.7.25 ~> 4.7.26], `@semcore/utils` [3.51.1 ~> 3.52.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.11 ~> 1.10.12], `@semcore/flex-box` [4.7.25 ~> 4.7.26], `@semcore/utils` [3.51.1 ~> 3.52.0]).
 
 ## [2.4.21] - 2023-05-24
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.10 ~> 1.10.11], `@semcore/flex-box` [4.7.24 ~> 4.7.25], `@semcore/utils` [3.51.0 ~> 3.51.1]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.10 ~> 1.10.11], `@semcore/flex-box` [4.7.24 ~> 4.7.25], `@semcore/utils` [3.51.0 ~> 3.51.1]).
 
 ## [2.4.20] - 2023-05-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.9 ~> 1.10.10], `@semcore/flex-box` [4.7.23 ~> 4.7.24], `@semcore/utils` [3.50.7 ~> 3.51.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.9 ~> 1.10.10], `@semcore/flex-box` [4.7.23 ~> 4.7.24], `@semcore/utils` [3.50.7 ~> 3.51.0]).
 
 ## [2.4.19] - 2023-05-11
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.8 ~> 1.10.9], `@semcore/flex-box` [4.7.22 ~> 4.7.23], `@semcore/utils` [3.50.6 ~> 3.50.7]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.8 ~> 1.10.9], `@semcore/flex-box` [4.7.22 ~> 4.7.23], `@semcore/utils` [3.50.6 ~> 3.50.7]).
 
 ## [2.4.18] - 2023-05-04
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.7 ~> 1.10.8], `@semcore/flex-box` [4.7.21 ~> 4.7.22], `@semcore/utils` [3.50.5 ~> 3.50.6]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.7 ~> 1.10.8], `@semcore/flex-box` [4.7.21 ~> 4.7.22], `@semcore/utils` [3.50.5 ~> 3.50.6]).
 
 ## [2.4.16] - 2023-05-02
 
@@ -500,76 +500,76 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Fixed
 
-* Improvements for A11Y. Added more correct label. Added role attribute. Return focus on cancel or confirm.
+- Improvements for A11Y. Added more correct label. Added role attribute. Return focus on cancel or confirm.
 
 ## [2.4.12] - 2023-04-14
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.9.9 ~> 1.10.0], `@semcore/flex-box` [4.7.17 ~> 4.7.19], `@semcore/utils` [3.49.1 ~> 3.50.2]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.9.9 ~> 1.10.0], `@semcore/flex-box` [4.7.17 ~> 4.7.19], `@semcore/utils` [3.49.1 ~> 3.50.2]).
 
 ## [2.4.0] - 2023-02-20
 
 ### Changed
 
-* Animation duration now might be controlled with design tokens.
+- Animation duration now might be controlled with design tokens.
 
 ## [2.3.6] - 2023-01-20
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.8.9 ~> 1.8.10], `@semcore/flex-box` [4.7.6 ~> 4.7.7], `@semcore/utils` [3.45.0 ~> 3.46.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.8.9 ~> 1.8.10], `@semcore/flex-box` [4.7.6 ~> 4.7.7], `@semcore/utils` [3.45.0 ~> 3.46.0]).
 
 ## [2.3.0] - 2022-12-14
 
 ### Added
 
-* Added internationalization of aria attributes.
+- Added internationalization of aria attributes.
 
 ## [2.2.1] - 2022-12-13
 
 ### Changed
 
-* Added `react-dom` to peer dependencies.
+- Added `react-dom` to peer dependencies.
 
 ## [2.2.0] - 2022-12-12
 
 ### Added
 
-* Design tokens based theming.
+- Design tokens based theming.
 
 ## [2.1.4] - 2022-10-28
 
 ### Fixed
 
-* Removed wrong aria role and added needed aria label.
+- Removed wrong aria role and added needed aria label.
 
 ## [2.1.3] - 2022-10-26
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.6.2 ~> 1.7.0]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.6.2 ~> 1.7.0]).
 
 ## [2.1.0] - 2022-10-10
 
 ### Changed
 
-* Added support for React 18 🔥
+- Added support for React 18 🔥
 
 ## [2.0.10] - 2022-10-04
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/flex-box` [4.5.11 ~> 4.5.12], `@semcore/utils` [3.37.1 ~> 3.37.2], `@semcore/animation` [1.5.10 ~> 1.5.11]).
+- Version patch update due to children dependencies update (`@semcore/flex-box` [4.5.11 ~> 4.5.12], `@semcore/utils` [3.37.1 ~> 3.37.2], `@semcore/animation` [1.5.10 ~> 1.5.11]).
 
 ## [2.0.0] - 2022-05-17
 
 ### BREAK
 
-* Updated styles according to the library redesign policy.
+- Updated styles according to the library redesign policy.
 
 ## [1.0.0] - 2022-04-07
 
 ### Added
 
-* Introduced `<InlineEdit />` component.
+- Introduced `<InlineEdit />` component.

--- a/semcore/notice-global/CHANGELOG.md
+++ b/semcore/notice-global/CHANGELOG.md
@@ -6,450 +6,450 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.30.0 ~> 4.31.0], `@semcore/icon` [4.41.0 ~> 4.42.0], `@semcore/flex-box` [5.29.0 ~> 5.30.0], `@semcore/animation` [2.29.0 ~> 2.30.0], `@semcore/core` [2.27.0 ~> 2.28.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.30.0 ~> 4.31.0], `@semcore/icon` [4.41.0 ~> 4.42.0], `@semcore/flex-box` [5.29.0 ~> 5.30.0], `@semcore/animation` [2.29.0 ~> 2.30.0], `@semcore/core` [2.27.0 ~> 2.28.0]).
 
 ## [2.46.0] - 2024-07-05
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/icon` [4.39.1 ~> 4.41.0]).
+- Version minor update due to children dependencies update (`@semcore/icon` [4.39.1 ~> 4.41.0]).
 
 ## [2.45.1] - 2024-06-27
 
 ### Fixed
 
-* Notice only with `danger` theme has aria-label "Critical Notification" (`warning` theme gets "Notification" as all other themes).
+- Notice only with `danger` theme has aria-label "Critical Notification" (`warning` theme gets "Notification" as all other themes).
 
 ## [2.45.0] - 2024-06-19
 
 ### Changed
 
-* Notice with `warning` and `danger` themes now has aria-label "Critical Notification" (other teams has "Notification" as before).
-* Close button aria-label now is "Close Notification" instead of "Close".
+- Notice with `warning` and `danger` themes now has aria-label "Critical Notification" (other teams has "Notification" as before).
+- Close button aria-label now is "Close Notification" instead of "Close".
 
 ## [2.44.3] - 2024-06-12
 
 ### Changed
 
-* Role from `status` to `region`.
+- Role from `status` to `region`.
 
 ### Fixed
 
-* Now `string` is not an allowed value for theme prop.
+- Now `string` is not an allowed value for theme prop.
 
 ## [2.44.2] - 2024-06-12
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [4.28.1 ~> 4.28.2], `@semcore/icon` [4.36.1 ~> 4.37.0], `@semcore/flex-box` [5.27.1 ~> 5.27.2], `@semcore/animation` [2.27.1 ~> 2.27.2], `@semcore/core` [2.25.1 ~> 2.25.2]).
+- Version patch update due to children dependencies update (`@semcore/utils` [4.28.1 ~> 4.28.2], `@semcore/icon` [4.36.1 ~> 4.37.0], `@semcore/flex-box` [5.27.1 ~> 5.27.2], `@semcore/animation` [2.27.1 ~> 2.27.2], `@semcore/core` [2.25.1 ~> 2.25.2]).
 
 ## [2.44.1] - 2024-05-28
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [4.28.0 ~> 4.28.1], `@semcore/icon` [4.36.0 ~> 4.36.1], `@semcore/flex-box` [5.27.0 ~> 5.27.1], `@semcore/animation` [2.27.0 ~> 2.27.1], `@semcore/core` [2.25.0 ~> 2.25.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [4.28.0 ~> 4.28.1], `@semcore/icon` [4.36.0 ~> 4.36.1], `@semcore/flex-box` [5.27.0 ~> 5.27.1], `@semcore/animation` [2.27.0 ~> 2.27.1], `@semcore/core` [2.25.0 ~> 2.25.1]).
 
 ## [2.44.0] - 2024-05-23
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.27.0 ~> 4.28.0], `@semcore/icon` [4.35.0 ~> 4.36.0], `@semcore/flex-box` [5.26.0 ~> 5.27.0], `@semcore/animation` [2.26.0 ~> 2.27.0], `@semcore/core` [2.24.0 ~> 2.25.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.27.0 ~> 4.28.0], `@semcore/icon` [4.35.0 ~> 4.36.0], `@semcore/flex-box` [5.26.0 ~> 5.27.0], `@semcore/animation` [2.26.0 ~> 2.27.0], `@semcore/core` [2.24.0 ~> 2.25.0]).
 
 ## [2.43.0] - 2024-05-22
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.26.2 ~> 4.27.0], `@semcore/icon` [4.34.1 ~> 4.35.0], `@semcore/flex-box` [5.25.1 ~> 5.26.0], `@semcore/animation` [2.25.1 ~> 2.26.0], `@semcore/core` [2.23.1 ~> 2.24.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.26.2 ~> 4.27.0], `@semcore/icon` [4.34.1 ~> 4.35.0], `@semcore/flex-box` [5.25.1 ~> 5.26.0], `@semcore/animation` [2.25.1 ~> 2.26.0], `@semcore/core` [2.23.1 ~> 2.24.0]).
 
 ## [2.42.1] - 2024-05-17
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [4.26.1 ~> 4.26.2], `@semcore/icon` [4.34.0 ~> 4.34.1], `@semcore/flex-box` [5.25.0 ~> 5.25.1], `@semcore/animation` [2.25.0 ~> 2.25.1], `@semcore/core` [2.23.0 ~> 2.23.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [4.26.1 ~> 4.26.2], `@semcore/icon` [4.34.0 ~> 4.34.1], `@semcore/flex-box` [5.25.0 ~> 5.25.1], `@semcore/animation` [2.25.0 ~> 2.25.1], `@semcore/core` [2.23.0 ~> 2.23.1]).
 
 ## [2.42.0] - 2024-05-17
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.25.0 ~> 4.26.1], `@semcore/icon` [4.33.0 ~> 4.34.0], `@semcore/flex-box` [5.24.0 ~> 5.25.0], `@semcore/animation` [2.24.0 ~> 2.25.0], `@semcore/core` [2.22.0 ~> 2.23.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.25.0 ~> 4.26.1], `@semcore/icon` [4.33.0 ~> 4.34.0], `@semcore/flex-box` [5.24.0 ~> 5.25.0], `@semcore/animation` [2.24.0 ~> 2.25.0], `@semcore/core` [2.22.0 ~> 2.23.0]).
 
 ## [2.41.0] - 2024-05-16
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.23.2 ~> 4.24.0], `@semcore/icon` [4.31.2 ~> 4.32.0], `@semcore/flex-box` [5.22.2 ~> 5.23.0], `@semcore/animation` [2.22.2 ~> 2.23.0], `@semcore/core` [2.20.2 ~> 2.21.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.23.2 ~> 4.24.0], `@semcore/icon` [4.31.2 ~> 4.32.0], `@semcore/flex-box` [5.22.2 ~> 5.23.0], `@semcore/animation` [2.22.2 ~> 2.23.0], `@semcore/core` [2.20.2 ~> 2.21.0]).
 
 ## [2.39.2] - 2024-04-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [4.23.1 ~> 4.23.2], `@semcore/icon` [4.31.1 ~> 4.31.2], `@semcore/flex-box` [5.22.1 ~> 5.22.2], `@semcore/animation` [2.22.1 ~> 2.22.2], `@semcore/core` [2.20.1 ~> 2.20.2]).
+- Version patch update due to children dependencies update (`@semcore/utils` [4.23.1 ~> 4.23.2], `@semcore/icon` [4.31.1 ~> 4.31.2], `@semcore/flex-box` [5.22.1 ~> 5.22.2], `@semcore/animation` [2.22.1 ~> 2.22.2], `@semcore/core` [2.20.1 ~> 2.20.2]).
 
 ## [2.39.1] - 2024-04-16
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [4.23.0 ~> 4.23.1], `@semcore/icon` [4.31.0 ~> 4.31.1], `@semcore/flex-box` [5.22.0 ~> 5.22.1], `@semcore/animation` [2.22.0 ~> 2.22.1], `@semcore/core` [2.20.0 ~> 2.20.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [4.23.0 ~> 4.23.1], `@semcore/icon` [4.31.0 ~> 4.31.1], `@semcore/flex-box` [5.22.0 ~> 5.22.1], `@semcore/animation` [2.22.0 ~> 2.22.1], `@semcore/core` [2.20.0 ~> 2.20.1]).
 
 ## [2.39.0] - 2024-04-15
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.22.2 ~> 4.23.0], `@semcore/icon` [4.30.2 ~> 4.31.0], `@semcore/flex-box` [5.21.2 ~> 5.22.0], `@semcore/animation` [2.21.2 ~> 2.22.0], `@semcore/core` [2.19.2 ~> 2.20.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.22.2 ~> 4.23.0], `@semcore/icon` [4.30.2 ~> 4.31.0], `@semcore/flex-box` [5.21.2 ~> 5.22.0], `@semcore/animation` [2.21.2 ~> 2.22.0], `@semcore/core` [2.19.2 ~> 2.20.0]).
 
 ## [2.38.2] - 2024-04-10
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [4.22.1 ~> 4.22.2], `@semcore/icon` [4.30.1 ~> 4.30.2], `@semcore/flex-box` [5.21.1 ~> 5.21.2], `@semcore/animation` [2.21.1 ~> 2.21.2], `@semcore/core` [2.19.1 ~> 2.19.2]).
+- Version patch update due to children dependencies update (`@semcore/utils` [4.22.1 ~> 4.22.2], `@semcore/icon` [4.30.1 ~> 4.30.2], `@semcore/flex-box` [5.21.1 ~> 5.21.2], `@semcore/animation` [2.21.1 ~> 2.21.2], `@semcore/core` [2.19.1 ~> 2.19.2]).
 
 ## [2.38.1] - 2024-04-09
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [4.22.0 ~> 4.22.1], `@semcore/icon` [4.30.0 ~> 4.30.1], `@semcore/flex-box` [5.21.0 ~> 5.21.1], `@semcore/animation` [2.21.0 ~> 2.21.1], `@semcore/core` [2.19.0 ~> 2.19.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [4.22.0 ~> 4.22.1], `@semcore/icon` [4.30.0 ~> 4.30.1], `@semcore/flex-box` [5.21.0 ~> 5.21.1], `@semcore/animation` [2.21.0 ~> 2.21.1], `@semcore/core` [2.19.0 ~> 2.19.1]).
 
 ## [2.38.0] - 2024-03-27
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.21.1 ~> 4.22.0], `@semcore/icon` [4.29.1 ~> 4.30.0], `@semcore/flex-box` [5.20.1 ~> 5.21.0], `@semcore/animation` [2.20.1 ~> 2.21.0], `@semcore/core` [2.18.1 ~> 2.19.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.21.1 ~> 4.22.0], `@semcore/icon` [4.29.1 ~> 4.30.0], `@semcore/flex-box` [5.20.1 ~> 5.21.0], `@semcore/animation` [2.20.1 ~> 2.21.0], `@semcore/core` [2.18.1 ~> 2.19.0]).
 
 ## [2.37.1] - 2024-03-26
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [4.21.0 ~> 4.21.1], `@semcore/icon` [4.29.0 ~> 4.29.1], `@semcore/flex-box` [5.20.0 ~> 5.20.1], `@semcore/animation` [2.20.0 ~> 2.20.1], `@semcore/core` [2.18.0 ~> 2.18.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [4.21.0 ~> 4.21.1], `@semcore/icon` [4.29.0 ~> 4.29.1], `@semcore/flex-box` [5.20.0 ~> 5.20.1], `@semcore/animation` [2.20.0 ~> 2.20.1], `@semcore/core` [2.18.0 ~> 2.18.1]).
 
 ## [2.37.0] - 2024-03-22
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/icon` [4.28.0 ~> 4.29.0]).
+- Version minor update due to children dependencies update (`@semcore/icon` [4.28.0 ~> 4.29.0]).
 
 ## [2.36.0] - 2024-03-15
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.20.5 ~> 4.21.0], `@semcore/icon` [4.27.1 ~> 4.28.0], `@semcore/flex-box` [5.19.4 ~> 5.20.0], `@semcore/animation` [2.19.2 ~> 2.20.0], `@semcore/core` [2.17.5 ~> 2.18.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.20.5 ~> 4.21.0], `@semcore/icon` [4.27.1 ~> 4.28.0], `@semcore/flex-box` [5.19.4 ~> 5.20.0], `@semcore/animation` [2.19.2 ~> 2.20.0], `@semcore/core` [2.17.5 ~> 2.18.0]).
 
 ## [2.35.5] - 2024-03-07
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/animation` [2.19.1 ~> 2.19.2]).
+- Version prepatch update due to children dependencies update (`@semcore/animation` [2.19.1 ~> 2.19.2]).
 
 ## [2.35.4] - 2024-03-06
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.20.4 ~> 4.20.5], `@semcore/icon` [4.27.0 ~> 4.27.1], `@semcore/flex-box` [5.19.3 ~> 5.19.4], `@semcore/animation` [2.19.0 ~> 2.19.1], `@semcore/core` [2.17.4 ~> 2.17.5]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.20.4 ~> 4.20.5], `@semcore/icon` [4.27.0 ~> 4.27.1], `@semcore/flex-box` [5.19.3 ~> 5.19.4], `@semcore/animation` [2.19.0 ~> 2.19.1], `@semcore/core` [2.17.4 ~> 2.17.5]).
 
 ## [2.35.3] - 2024-03-01
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.20.3 ~> 4.20.4], `@semcore/icon` [4.26.1 ~> 4.27.0], `@semcore/flex-box` [5.19.2 ~> 5.19.3], `@semcore/animation` [2.18.3 ~> 2.19.0], `@semcore/core` [2.17.3 ~> 2.17.4]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.20.3 ~> 4.20.4], `@semcore/icon` [4.26.1 ~> 4.27.0], `@semcore/flex-box` [5.19.2 ~> 5.19.3], `@semcore/animation` [2.18.3 ~> 2.19.0], `@semcore/core` [2.17.3 ~> 2.17.4]).
 
 ## [2.35.2] - 2024-02-21
 
 ### Changed
 
-* Version prerelease update due to children dependencies update (`@semcore/icon` [4.26.1-prerelease.10 ~> 4.26.1], `@semcore/flex-box` [5.19.2-prerelease.10 ~> 5.19.2], `@semcore/animation` [2.18.3-prerelease.10 ~> 2.18.3], `@semcore/core` [2.17.3-prerelease.10 ~> 2.17.3]).
+- Version prerelease update due to children dependencies update (`@semcore/icon` [4.26.1-prerelease.10 ~> 4.26.1], `@semcore/flex-box` [5.19.2-prerelease.10 ~> 5.19.2], `@semcore/animation` [2.18.3-prerelease.10 ~> 2.18.3], `@semcore/core` [2.17.3-prerelease.10 ~> 2.17.3]).
 
 ## [2.35.1] - 2024-02-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.20.2 ~> 4.20.3], `@semcore/icon` [4.26.0 ~> 4.26.1], `@semcore/flex-box` [5.19.1 ~> 5.19.2], `@semcore/animation` [2.18.2 ~> 2.18.3], `@semcore/core` [2.17.2 ~> 2.17.3]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.20.2 ~> 4.20.3], `@semcore/icon` [4.26.0 ~> 4.26.1], `@semcore/flex-box` [5.19.1 ~> 5.19.2], `@semcore/animation` [2.18.2 ~> 2.18.3], `@semcore/core` [2.17.2 ~> 2.17.3]).
 
 ## [2.35.0] - 2024-02-14
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.25.0 ~> 4.26.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.25.0 ~> 4.26.0]).
 
 ## [2.34.2] - 2024-02-09
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.20.1 ~> 4.20.2], `@semcore/icon` [4.24.1 ~> 4.25.0], `@semcore/flex-box` [5.19.0 ~> 5.19.1], `@semcore/animation` [2.18.1 ~> 2.18.2], `@semcore/core` [2.17.1 ~> 2.17.2]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.20.1 ~> 4.20.2], `@semcore/icon` [4.24.1 ~> 4.25.0], `@semcore/flex-box` [5.19.0 ~> 5.19.1], `@semcore/animation` [2.18.1 ~> 2.18.2], `@semcore/core` [2.17.1 ~> 2.17.2]).
 
 ## [2.34.1] - 2024-02-06
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.20.0 ~> 4.20.1], `@semcore/icon` [4.24.0 ~> 4.24.1], `@semcore/flex-box` [5.18.0 ~> 5.19.0], `@semcore/animation` [2.18.0 ~> 2.18.1], `@semcore/core` [2.17.0 ~> 2.17.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.20.0 ~> 4.20.1], `@semcore/icon` [4.24.0 ~> 4.24.1], `@semcore/flex-box` [5.18.0 ~> 5.19.0], `@semcore/animation` [2.18.0 ~> 2.18.1], `@semcore/core` [2.17.0 ~> 2.17.1]).
 
 ## [2.34.0] - 2024-02-01
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.19.1 ~> 4.20.0], `@semcore/icon` [4.23.1 ~> 4.24.0], `@semcore/flex-box` [5.17.1 ~> 5.18.0], `@semcore/animation` [2.17.1 ~> 2.18.0], `@semcore/core` [2.16.1 ~> 2.17.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.19.1 ~> 4.20.0], `@semcore/icon` [4.23.1 ~> 4.24.0], `@semcore/flex-box` [5.17.1 ~> 5.18.0], `@semcore/animation` [2.17.1 ~> 2.18.0], `@semcore/core` [2.16.1 ~> 2.17.0]).
 
 ## [2.33.1] - 2024-02-01
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.19.0 ~> 4.19.1], `@semcore/icon` [4.23.0 ~> 4.23.1], `@semcore/flex-box` [5.17.0 ~> 5.17.1], `@semcore/animation` [2.17.0 ~> 2.17.1], `@semcore/core` [2.16.0 ~> 2.16.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.19.0 ~> 4.19.1], `@semcore/icon` [4.23.0 ~> 4.23.1], `@semcore/flex-box` [5.17.0 ~> 5.17.1], `@semcore/animation` [2.17.0 ~> 2.17.1], `@semcore/core` [2.16.0 ~> 2.16.1]).
 
 ## [2.33.0] - 2024-01-31
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.18.0 ~> 4.19.0], `@semcore/icon` [4.22.0 ~> 4.23.0], `@semcore/flex-box` [5.16.0 ~> 5.17.0], `@semcore/animation` [2.16.0 ~> 2.17.0], `@semcore/core` [2.15.0 ~> 2.16.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.18.0 ~> 4.19.0], `@semcore/icon` [4.22.0 ~> 4.23.0], `@semcore/flex-box` [5.16.0 ~> 5.17.0], `@semcore/animation` [2.16.0 ~> 2.17.0], `@semcore/core` [2.15.0 ~> 2.16.0]).
 
 ## [2.32.0] - 2024-01-19
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.17.0 ~> 4.18.0], `@semcore/icon` [4.21.0 ~> 4.22.0], `@semcore/flex-box` [5.15.0 ~> 5.16.0], `@semcore/animation` [2.15.0 ~> 2.16.0], `@semcore/core` [2.14.0 ~> 2.15.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.17.0 ~> 4.18.0], `@semcore/icon` [4.21.0 ~> 4.22.0], `@semcore/flex-box` [5.15.0 ~> 5.16.0], `@semcore/animation` [2.15.0 ~> 2.16.0], `@semcore/core` [2.14.0 ~> 2.15.0]).
 
 ## [2.31.0] - 2024-01-19
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.20.2 ~> 4.21.0], `@semcore/flex-box` [5.14.1 ~> 5.15.0], `@semcore/animation` [2.14.1 ~> 2.15.0], `@semcore/core` [2.13.1 ~> 2.14.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.20.2 ~> 4.21.0], `@semcore/flex-box` [5.14.1 ~> 5.15.0], `@semcore/animation` [2.14.1 ~> 2.15.0], `@semcore/core` [2.13.1 ~> 2.14.0]).
 
 ## [2.30.2] - 2024-01-15
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/icon` [4.20.1 ~> 4.20.2]).
+- Version prepatch update due to children dependencies update (`@semcore/icon` [4.20.1 ~> 4.20.2]).
 
 ## [2.30.1] - 2024-01-10
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.16.0 ~> 4.16.2], `@semcore/icon` [4.20.0 ~> 4.20.1], `@semcore/flex-box` [5.14.0 ~> 5.14.1], `@semcore/animation` [2.14.0 ~> 2.14.1], `@semcore/core` [2.13.0 ~> 2.13.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.16.0 ~> 4.16.2], `@semcore/icon` [4.20.0 ~> 4.20.1], `@semcore/flex-box` [5.14.0 ~> 5.14.1], `@semcore/animation` [2.14.0 ~> 2.14.1], `@semcore/core` [2.13.0 ~> 2.13.1]).
 
 ## [2.30.0] - 2023-12-22
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.15.1 ~> 4.16.0], `@semcore/icon` [4.19.1 ~> 4.20.0], `@semcore/flex-box` [5.13.1 ~> 5.14.0], `@semcore/animation` [2.13.1 ~> 2.14.0], `@semcore/core` [2.12.1 ~> 2.13.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.15.1 ~> 4.16.0], `@semcore/icon` [4.19.1 ~> 4.20.0], `@semcore/flex-box` [5.13.1 ~> 5.14.0], `@semcore/animation` [2.13.1 ~> 2.14.0], `@semcore/core` [2.12.1 ~> 2.13.0]).
 
 ## [2.29.1] - 2023-12-19
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.15.0 ~> 4.15.1], `@semcore/icon` [4.19.0 ~> 4.19.1], `@semcore/flex-box` [5.13.0 ~> 5.13.1], `@semcore/animation` [2.13.0 ~> 2.13.1], `@semcore/core` [2.12.0 ~> 2.12.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.15.0 ~> 4.15.1], `@semcore/icon` [4.19.0 ~> 4.19.1], `@semcore/flex-box` [5.13.0 ~> 5.13.1], `@semcore/animation` [2.13.0 ~> 2.13.1], `@semcore/core` [2.12.0 ~> 2.12.1]).
 
 ## [2.29.0] - 2023-12-06
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.18.0 ~> 4.19.0], `@semcore/flex-box` [5.12.0 ~> 5.13.0], `@semcore/animation` [2.12.0 ~> 2.13.0], `@semcore/core` [2.11.0 ~> 2.12.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.18.0 ~> 4.19.0], `@semcore/flex-box` [5.12.0 ~> 5.13.0], `@semcore/animation` [2.12.0 ~> 2.13.0], `@semcore/core` [2.11.0 ~> 2.12.0]).
 
 ## [2.28.0] - 2023-12-04
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.13.0 ~> 4.14.0], `@semcore/icon` [4.17.0 ~> 4.18.0], `@semcore/flex-box` [5.11.0 ~> 5.12.0], `@semcore/animation` [2.11.0 ~> 2.12.0], `@semcore/core` [2.10.0 ~> 2.11.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.13.0 ~> 4.14.0], `@semcore/icon` [4.17.0 ~> 4.18.0], `@semcore/flex-box` [5.11.0 ~> 5.12.0], `@semcore/animation` [2.11.0 ~> 2.12.0], `@semcore/core` [2.10.0 ~> 2.11.0]).
 
 ## [2.27.0] - 2023-11-24
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.10.3 ~> 4.13.0], `@semcore/icon` [4.16.1 ~> 4.17.0], `@semcore/flex-box` [5.10.2 ~> 5.11.0], `@semcore/animation` [2.10.2 ~> 2.11.0], `@semcore/core` [2.9.2 ~> 2.10.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.10.3 ~> 4.13.0], `@semcore/icon` [4.16.1 ~> 4.17.0], `@semcore/flex-box` [5.10.2 ~> 5.11.0], `@semcore/animation` [2.10.2 ~> 2.11.0], `@semcore/core` [2.9.2 ~> 2.10.0]).
 
 ## [2.26.1] - 2023-11-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/icon` [4.16.0 ~> 4.16.1], `@semcore/flex-box` [5.10.1 ~> 5.10.2], `@semcore/animation` [2.10.1 ~> 2.10.2], `@semcore/core` [2.9.1 ~> 2.9.2]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/icon` [4.16.0 ~> 4.16.1], `@semcore/flex-box` [5.10.1 ~> 5.10.2], `@semcore/animation` [2.10.1 ~> 2.10.2], `@semcore/core` [2.9.1 ~> 2.9.2]).
 
 ## [2.26.0] - 2023-11-13
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.15.0 ~> 4.16.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.15.0 ~> 4.16.0]).
 
 ## [2.25.0] - 2023-11-10
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.14.1 ~> 4.15.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.14.1 ~> 4.15.0]).
 
 ## [2.24.1] - 2023-11-09
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.10.1 ~> 4.10.2], `@semcore/icon` [4.14.0 ~> 4.14.1], `@semcore/flex-box` [5.10.0 ~> 5.10.1], `@semcore/animation` [2.10.0 ~> 2.10.1], `@semcore/core` [2.9.0 ~> 2.9.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.10.1 ~> 4.10.2], `@semcore/icon` [4.14.0 ~> 4.14.1], `@semcore/flex-box` [5.10.0 ~> 5.10.1], `@semcore/animation` [2.10.0 ~> 2.10.1], `@semcore/core` [2.9.0 ~> 2.9.1]).
 
 ## [2.24.0] - 2023-11-06
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/icon` [4.13.0 ~> 4.14.0], `@semcore/flex-box` [5.9.0 ~> 5.10.0], `@semcore/animation` [2.9.0 ~> 2.10.0], `@semcore/core` [2.8.0 ~> 2.9.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/icon` [4.13.0 ~> 4.14.0], `@semcore/flex-box` [5.9.0 ~> 5.10.0], `@semcore/animation` [2.9.0 ~> 2.10.0], `@semcore/core` [2.8.0 ~> 2.9.0]).
 
 ## [2.23.0] - 2023-10-26
 
 ### Added
 
-* Design tokens resolving for `theme` prop.
+- Design tokens resolving for `theme` prop.
 
 ## [2.12.0] - 2023-10-26
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.11.2 ~> 4.12.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.11.2 ~> 4.12.0]).
 
 ## [2.11.2] - 2023-10-24
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/icon` [4.11.1 ~> 4.11.2], `@semcore/flex-box` [5.8.1 ~> 5.8.2], `@semcore/animation` [2.8.1 ~> 2.8.2], `@semcore/core` [2.7.6 ~> 2.7.7]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/icon` [4.11.1 ~> 4.11.2], `@semcore/flex-box` [5.8.1 ~> 5.8.2], `@semcore/animation` [2.8.1 ~> 2.8.2], `@semcore/core` [2.7.6 ~> 2.7.7]).
 
 ## [2.11.1] - 2023-10-16
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/icon` [4.11.0 ~> 4.11.1], `@semcore/flex-box` [5.8.0 ~> 5.8.1], `@semcore/animation` [2.8.0 ~> 2.8.1], `@semcore/core` [2.7.5 ~> 2.7.6]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/icon` [4.11.0 ~> 4.11.1], `@semcore/flex-box` [5.8.0 ~> 5.8.1], `@semcore/animation` [2.8.0 ~> 2.8.1], `@semcore/core` [2.7.5 ~> 2.7.6]).
 
 ## [2.11.0] - 2023-10-10
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.10.2 ~> 4.11.0], `@semcore/flex-box` [5.7.5 ~> 5.8.0], `@semcore/animation` [2.7.5 ~> 2.8.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.10.2 ~> 4.11.0], `@semcore/flex-box` [5.7.5 ~> 5.8.0], `@semcore/animation` [2.7.5 ~> 2.8.0]).
 
 ## [2.10.0] - 2023-10-09
 
 ### Added
 
-* `nl` locale support.
+- `nl` locale support.
 
 ## [2.9.5] - 2023-10-06
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.1 ~> 4.8.2], `@semcore/icon` [4.10.1 ~> 4.10.2], `@semcore/flex-box` [5.7.4 ~> 5.7.5], `@semcore/animation` [2.7.4 ~> 2.7.5], `@semcore/core` [2.7.4 ~> 2.7.5]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.1 ~> 4.8.2], `@semcore/icon` [4.10.1 ~> 4.10.2], `@semcore/flex-box` [5.7.4 ~> 5.7.5], `@semcore/animation` [2.7.4 ~> 2.7.5], `@semcore/core` [2.7.4 ~> 2.7.5]).
 
 ## [2.9.4] - 2023-10-03
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/icon` [4.10.0 ~> 4.10.1], `@semcore/flex-box` [5.7.3 ~> 5.7.4], `@semcore/animation` [2.7.3 ~> 2.7.4], `@semcore/core` [2.7.3 ~> 2.7.4]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/icon` [4.10.0 ~> 4.10.1], `@semcore/flex-box` [5.7.3 ~> 5.7.4], `@semcore/animation` [2.7.3 ~> 2.7.4], `@semcore/core` [2.7.3 ~> 2.7.4]).
 
 ## [2.9.3] - 2023-10-02
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/icon` [4.9.2 ~> 4.10.0], `@semcore/flex-box` [5.7.2 ~> 5.7.3], `@semcore/animation` [2.7.2 ~> 2.7.3], `@semcore/core` [2.7.2 ~> 2.7.3]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/icon` [4.9.2 ~> 4.10.0], `@semcore/flex-box` [5.7.2 ~> 5.7.3], `@semcore/animation` [2.7.2 ~> 2.7.3], `@semcore/core` [2.7.2 ~> 2.7.3]).
 
 ## [2.9.2] - 2023-09-20
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/icon` [4.9.1 ~> 4.9.2], `@semcore/flex-box` [5.7.1 ~> 5.7.2], `@semcore/animation` [2.7.1 ~> 2.7.2], `@semcore/core` [2.7.1 ~> 2.7.2]).
+- Version prepatch update due to children dependencies update (`@semcore/icon` [4.9.1 ~> 4.9.2], `@semcore/flex-box` [5.7.1 ~> 5.7.2], `@semcore/animation` [2.7.1 ~> 2.7.2], `@semcore/core` [2.7.1 ~> 2.7.2]).
 
 ## [2.9.1] - 2023-09-20
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.7.0 ~> 4.7.1], `@semcore/icon` [4.9.0 ~> 4.9.1], `@semcore/flex-box` [5.7.0 ~> 5.7.1], `@semcore/animation` [2.7.0 ~> 2.7.1], `@semcore/core` [2.7.0 ~> 2.7.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.7.0 ~> 4.7.1], `@semcore/icon` [4.9.0 ~> 4.9.1], `@semcore/flex-box` [5.7.0 ~> 5.7.1], `@semcore/animation` [2.7.0 ~> 2.7.1], `@semcore/core` [2.7.0 ~> 2.7.1]).
 
 ## [2.9.0] - 2023-09-19
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.8.3 ~> 4.9.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.8.3 ~> 4.9.0]).
 
 ## [2.8.3] - 2023-09-13
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/icon` [4.8.2 ~> 4.8.3], `@semcore/flex-box` [5.6.3 ~> 5.7.0], `@semcore/animation` [2.6.3 ~> 2.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/icon` [4.8.2 ~> 4.8.3], `@semcore/flex-box` [5.6.3 ~> 5.7.0], `@semcore/animation` [2.6.3 ~> 2.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
 
 ## [2.8.2] - 2023-09-12
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/icon` [4.8.1 ~> 4.8.2], `@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/animation` [2.6.2 ~> 2.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
+- Version prepatch update due to children dependencies update (`@semcore/icon` [4.8.1 ~> 4.8.2], `@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/animation` [2.6.2 ~> 2.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
 
 ## [2.8.1] - 2023-09-08
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/icon` [4.8.0 ~> 4.8.1], `@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/animation` [2.6.1 ~> 2.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/icon` [4.8.0 ~> 4.8.1], `@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/animation` [2.6.1 ~> 2.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
 
 ## [2.8.0] - 2023-09-05
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.7.1 ~> 4.8.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.7.1 ~> 4.8.0]).
 
 ## [2.7.1] - 2023-09-05
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/icon` [4.7.0 ~> 4.7.1], `@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/animation` [2.6.0 ~> 2.6.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
+- Version prepatch update due to children dependencies update (`@semcore/icon` [4.7.0 ~> 4.7.1], `@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/animation` [2.6.0 ~> 2.6.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
 
 ## [2.7.0] - 2023-09-04
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.6.0 ~> 4.7.0], `@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/animation` [2.5.0 ~> 2.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.6.0 ~> 4.7.0], `@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/animation` [2.5.0 ~> 2.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
 
 ## [2.6.0] - 2023-08-28
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/icon` [4.5.1 ~> 4.6.0], `@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/animation` [2.4.1 ~> 2.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/icon` [4.5.1 ~> 4.6.0], `@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/animation` [2.4.1 ~> 2.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
 
 ## [2.5.1] - 2023-08-24
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/icon` [4.5.0 ~> 4.5.1], `@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/animation` [2.4.0 ~> 2.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/icon` [4.5.0 ~> 4.5.1], `@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/animation` [2.4.0 ~> 2.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
 
 ## [2.5.0] - 2023-08-23
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/icon` [4.4.1 ~> 4.5.0], `@semcore/flex-box` [5.3.1 ~> 5.4.0], `@semcore/animation` [2.3.1 ~> 2.4.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.3.1 ~> 4.4.0], `@semcore/icon` [4.4.1 ~> 4.5.0], `@semcore/flex-box` [5.3.1 ~> 5.4.0], `@semcore/animation` [2.3.1 ~> 2.4.0], `@semcore/core` [2.3.1 ~> 2.4.0]).
 
 ## [2.4.1] - 2023-08-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/icon` [4.4.0 ~> 4.4.1], `@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/animation` [2.3.0 ~> 2.3.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
+- Version prepatch update due to children dependencies update (`@semcore/icon` [4.4.0 ~> 4.4.1], `@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/animation` [2.3.0 ~> 2.3.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
 
 ## [2.4.0] - 2023-08-18
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/icon` [4.3.1 ~> 4.4.0], `@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/animation` [2.2.1 ~> 2.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/icon` [4.3.1 ~> 4.4.0], `@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/animation` [2.2.1 ~> 2.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
 
 ## [2.3.1] - 2023-08-16
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/icon` [4.3.0 ~> 4.3.1], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/animation` [2.2.0 ~> 2.2.1], `@semcore/core` [2.2.0 ~> 2.2.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/icon` [4.3.0 ~> 4.3.1], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/animation` [2.2.0 ~> 2.2.1], `@semcore/core` [2.2.0 ~> 2.2.1]).
 
 ## [2.3.0] - 2023-08-07
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.0.0 ~> 4.1.0], `@semcore/icon` [4.2.0 ~> 4.3.0], `@semcore/flex-box` [5.1.0 ~> 5.2.0], `@semcore/animation` [2.1.0 ~> 2.2.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.0.0 ~> 4.1.0], `@semcore/icon` [4.2.0 ~> 4.3.0], `@semcore/flex-box` [5.1.0 ~> 5.2.0], `@semcore/animation` [2.1.0 ~> 2.2.0]).
 
 ## [2.2.0] - 2023-08-01
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/icon` [4.1.0 ~> 4.2.0], `@semcore/flex-box` [5.0.0 ~> 5.1.0], `@semcore/animation` [2.0.0 ~> 2.1.0]).
+- Version minor update due to children dependencies update (`@semcore/icon` [4.1.0 ~> 4.2.0], `@semcore/flex-box` [5.0.0 ~> 5.1.0], `@semcore/animation` [2.0.0 ~> 2.1.0]).
 
 ## [2.1.0] - 2023-07-27
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/icon` [4.0.0 ~> 4.1.0]).
+- Version minor update due to children dependencies update (`@semcore/icon` [4.0.0 ~> 4.1.0]).
 
 ## [2.0.0] - 2023-07-17
 
 ### Break
 
-* Strict, backward incompatible typings.
+- Strict, backward incompatible typings.
 
 ## [1.7.4] - 2023-06-30
 
@@ -457,97 +457,97 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [3.15.3 ~> 3.16.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [3.15.3 ~> 3.16.0]).
 
 ## [1.7.2] - 2023-06-27
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.4 ~> 3.54.0], `@semcore/icon` [3.15.2 ~> 3.15.3], `@semcore/flex-box` [4.7.31 ~> 4.7.32], `@semcore/animation` [1.10.19 ~> 1.10.20]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.4 ~> 3.54.0], `@semcore/icon` [3.15.2 ~> 3.15.3], `@semcore/flex-box` [4.7.31 ~> 4.7.32], `@semcore/animation` [1.10.19 ~> 1.10.20]).
 
 ## [1.7.1] - 2023-06-14
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.3 ~> 3.53.4], `@semcore/icon` [3.15.1 ~> 3.15.2], `@semcore/flex-box` [4.7.30 ~> 4.7.31], `@semcore/animation` [1.10.18 ~> 1.10.19]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.3 ~> 3.53.4], `@semcore/icon` [3.15.1 ~> 3.15.2], `@semcore/flex-box` [4.7.30 ~> 4.7.31], `@semcore/animation` [1.10.18 ~> 1.10.19]).
 
 ## [1.7.0] - 2023-06-12
 
 ### Added
 
-* Swedish (`sv`) locale support.
+- Swedish (`sv`) locale support.
 
 ## [1.6.2] - 2023-06-12
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.2 ~> 3.53.3], `@semcore/icon` [3.15.0 ~> 3.15.1], `@semcore/flex-box` [4.7.29 ~> 4.7.30], `@semcore/animation` [1.10.17 ~> 1.10.18]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.2 ~> 3.53.3], `@semcore/icon` [3.15.0 ~> 3.15.1], `@semcore/flex-box` [4.7.29 ~> 4.7.30], `@semcore/animation` [1.10.17 ~> 1.10.18]).
 
 ## [1.6.1] - 2023-06-09
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.1 ~> 3.53.2], `@semcore/icon` [3.14.16 ~> 3.15.0], `@semcore/flex-box` [4.7.28 ~> 4.7.29], `@semcore/animation` [1.10.16 ~> 1.10.17]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.1 ~> 3.53.2], `@semcore/icon` [3.14.16 ~> 3.15.0], `@semcore/flex-box` [4.7.28 ~> 4.7.29], `@semcore/animation` [1.10.16 ~> 1.10.17]).
 
 ## [1.6.0] - 2023-06-09
 
 ### Added
 
-* Polish (`pl`) locale support.
+- Polish (`pl`) locale support.
 
 ## [1.5.30] - 2023-06-07
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.0 ~> 3.53.1], `@semcore/icon` [3.14.15 ~> 3.14.16], `@semcore/flex-box` [4.7.27 ~> 4.7.28], `@semcore/animation` [1.10.15 ~> 1.10.16]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.0 ~> 3.53.1], `@semcore/icon` [3.14.15 ~> 3.14.16], `@semcore/flex-box` [4.7.27 ~> 4.7.28], `@semcore/animation` [1.10.15 ~> 1.10.16]).
 
 ## [1.5.29] - 2023-06-02
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.14 ~> 1.10.15]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.14 ~> 1.10.15]).
 
 ## [1.5.28] - 2023-05-31
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.52.0 ~> 3.53.0], `@semcore/icon` [3.14.14 ~> 3.14.15], `@semcore/flex-box` [4.7.26 ~> 4.7.27], `@semcore/animation` [1.10.13 ~> 1.10.14]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.52.0 ~> 3.53.0], `@semcore/icon` [3.14.14 ~> 3.14.15], `@semcore/flex-box` [4.7.26 ~> 4.7.27], `@semcore/animation` [1.10.13 ~> 1.10.14]).
 
 ## [1.5.27] - 2023-05-29
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.10.12 ~> 1.10.13]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.10.12 ~> 1.10.13]).
 
 ## [1.5.26] - 2023-05-25
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.51.1 ~> 3.52.0], `@semcore/icon` [3.14.13 ~> 3.14.14], `@semcore/flex-box` [4.7.25 ~> 4.7.26], `@semcore/animation` [1.10.11 ~> 1.10.12]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.51.1 ~> 3.52.0], `@semcore/icon` [3.14.13 ~> 3.14.14], `@semcore/flex-box` [4.7.25 ~> 4.7.26], `@semcore/animation` [1.10.11 ~> 1.10.12]).
 
 ## [1.5.25] - 2023-05-24
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.51.0 ~> 3.51.1], `@semcore/icon` [3.14.12 ~> 3.14.13], `@semcore/flex-box` [4.7.24 ~> 4.7.25], `@semcore/animation` [1.10.10 ~> 1.10.11]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.51.0 ~> 3.51.1], `@semcore/icon` [3.14.12 ~> 3.14.13], `@semcore/flex-box` [4.7.24 ~> 4.7.25], `@semcore/animation` [1.10.10 ~> 1.10.11]).
 
 ## [1.5.24] - 2023-05-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.7 ~> 3.51.0], `@semcore/icon` [3.14.11 ~> 3.14.12], `@semcore/flex-box` [4.7.23 ~> 4.7.24], `@semcore/animation` [1.10.9 ~> 1.10.10]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.7 ~> 3.51.0], `@semcore/icon` [3.14.11 ~> 3.14.12], `@semcore/flex-box` [4.7.23 ~> 4.7.24], `@semcore/animation` [1.10.9 ~> 1.10.10]).
 
 ## [1.5.23] - 2023-05-11
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7], `@semcore/icon` [3.14.10 ~> 3.14.11], `@semcore/flex-box` [4.7.22 ~> 4.7.23], `@semcore/animation` [1.10.8 ~> 1.10.9]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7], `@semcore/icon` [3.14.10 ~> 3.14.11], `@semcore/flex-box` [4.7.22 ~> 4.7.23], `@semcore/animation` [1.10.8 ~> 1.10.9]).
 
 ## [1.5.22] - 2023-05-04
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.5 ~> 3.50.6], `@semcore/icon` [3.14.9 ~> 3.14.10], `@semcore/flex-box` [4.7.21 ~> 4.7.22], `@semcore/animation` [1.10.7 ~> 1.10.8]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.5 ~> 3.50.6], `@semcore/icon` [3.14.9 ~> 3.14.10], `@semcore/flex-box` [4.7.21 ~> 4.7.22], `@semcore/animation` [1.10.7 ~> 1.10.8]).
 
 ## [1.5.20] - 2023-05-02
 
@@ -559,7 +559,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.0 ~> 3.50.3], `@semcore/icon` [3.14.6 ~> 3.14.7], `@semcore/flex-box` [4.7.18 ~> 4.7.19], `@semcore/animation` [1.10.1 ~> 1.10.2]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.0 ~> 3.50.3], `@semcore/icon` [3.14.6 ~> 3.14.7], `@semcore/flex-box` [4.7.18 ~> 4.7.19], `@semcore/animation` [1.10.1 ~> 1.10.2]).
 
 ## [1.5.16] - 2023-04-03
 
@@ -567,7 +567,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.49.1 ~> 3.50.0], `@semcore/icon` [3.14.5 ~> 3.14.6], `@semcore/flex-box` [4.7.17 ~> 4.7.18], `@semcore/animation` [1.9.9 ~> 1.10.0]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.49.1 ~> 3.50.0], `@semcore/icon` [3.14.5 ~> 3.14.6], `@semcore/flex-box` [4.7.17 ~> 4.7.18], `@semcore/animation` [1.9.9 ~> 1.10.0]).
 
 ## [1.5.5] - 2023-03-01
 
@@ -575,7 +575,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/animation` [1.9.1 ~> 1.9.2]).
+- Version patch update due to children dependencies update (`@semcore/animation` [1.9.1 ~> 1.9.2]).
 
 ## [1.5.2] - 2023-02-22
 
@@ -583,19 +583,19 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.47.0 ~> 3.47.1], `@semcore/icon` [3.10.1 ~> 3.10.2], `@semcore/flex-box` [4.7.9 ~> 4.7.10], `@semcore/animation` [1.9.0 ~> 1.9.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.47.0 ~> 3.47.1], `@semcore/icon` [3.10.1 ~> 3.10.2], `@semcore/flex-box` [4.7.9 ~> 4.7.10], `@semcore/animation` [1.9.0 ~> 1.9.1]).
 
 ## [1.5.0] - 2023-02-20
 
 ### Changed
 
-* Animation duration now might be controlled with design tokens.
+- Animation duration now might be controlled with design tokens.
 
 ## [1.4.13] - 2023-02-13
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [3.9.0 ~> 3.10.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [3.9.0 ~> 3.10.0]).
 
 ## [1.4.12] - 2023-02-13
 
@@ -605,7 +605,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.45.0 ~> 3.46.0], `@semcore/icon` [3.7.0 ~> 3.8.0], `@semcore/flex-box` [4.7.6 ~> 4.7.7], `@semcore/animation` [1.8.9 ~> 1.8.10]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.45.0 ~> 3.46.0], `@semcore/icon` [3.7.0 ~> 3.8.0], `@semcore/flex-box` [4.7.6 ~> 4.7.7], `@semcore/animation` [1.8.9 ~> 1.8.10]).
 
 ## [1.4.6] - 2023-01-11
 
@@ -615,37 +615,37 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.44.1 ~> 3.44.2], `@semcore/icon` [3.5.0 ~> 3.5.1], `@semcore/flex-box` [4.7.3 ~> 4.7.4], `@semcore/animation` [1.8.5 ~> 1.8.6]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.44.1 ~> 3.44.2], `@semcore/icon` [3.5.0 ~> 3.5.1], `@semcore/flex-box` [4.7.3 ~> 4.7.4], `@semcore/animation` [1.8.5 ~> 1.8.6]).
 
 ## [1.4.3] - 2022-12-28
 
 ### Added
 
-* Added cursor change when hovering `NoticeGlobal.CloseIcon`.
+- Added cursor change when hovering `NoticeGlobal.CloseIcon`.
 
 ## [1.4.2] - 2022-12-27
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [3.4.3 ~> 3.5.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [3.4.3 ~> 3.5.0]).
 
 ## [1.4.0] - 2022-12-14
 
 ### Added
 
-* Added internationalization of aria attributes.
+- Added internationalization of aria attributes.
 
 ## [1.3.1] - 2022-12-13
 
 ### Changed
 
-* Added `react-dom` to peer dependencies.
+- Added `react-dom` to peer dependencies.
 
 ## [1.3.0] - 2022-12-12
 
 ### Added
 
-* Design tokens based theming.
+- Design tokens based theming.
 
 ## [1.2.7] - 2022-11-08
 
@@ -653,47 +653,47 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.40.0 ~> 3.40.0], `@semcore/icon` [3.1.1 ~> 3.1.2], `@semcore/flex-box` [4.6.2 ~> 4.6.3], `@semcore/animation` [1.7.0 ~> 1.7.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.40.0 ~> 3.40.0], `@semcore/icon` [3.1.1 ~> 3.1.2], `@semcore/flex-box` [4.6.2 ~> 4.6.3], `@semcore/animation` [1.7.0 ~> 1.7.1]).
 
 ## [1.2.0] - 2022-10-10
 
 ### Changed
 
-* Added support for React 18 🔥
-* Extended version range for dependency `@semcore/icons`.
+- Added support for React 18 🔥
+- Extended version range for dependency `@semcore/icons`.
 
 ## [1.1.18] - 2022-10-06
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [2.32.2 ~> 2.33.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [2.32.2 ~> 2.33.0]).
 
 ## [1.1.10] - 2022-08-23
 
 ### Added
 
-* Added aria-live attribute for better accessibility.
+- Added aria-live attribute for better accessibility.
 
 ## [1.1.9] - 2022-08-18
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [2.30.0 ~> 2.30.1]).
+- Version patch update due to children dependencies update (`@semcore/icon` [2.30.0 ~> 2.30.1]).
 
 ## [1.1.0] - 2022-06-01
 
 ### Changed
 
-* Changed type names from 'NoticeTheme' to 'NoticeGlobalTheme' so that there are no intersections with other components.
+- Changed type names from 'NoticeTheme' to 'NoticeGlobalTheme' so that there are no intersections with other components.
 
 ## [1.0.1] - 2022-05-31
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.32.1 ~> 3.32.2], `@semcore/icon` [2.26.0 ~> 2.26.1], `@semcore/flex-box` [4.5.3 ~> 4.5.4], `@semcore/animation` [1.5.1 ~> 1.5.2]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.32.1 ~> 3.32.2], `@semcore/icon` [2.26.0 ~> 2.26.1], `@semcore/flex-box` [4.5.3 ~> 4.5.4], `@semcore/animation` [1.5.1 ~> 1.5.2]).
 
 ## [1.0.0] - 2022-05-30
 
 ### Added
 
-* Initial release
+- Initial release

--- a/semcore/tag/CHANGELOG.md
+++ b/semcore/tag/CHANGELOG.md
@@ -6,469 +6,469 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.30.0 ~> 4.31.0], `@semcore/icon` [4.41.0 ~> 4.42.0], `@semcore/flex-box` [5.29.0 ~> 5.30.0], `@semcore/core` [2.27.0 ~> 2.28.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.30.0 ~> 4.31.0], `@semcore/icon` [4.41.0 ~> 4.42.0], `@semcore/flex-box` [5.29.0 ~> 5.30.0], `@semcore/core` [2.27.0 ~> 2.28.0]).
 
 ## [5.39.0] - 2024-07-05
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/icon` [4.39.1 ~> 4.41.0]).
+- Version minor update due to children dependencies update (`@semcore/icon` [4.39.1 ~> 4.41.0]).
 
 ## [5.38.1] - 2024-07-05
 
 ### Changed
 
-* Roles for the container and tag content.
+- Roles for the container and tag content.
 
 ## [5.38.0] - 2024-06-26
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.29.0 ~> 4.30.0], `@semcore/icon` [4.38.0 ~> 4.39.1], `@semcore/flex-box` [5.28.0 ~> 5.29.0], `@semcore/core` [2.26.0 ~> 2.27.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.29.0 ~> 4.30.0], `@semcore/icon` [4.38.0 ~> 4.39.1], `@semcore/flex-box` [5.28.0 ~> 5.29.0], `@semcore/core` [2.26.0 ~> 2.27.0]).
 
 ## [5.37.0] - 2024-06-13
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.28.2 ~> 4.29.0], `@semcore/icon` [4.37.0 ~> 4.38.0], `@semcore/flex-box` [5.27.2 ~> 5.28.0], `@semcore/core` [2.25.2 ~> 2.26.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.28.2 ~> 4.29.0], `@semcore/icon` [4.37.0 ~> 4.38.0], `@semcore/flex-box` [5.27.2 ~> 5.28.0], `@semcore/core` [2.25.2 ~> 2.26.0]).
 
 ## [5.36.2] - 2024-06-12
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [4.28.1 ~> 4.28.2], `@semcore/icon` [4.36.1 ~> 4.37.0], `@semcore/flex-box` [5.27.1 ~> 5.27.2], `@semcore/core` [2.25.1 ~> 2.25.2]).
+- Version patch update due to children dependencies update (`@semcore/utils` [4.28.1 ~> 4.28.2], `@semcore/icon` [4.36.1 ~> 4.37.0], `@semcore/flex-box` [5.27.1 ~> 5.27.2], `@semcore/core` [2.25.1 ~> 2.25.2]).
 
 ## [5.36.1] - 2024-05-28
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [4.28.0 ~> 4.28.1], `@semcore/icon` [4.36.0 ~> 4.36.1], `@semcore/flex-box` [5.27.0 ~> 5.27.1], `@semcore/core` [2.25.0 ~> 2.25.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [4.28.0 ~> 4.28.1], `@semcore/icon` [4.36.0 ~> 4.36.1], `@semcore/flex-box` [5.27.0 ~> 5.27.1], `@semcore/core` [2.25.0 ~> 2.25.1]).
 
 ## [5.36.0] - 2024-05-23
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.27.0 ~> 4.28.0], `@semcore/icon` [4.35.0 ~> 4.36.0], `@semcore/flex-box` [5.26.0 ~> 5.27.0], `@semcore/core` [2.24.0 ~> 2.25.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.27.0 ~> 4.28.0], `@semcore/icon` [4.35.0 ~> 4.36.0], `@semcore/flex-box` [5.26.0 ~> 5.27.0], `@semcore/core` [2.24.0 ~> 2.25.0]).
 
 ## [5.35.0] - 2024-05-22
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.26.2 ~> 4.27.0], `@semcore/icon` [4.34.1 ~> 4.35.0], `@semcore/flex-box` [5.25.1 ~> 5.26.0], `@semcore/core` [2.23.1 ~> 2.24.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.26.2 ~> 4.27.0], `@semcore/icon` [4.34.1 ~> 4.35.0], `@semcore/flex-box` [5.25.1 ~> 5.26.0], `@semcore/core` [2.23.1 ~> 2.24.0]).
 
 ## [5.34.1] - 2024-05-17
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [4.26.1 ~> 4.26.2], `@semcore/icon` [4.34.0 ~> 4.34.1], `@semcore/flex-box` [5.25.0 ~> 5.25.1], `@semcore/core` [2.23.0 ~> 2.23.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [4.26.1 ~> 4.26.2], `@semcore/icon` [4.34.0 ~> 4.34.1], `@semcore/flex-box` [5.25.0 ~> 5.25.1], `@semcore/core` [2.23.0 ~> 2.23.1]).
 
 ## [5.34.0] - 2024-05-17
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.25.0 ~> 4.26.1], `@semcore/icon` [4.33.0 ~> 4.34.0], `@semcore/flex-box` [5.24.0 ~> 5.25.0], `@semcore/core` [2.22.0 ~> 2.23.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.25.0 ~> 4.26.1], `@semcore/icon` [4.33.0 ~> 4.34.0], `@semcore/flex-box` [5.24.0 ~> 5.25.0], `@semcore/core` [2.22.0 ~> 2.23.0]).
 
 ## [5.33.0] - 2024-05-16
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.23.2 ~> 4.24.0], `@semcore/icon` [4.31.2 ~> 4.32.0], `@semcore/flex-box` [5.22.2 ~> 5.23.0], `@semcore/core` [2.20.2 ~> 2.21.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.23.2 ~> 4.24.0], `@semcore/icon` [4.31.2 ~> 4.32.0], `@semcore/flex-box` [5.22.2 ~> 5.23.0], `@semcore/core` [2.20.2 ~> 2.21.0]).
 
 ## [5.31.2] - 2024-04-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [4.23.1 ~> 4.23.2], `@semcore/icon` [4.31.1 ~> 4.31.2], `@semcore/flex-box` [5.22.1 ~> 5.22.2], `@semcore/core` [2.20.1 ~> 2.20.2]).
+- Version patch update due to children dependencies update (`@semcore/utils` [4.23.1 ~> 4.23.2], `@semcore/icon` [4.31.1 ~> 4.31.2], `@semcore/flex-box` [5.22.1 ~> 5.22.2], `@semcore/core` [2.20.1 ~> 2.20.2]).
 
 ## [5.31.1] - 2024-04-16
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [4.23.0 ~> 4.23.1], `@semcore/icon` [4.31.0 ~> 4.31.1], `@semcore/flex-box` [5.22.0 ~> 5.22.1], `@semcore/core` [2.20.0 ~> 2.20.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [4.23.0 ~> 4.23.1], `@semcore/icon` [4.31.0 ~> 4.31.1], `@semcore/flex-box` [5.22.0 ~> 5.22.1], `@semcore/core` [2.20.0 ~> 2.20.1]).
 
 ## [5.31.0] - 2024-04-15
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.22.2 ~> 4.23.0], `@semcore/icon` [4.30.2 ~> 4.31.0], `@semcore/flex-box` [5.21.2 ~> 5.22.0], `@semcore/core` [2.19.2 ~> 2.20.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.22.2 ~> 4.23.0], `@semcore/icon` [4.30.2 ~> 4.31.0], `@semcore/flex-box` [5.21.2 ~> 5.22.0], `@semcore/core` [2.19.2 ~> 2.20.0]).
 
 ## [5.30.4] - 2024-04-15
 
 ### Fixed
 
-* Interactive tags were calling keyDown event handler twice.
+- Interactive tags were calling keyDown event handler twice.
 
 ## [5.30.3] - 2024-04-11
 
 ### Fixed
 
-* Focused tag was rendering focus ring even if it wasn't marked as interactive.
+- Focused tag was rendering focus ring even if it wasn't marked as interactive.
 
 ## [5.30.2] - 2024-04-10
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [4.22.1 ~> 4.22.2], `@semcore/icon` [4.30.1 ~> 4.30.2], `@semcore/flex-box` [5.21.1 ~> 5.21.2], `@semcore/core` [2.19.1 ~> 2.19.2]).
+- Version patch update due to children dependencies update (`@semcore/utils` [4.22.1 ~> 4.22.2], `@semcore/icon` [4.30.1 ~> 4.30.2], `@semcore/flex-box` [5.21.1 ~> 5.21.2], `@semcore/core` [2.19.1 ~> 2.19.2]).
 
 ## [5.30.1] - 2024-04-09
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [4.22.0 ~> 4.22.1], `@semcore/icon` [4.30.0 ~> 4.30.1], `@semcore/flex-box` [5.21.0 ~> 5.21.1], `@semcore/core` [2.19.0 ~> 2.19.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [4.22.0 ~> 4.22.1], `@semcore/icon` [4.30.0 ~> 4.30.1], `@semcore/flex-box` [5.21.0 ~> 5.21.1], `@semcore/core` [2.19.0 ~> 2.19.1]).
 
 ## [5.30.0] - 2024-03-27
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.21.1 ~> 4.22.0], `@semcore/icon` [4.29.1 ~> 4.30.0], `@semcore/flex-box` [5.20.1 ~> 5.21.0], `@semcore/core` [2.18.1 ~> 2.19.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.21.1 ~> 4.22.0], `@semcore/icon` [4.29.1 ~> 4.30.0], `@semcore/flex-box` [5.20.1 ~> 5.21.0], `@semcore/core` [2.18.1 ~> 2.19.0]).
 
 ## [5.29.1] - 2024-03-26
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [4.21.0 ~> 4.21.1], `@semcore/icon` [4.29.0 ~> 4.29.1], `@semcore/flex-box` [5.20.0 ~> 5.20.1], `@semcore/core` [2.18.0 ~> 2.18.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [4.21.0 ~> 4.21.1], `@semcore/icon` [4.29.0 ~> 4.29.1], `@semcore/flex-box` [5.20.0 ~> 5.20.1], `@semcore/core` [2.18.0 ~> 2.18.1]).
 
 ## [5.29.0] - 2024-03-22
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/icon` [4.28.0 ~> 4.29.0]).
+- Version minor update due to children dependencies update (`@semcore/icon` [4.28.0 ~> 4.29.0]).
 
 ## [5.28.0] - 2024-03-15
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.20.5 ~> 4.21.0], `@semcore/icon` [4.27.1 ~> 4.28.0], `@semcore/flex-box` [5.19.4 ~> 5.20.0], `@semcore/core` [2.17.5 ~> 2.18.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.20.5 ~> 4.21.0], `@semcore/icon` [4.27.1 ~> 4.28.0], `@semcore/flex-box` [5.19.4 ~> 5.20.0], `@semcore/core` [2.17.5 ~> 2.18.0]).
 
 ## [5.27.4] - 2024-03-05
 
 ### Changed
 
-* Use `event.key` instead of `event.code`.
+- Use `event.key` instead of `event.code`.
 
 ## [5.27.3] - 2024-03-01
 
 ### Fixed
 
-* Order in layers for `Tag.Close` component for correct handling `onClick` events.
+- Order in layers for `Tag.Close` component for correct handling `onClick` events.
 
 ## [5.27.2] - 2024-02-21
 
 ### Changed
 
-* Version prerelease update due to children dependencies update (`@semcore/icon` [4.26.1-prerelease.10 ~> 4.26.1], `@semcore/flex-box` [5.19.2-prerelease.10 ~> 5.19.2], `@semcore/core` [2.17.3-prerelease.10 ~> 2.17.3]).
+- Version prerelease update due to children dependencies update (`@semcore/icon` [4.26.1-prerelease.10 ~> 4.26.1], `@semcore/flex-box` [5.19.2-prerelease.10 ~> 5.19.2], `@semcore/core` [2.17.3-prerelease.10 ~> 2.17.3]).
 
 ## [5.27.1] - 2024-02-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.20.2 ~> 4.20.3], `@semcore/icon` [4.26.0 ~> 4.26.1], `@semcore/flex-box` [5.19.1 ~> 5.19.2], `@semcore/core` [2.17.2 ~> 2.17.3]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.20.2 ~> 4.20.3], `@semcore/icon` [4.26.0 ~> 4.26.1], `@semcore/flex-box` [5.19.1 ~> 5.19.2], `@semcore/core` [2.17.2 ~> 2.17.3]).
 
 ## [5.27.0] - 2024-02-19
 
 ### Changed
 
-* Interactive tags keyboard focused ring style adjusted to same focus ring styles of other components.
-* Interactive tags now get `role=button`.
-* If tag contains `Tag.Close`, tag will not be focusable. Instead, focus will go to `Tag.Text`.
+- Interactive tags keyboard focused ring style adjusted to same focus ring styles of other components.
+- Interactive tags now get `role=button`.
+- If tag contains `Tag.Close`, tag will not be focusable. Instead, focus will go to `Tag.Text`.
 
 ## [5.26.0] - 2024-02-13
 
 ### Changed
 
-* Tags are clickable by `Space` now (along with `Enter` as before).
+- Tags are clickable by `Space` now (along with `Enter` as before).
 
 ## [5.25.2] - 2024-02-09
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.20.1 ~> 4.20.2], `@semcore/icon` [4.24.1 ~> 4.25.0], `@semcore/flex-box` [5.19.0 ~> 5.19.1], `@semcore/core` [2.17.1 ~> 2.17.2]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.20.1 ~> 4.20.2], `@semcore/icon` [4.24.1 ~> 4.25.0], `@semcore/flex-box` [5.19.0 ~> 5.19.1], `@semcore/core` [2.17.1 ~> 2.17.2]).
 
 ## [5.25.1] - 2024-02-06
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.20.0 ~> 4.20.1], `@semcore/icon` [4.24.0 ~> 4.24.1], `@semcore/flex-box` [5.18.0 ~> 5.19.0], `@semcore/core` [2.17.0 ~> 2.17.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.20.0 ~> 4.20.1], `@semcore/icon` [4.24.0 ~> 4.24.1], `@semcore/flex-box` [5.18.0 ~> 5.19.0], `@semcore/core` [2.17.0 ~> 2.17.1]).
 
 ## [5.25.0] - 2024-02-01
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.19.1 ~> 4.20.0], `@semcore/icon` [4.23.1 ~> 4.24.0], `@semcore/flex-box` [5.17.1 ~> 5.18.0], `@semcore/core` [2.16.1 ~> 2.17.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.19.1 ~> 4.20.0], `@semcore/icon` [4.23.1 ~> 4.24.0], `@semcore/flex-box` [5.17.1 ~> 5.18.0], `@semcore/core` [2.16.1 ~> 2.17.0]).
 
 ## [5.24.1] - 2024-02-01
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.19.0 ~> 4.19.1], `@semcore/icon` [4.23.0 ~> 4.23.1], `@semcore/flex-box` [5.17.0 ~> 5.17.1], `@semcore/core` [2.16.0 ~> 2.16.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.19.0 ~> 4.19.1], `@semcore/icon` [4.23.0 ~> 4.23.1], `@semcore/flex-box` [5.17.0 ~> 5.17.1], `@semcore/core` [2.16.0 ~> 2.16.1]).
 
 ## [5.24.0] - 2024-01-31
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.18.0 ~> 4.19.0], `@semcore/icon` [4.22.0 ~> 4.23.0], `@semcore/flex-box` [5.16.0 ~> 5.17.0], `@semcore/core` [2.15.0 ~> 2.16.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.18.0 ~> 4.19.0], `@semcore/icon` [4.22.0 ~> 4.23.0], `@semcore/flex-box` [5.16.0 ~> 5.17.0], `@semcore/core` [2.15.0 ~> 2.16.0]).
 
 ## [5.23.0] - 2024-01-19
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.17.0 ~> 4.18.0], `@semcore/icon` [4.21.0 ~> 4.22.0], `@semcore/flex-box` [5.15.0 ~> 5.16.0], `@semcore/core` [2.14.0 ~> 2.15.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.17.0 ~> 4.18.0], `@semcore/icon` [4.21.0 ~> 4.22.0], `@semcore/flex-box` [5.15.0 ~> 5.16.0], `@semcore/core` [2.14.0 ~> 2.15.0]).
 
 ## [5.22.0] - 2024-01-19
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.20.2 ~> 4.21.0], `@semcore/flex-box` [5.14.1 ~> 5.15.0], `@semcore/core` [2.13.1 ~> 2.14.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.20.2 ~> 4.21.0], `@semcore/flex-box` [5.14.1 ~> 5.15.0], `@semcore/core` [2.13.1 ~> 2.14.0]).
 
 ## [5.21.2] - 2024-01-15
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/icon` [4.20.1 ~> 4.20.2]).
+- Version prepatch update due to children dependencies update (`@semcore/icon` [4.20.1 ~> 4.20.2]).
 
 ## [5.21.1] - 2024-01-10
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.16.0 ~> 4.16.2], `@semcore/icon` [4.20.0 ~> 4.20.1], `@semcore/flex-box` [5.14.0 ~> 5.14.1], `@semcore/core` [2.13.0 ~> 2.13.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.16.0 ~> 4.16.2], `@semcore/icon` [4.20.0 ~> 4.20.1], `@semcore/flex-box` [5.14.0 ~> 5.14.1], `@semcore/core` [2.13.0 ~> 2.13.1]).
 
 ## [5.21.0] - 2023-12-22
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.15.1 ~> 4.16.0], `@semcore/icon` [4.19.1 ~> 4.20.0], `@semcore/flex-box` [5.13.1 ~> 5.14.0], `@semcore/core` [2.12.1 ~> 2.13.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.15.1 ~> 4.16.0], `@semcore/icon` [4.19.1 ~> 4.20.0], `@semcore/flex-box` [5.13.1 ~> 5.14.0], `@semcore/core` [2.12.1 ~> 2.13.0]).
 
 ## [5.20.1] - 2023-12-19
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.15.0 ~> 4.15.1], `@semcore/icon` [4.19.0 ~> 4.19.1], `@semcore/flex-box` [5.13.0 ~> 5.13.1], `@semcore/core` [2.12.0 ~> 2.12.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.15.0 ~> 4.15.1], `@semcore/icon` [4.19.0 ~> 4.19.1], `@semcore/flex-box` [5.13.0 ~> 5.13.1], `@semcore/core` [2.12.0 ~> 2.12.1]).
 
 ## [5.20.0] - 2023-12-06
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.18.0 ~> 4.19.0], `@semcore/flex-box` [5.12.0 ~> 5.13.0], `@semcore/core` [2.11.0 ~> 2.12.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.18.0 ~> 4.19.0], `@semcore/flex-box` [5.12.0 ~> 5.13.0], `@semcore/core` [2.11.0 ~> 2.12.0]).
 
 ## [5.19.0] - 2023-12-04
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.13.0 ~> 4.14.0], `@semcore/icon` [4.17.0 ~> 4.18.0], `@semcore/flex-box` [5.11.0 ~> 5.12.0], `@semcore/core` [2.10.0 ~> 2.11.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.13.0 ~> 4.14.0], `@semcore/icon` [4.17.0 ~> 4.18.0], `@semcore/flex-box` [5.11.0 ~> 5.12.0], `@semcore/core` [2.10.0 ~> 2.11.0]).
 
 ## [5.18.0] - 2023-11-23
 
 ### Added
 
-* Behavior as `Button` when working from the keyboard.
+- Behavior as `Button` when working from the keyboard.
 
 ## [5.17.1] - 2023-11-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/icon` [4.16.0 ~> 4.16.1], `@semcore/flex-box` [5.10.1 ~> 5.10.2], `@semcore/core` [2.9.1 ~> 2.9.2]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.10.2 ~> 4.10.3], `@semcore/icon` [4.16.0 ~> 4.16.1], `@semcore/flex-box` [5.10.1 ~> 5.10.2], `@semcore/core` [2.9.1 ~> 2.9.2]).
 
 ## [5.17.0] - 2023-11-13
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.15.0 ~> 4.16.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.15.0 ~> 4.16.0]).
 
 ## [5.16.0] - 2023-11-10
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.14.1 ~> 4.15.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.14.1 ~> 4.15.0]).
 
 ## [5.15.1] - 2023-11-09
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.10.1 ~> 4.10.2], `@semcore/icon` [4.14.0 ~> 4.14.1], `@semcore/flex-box` [5.10.0 ~> 5.10.1], `@semcore/core` [2.9.0 ~> 2.9.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.10.1 ~> 4.10.2], `@semcore/icon` [4.14.0 ~> 4.14.1], `@semcore/flex-box` [5.10.0 ~> 5.10.1], `@semcore/core` [2.9.0 ~> 2.9.1]).
 
 ## [5.15.0] - 2023-11-06
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/icon` [4.13.0 ~> 4.14.0], `@semcore/flex-box` [5.9.0 ~> 5.10.0], `@semcore/core` [2.8.0 ~> 2.9.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.9.0 ~> 4.10.1], `@semcore/icon` [4.13.0 ~> 4.14.0], `@semcore/flex-box` [5.9.0 ~> 5.10.0], `@semcore/core` [2.8.0 ~> 2.9.0]).
 
 ## [5.14.0] - 2023-10-26
 
 ### Added
 
-* Design tokens resolving for prop `color`.
+- Design tokens resolving for prop `color`.
 
 ### Changed
 
-* Default text color is based on inversed and processed background color.
+- Default text color is based on inversed and processed background color.
 
 ## [5.13.0] - 2023-10-26
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.11.2 ~> 4.12.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.11.2 ~> 4.12.0]).
 
 ## [5.12.2] - 2023-10-24
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/icon` [4.11.1 ~> 4.11.2], `@semcore/flex-box` [5.8.1 ~> 5.8.2], `@semcore/core` [2.7.6 ~> 2.7.7]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.3 ~> 4.8.4], `@semcore/icon` [4.11.1 ~> 4.11.2], `@semcore/flex-box` [5.8.1 ~> 5.8.2], `@semcore/core` [2.7.6 ~> 2.7.7]).
 
 ## [5.12.1] - 2023-10-16
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/icon` [4.11.0 ~> 4.11.1], `@semcore/flex-box` [5.8.0 ~> 5.8.1], `@semcore/core` [2.7.5 ~> 2.7.6]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.2 ~> 4.8.3], `@semcore/icon` [4.11.0 ~> 4.11.1], `@semcore/flex-box` [5.8.0 ~> 5.8.1], `@semcore/core` [2.7.5 ~> 2.7.6]).
 
 ## [5.12.0] - 2023-10-10
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.10.2 ~> 4.11.0], `@semcore/flex-box` [5.7.5 ~> 5.8.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.10.2 ~> 4.11.0], `@semcore/flex-box` [5.7.5 ~> 5.8.0]).
 
 ## [5.11.0] - 2023-10-09
 
 ### Added
 
-* `nl` locale support.
+- `nl` locale support.
 
 ## [5.10.5] - 2023-10-06
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.1 ~> 4.8.2], `@semcore/icon` [4.10.1 ~> 4.10.2], `@semcore/flex-box` [5.7.4 ~> 5.7.5], `@semcore/core` [2.7.4 ~> 2.7.5]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.1 ~> 4.8.2], `@semcore/icon` [4.10.1 ~> 4.10.2], `@semcore/flex-box` [5.7.4 ~> 5.7.5], `@semcore/core` [2.7.4 ~> 2.7.5]).
 
 ## [5.10.4] - 2023-10-03
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/icon` [4.10.0 ~> 4.10.1], `@semcore/flex-box` [5.7.3 ~> 5.7.4], `@semcore/core` [2.7.3 ~> 2.7.4]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.8.0 ~> 4.8.1], `@semcore/icon` [4.10.0 ~> 4.10.1], `@semcore/flex-box` [5.7.3 ~> 5.7.4], `@semcore/core` [2.7.3 ~> 2.7.4]).
 
 ## [5.10.3] - 2023-10-02
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/icon` [4.9.2 ~> 4.10.0], `@semcore/flex-box` [5.7.2 ~> 5.7.3], `@semcore/core` [2.7.2 ~> 2.7.3]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.7.2 ~> 4.8.0], `@semcore/icon` [4.9.2 ~> 4.10.0], `@semcore/flex-box` [5.7.2 ~> 5.7.3], `@semcore/core` [2.7.2 ~> 2.7.3]).
 
 ## [5.10.2] - 2023-09-20
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/icon` [4.9.1 ~> 4.9.2], `@semcore/flex-box` [5.7.1 ~> 5.7.2], `@semcore/core` [2.7.1 ~> 2.7.2]).
+- Version prepatch update due to children dependencies update (`@semcore/icon` [4.9.1 ~> 4.9.2], `@semcore/flex-box` [5.7.1 ~> 5.7.2], `@semcore/core` [2.7.1 ~> 2.7.2]).
 
 ## [5.10.1] - 2023-09-20
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.7.0 ~> 4.7.1], `@semcore/icon` [4.9.0 ~> 4.9.1], `@semcore/flex-box` [5.7.0 ~> 5.7.1], `@semcore/core` [2.7.0 ~> 2.7.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.7.0 ~> 4.7.1], `@semcore/icon` [4.9.0 ~> 4.9.1], `@semcore/flex-box` [5.7.0 ~> 5.7.1], `@semcore/core` [2.7.0 ~> 2.7.1]).
 
 ## [5.10.0] - 2023-09-19
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.8.3 ~> 4.9.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.8.3 ~> 4.9.0]).
 
 ## [5.9.3] - 2023-09-13
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/icon` [4.8.2 ~> 4.8.3], `@semcore/flex-box` [5.6.3 ~> 5.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.3 ~> 4.7.0], `@semcore/icon` [4.8.2 ~> 4.8.3], `@semcore/flex-box` [5.6.3 ~> 5.7.0], `@semcore/core` [2.6.3 ~> 2.7.0]).
 
 ## [5.9.2] - 2023-09-12
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/icon` [4.8.1 ~> 4.8.2], `@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
+- Version prepatch update due to children dependencies update (`@semcore/icon` [4.8.1 ~> 4.8.2], `@semcore/flex-box` [5.6.2 ~> 5.6.3], `@semcore/core` [2.6.2 ~> 2.6.3]).
 
 ## [5.9.1] - 2023-09-08
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/icon` [4.8.0 ~> 4.8.1], `@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.6.1 ~> 4.6.2], `@semcore/icon` [4.8.0 ~> 4.8.1], `@semcore/flex-box` [5.6.1 ~> 5.6.2], `@semcore/core` [2.6.1 ~> 2.6.2]).
 
 ## [5.9.0] - 2023-09-05
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.7.1 ~> 4.8.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.7.1 ~> 4.8.0]).
 
 ## [5.8.1] - 2023-09-05
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/icon` [4.7.0 ~> 4.7.1], `@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
+- Version prepatch update due to children dependencies update (`@semcore/icon` [4.7.0 ~> 4.7.1], `@semcore/flex-box` [5.6.0 ~> 5.6.1], `@semcore/core` [2.6.0 ~> 2.6.1]).
 
 ## [5.8.0] - 2023-09-04
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/icon` [4.6.0 ~> 4.7.0], `@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
+- Version preminor update due to children dependencies update (`@semcore/icon` [4.6.0 ~> 4.7.0], `@semcore/flex-box` [5.5.0 ~> 5.6.0], `@semcore/core` [2.5.0 ~> 2.6.0]).
 
 ## [5.7.0] - 2023-08-28
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/icon` [4.5.1 ~> 4.6.0], `@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.4.1 ~> 4.5.0], `@semcore/icon` [4.5.1 ~> 4.6.0], `@semcore/flex-box` [5.4.1 ~> 5.5.0], `@semcore/core` [2.4.1 ~> 2.5.0]).
 
 ## [5.6.1] - 2023-08-24
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/icon` [4.5.0 ~> 4.5.1], `@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.4.0 ~> 4.4.1], `@semcore/icon` [4.5.0 ~> 4.5.1], `@semcore/flex-box` [5.4.0 ~> 5.4.1], `@semcore/core` [2.4.0 ~> 2.4.1]).
 
 ## [5.6.0] - 2023-08-21
 
 ### Changed
 
-* Improved visual state of focusable tags.
+- Improved visual state of focusable tags.
 
 ## [5.5.1] - 2023-08-21
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/icon` [4.4.0 ~> 4.4.1], `@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
+- Version prepatch update due to children dependencies update (`@semcore/icon` [4.4.0 ~> 4.4.1], `@semcore/flex-box` [5.3.0 ~> 5.3.1], `@semcore/core` [2.3.0 ~> 2.3.1]).
 
 ## [5.5.0] - 2023-08-18
 
 ### Changed
 
-* Version preminor update due to children dependencies update (`@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/icon` [4.3.1 ~> 4.4.0], `@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
+- Version preminor update due to children dependencies update (`@semcore/utils` [4.2.0 ~> 4.3.0], `@semcore/icon` [4.3.1 ~> 4.4.0], `@semcore/flex-box` [5.2.1 ~> 5.3.0], `@semcore/core` [2.2.1 ~> 2.3.0]).
 
 ## [5.4.0] - 2023-08-07
 
 ### Changed
 
-* Remove tag button aria-label now refers both to the tag and remove button itself.
+- Remove tag button aria-label now refers both to the tag and remove button itself.
 
 ## [5.3.1] - 2023-08-16
 
 ### Changed
 
-* Version prepatch update due to children dependencies update (`@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/icon` [4.3.0 ~> 4.3.1], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/core` [2.2.0 ~> 2.2.1]).
+- Version prepatch update due to children dependencies update (`@semcore/utils` [4.1.0 ~> 4.2.0], `@semcore/icon` [4.3.0 ~> 4.3.1], `@semcore/flex-box` [5.2.0 ~> 5.2.1], `@semcore/core` [2.2.0 ~> 2.2.1]).
 
 ## [5.3.0] - 2023-08-07
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/utils` [4.0.0 ~> 4.1.0], `@semcore/icon` [4.2.0 ~> 4.3.0], `@semcore/flex-box` [5.1.0 ~> 5.2.0]).
+- Version minor update due to children dependencies update (`@semcore/utils` [4.0.0 ~> 4.1.0], `@semcore/icon` [4.2.0 ~> 4.3.0], `@semcore/flex-box` [5.1.0 ~> 5.2.0]).
 
 ## [5.2.0] - 2023-08-01
 
 ### Changed
 
-* Version minor update due to children dependencies update (`@semcore/icon` [4.1.0 ~> 4.2.0], `@semcore/flex-box` [5.0.0 ~> 5.1.0]).
+- Version minor update due to children dependencies update (`@semcore/icon` [4.1.0 ~> 4.2.0], `@semcore/flex-box` [5.0.0 ~> 5.1.0]).
 
 ## [5.1.0] - 2023-07-27
 
 ### Changed
 
-* Use `event.key` instead of `event.code` for better support of non QWERTY keyboard layouts.
+- Use `event.key` instead of `event.code` for better support of non QWERTY keyboard layouts.
 
 ## [5.0.0] - 2023-07-17
 
 ### Break
 
-* Strict, backward incompatible typings.
+- Strict, backward incompatible typings.
 
 ## [4.6.4] - 2023-06-30
 
@@ -476,85 +476,85 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [3.15.3 ~> 3.16.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [3.15.3 ~> 3.16.0]).
 
 ## [4.6.2] - 2023-06-27
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.4 ~> 3.54.0], `@semcore/icon` [3.15.2 ~> 3.15.3], `@semcore/flex-box` [4.7.31 ~> 4.7.32]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.4 ~> 3.54.0], `@semcore/icon` [3.15.2 ~> 3.15.3], `@semcore/flex-box` [4.7.31 ~> 4.7.32]).
 
 ## [4.6.1] - 2023-06-14
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.3 ~> 3.53.4], `@semcore/icon` [3.15.1 ~> 3.15.2], `@semcore/flex-box` [4.7.30 ~> 4.7.31]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.3 ~> 3.53.4], `@semcore/icon` [3.15.1 ~> 3.15.2], `@semcore/flex-box` [4.7.30 ~> 4.7.31]).
 
 ## [4.6.0] - 2023-06-12
 
 ### Added
 
-* Swedish (`sv`) locale support.
+- Swedish (`sv`) locale support.
 
 ## [4.5.2] - 2023-06-12
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.2 ~> 3.53.3], `@semcore/icon` [3.15.0 ~> 3.15.1], `@semcore/flex-box` [4.7.29 ~> 4.7.30]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.2 ~> 3.53.3], `@semcore/icon` [3.15.0 ~> 3.15.1], `@semcore/flex-box` [4.7.29 ~> 4.7.30]).
 
 ## [4.5.1] - 2023-06-09
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.1 ~> 3.53.2], `@semcore/icon` [3.14.16 ~> 3.15.0], `@semcore/flex-box` [4.7.28 ~> 4.7.29]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.1 ~> 3.53.2], `@semcore/icon` [3.14.16 ~> 3.15.0], `@semcore/flex-box` [4.7.28 ~> 4.7.29]).
 
 ## [4.5.0] - 2023-06-09
 
 ### Added
 
-* Polish (`pl`) locale support.
+- Polish (`pl`) locale support.
 
 ## [4.4.39] - 2023-06-07
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.53.0 ~> 3.53.1], `@semcore/icon` [3.14.15 ~> 3.14.16], `@semcore/flex-box` [4.7.27 ~> 4.7.28]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.53.0 ~> 3.53.1], `@semcore/icon` [3.14.15 ~> 3.14.16], `@semcore/flex-box` [4.7.27 ~> 4.7.28]).
 
 ## [4.4.38] - 2023-05-31
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.52.0 ~> 3.53.0], `@semcore/icon` [3.14.14 ~> 3.14.15], `@semcore/flex-box` [4.7.26 ~> 4.7.27]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.52.0 ~> 3.53.0], `@semcore/icon` [3.14.14 ~> 3.14.15], `@semcore/flex-box` [4.7.26 ~> 4.7.27]).
 
 ## [4.4.37] - 2023-05-25
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.51.1 ~> 3.52.0], `@semcore/icon` [3.14.13 ~> 3.14.14], `@semcore/flex-box` [4.7.25 ~> 4.7.26]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.51.1 ~> 3.52.0], `@semcore/icon` [3.14.13 ~> 3.14.14], `@semcore/flex-box` [4.7.25 ~> 4.7.26]).
 
 ## [4.4.36] - 2023-05-24
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.51.0 ~> 3.51.1], `@semcore/icon` [3.14.12 ~> 3.14.13], `@semcore/flex-box` [4.7.24 ~> 4.7.25]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.51.0 ~> 3.51.1], `@semcore/icon` [3.14.12 ~> 3.14.13], `@semcore/flex-box` [4.7.24 ~> 4.7.25]).
 
 ## [4.4.35] - 2023-05-22
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.7 ~> 3.51.0], `@semcore/icon` [3.14.11 ~> 3.14.12], `@semcore/flex-box` [4.7.23 ~> 4.7.24]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.7 ~> 3.51.0], `@semcore/icon` [3.14.11 ~> 3.14.12], `@semcore/flex-box` [4.7.23 ~> 4.7.24]).
 
 ## [4.4.34] - 2023-05-11
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7], `@semcore/icon` [3.14.10 ~> 3.14.11], `@semcore/flex-box` [4.7.22 ~> 4.7.23]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.6 ~> 3.50.7], `@semcore/icon` [3.14.10 ~> 3.14.11], `@semcore/flex-box` [4.7.22 ~> 4.7.23]).
 
 ## [4.4.33] - 2023-05-04
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.5 ~> 3.50.6], `@semcore/icon` [3.14.9 ~> 3.14.10], `@semcore/flex-box` [4.7.21 ~> 4.7.22]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.5 ~> 3.50.6], `@semcore/icon` [3.14.9 ~> 3.14.10], `@semcore/flex-box` [4.7.21 ~> 4.7.22]).
 
 ## [4.4.31] - 2023-04-24
 
@@ -562,19 +562,19 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.50.0 ~> 3.50.3], `@semcore/icon` [3.14.6 ~> 3.14.7], `@semcore/flex-box` [4.7.18 ~> 4.7.19]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.50.0 ~> 3.50.3], `@semcore/icon` [3.14.6 ~> 3.14.7], `@semcore/flex-box` [4.7.18 ~> 4.7.19]).
 
 ## [4.4.29] - 2023-04-11
 
 ### Fixed
 
-* Non-interactive tags are not focusable by keyboard now.
+- Non-interactive tags are not focusable by keyboard now.
 
 ## [4.4.28] - 2023-03-28
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.49.1 ~> 3.50.0], `@semcore/icon` [3.14.5 ~> 3.14.6], `@semcore/flex-box` [4.7.17 ~> 4.7.18]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.49.1 ~> 3.50.0], `@semcore/icon` [3.14.5 ~> 3.14.6], `@semcore/flex-box` [4.7.17 ~> 4.7.18]).
 
 ## [4.4.16] - 2023-02-22
 
@@ -582,7 +582,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.47.0 ~> 3.47.1], `@semcore/icon` [3.10.1 ~> 3.10.2], `@semcore/flex-box` [4.7.9 ~> 4.7.10]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.47.0 ~> 3.47.1], `@semcore/icon` [3.10.1 ~> 3.10.2], `@semcore/flex-box` [4.7.9 ~> 4.7.10]).
 
 ## [4.4.12] - 2023-02-13
 
@@ -590,13 +590,13 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Renamed rounding design token (`--intergalactic-rounded-extra-large` -> `--intergalactic-tag-rounded`).
+- Renamed rounding design token (`--intergalactic-rounded-extra-large` -> `--intergalactic-tag-rounded`).
 
 ## [4.4.10] - 2023-01-20
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.45.0 ~> 3.46.0], `@semcore/icon` [3.7.0 ~> 3.8.0], `@semcore/flex-box` [4.7.6 ~> 4.7.7]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.45.0 ~> 3.46.0], `@semcore/icon` [3.7.0 ~> 3.8.0], `@semcore/flex-box` [4.7.6 ~> 4.7.7]).
 
 ## [4.4.7] - 2023-01-11
 
@@ -606,55 +606,55 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.44.1 ~> 3.44.2], `@semcore/icon` [3.5.0 ~> 3.5.1], `@semcore/flex-box` [4.7.3 ~> 4.7.4]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.44.1 ~> 3.44.2], `@semcore/icon` [3.5.0 ~> 3.5.1], `@semcore/flex-box` [4.7.3 ~> 4.7.4]).
 
 ## [4.4.4] - 2023-01-03
 
 ### Fixed
 
-* Fixed CSS variable design tokens.
+- Fixed CSS variable design tokens.
 
 ## [4.4.3] - 2022-12-27
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [3.4.3 ~> 3.5.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [3.4.3 ~> 3.5.0]).
 
 ## [4.4.2] - 2022-12-19
 
 ### Fixed
 
-* Fixed CSS syntax error.
+- Fixed CSS syntax error.
 
 ## [4.4.1] - 2022-12-19
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.44.0 ~> 3.44.1], `@semcore/icon` [3.4.2 ~> 3.4.3], `@semcore/flex-box` [4.7.2 ~> 4.7.3]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.44.0 ~> 3.44.1], `@semcore/icon` [3.4.2 ~> 3.4.3], `@semcore/flex-box` [4.7.2 ~> 4.7.3]).
 
 ## [4.4.0] - 2022-12-14
 
 ### Added
 
-* Added internationalization of aria attributes.
+- Added internationalization of aria attributes.
 
 ## [4.3.1] - 2022-12-13
 
 ### Changed
 
-* Added `react-dom` to peer dependencies.
+- Added `react-dom` to peer dependencies.
 
 ## [4.3.0] - 2022-12-12
 
 ### Added
 
-* Design tokens based theming.
+- Design tokens based theming.
 
 ## [4.2.7] - 2022-11-15
 
 ### Added
 
-* Added hover styles for close icon.
+- Added hover styles for close icon.
 
 ## [4.2.6] - 2022-11-08
 
@@ -662,307 +662,307 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.40.0 ~> 3.40.0], `@semcore/icon` [3.1.1 ~> 3.1.2], `@semcore/flex-box` [4.6.2 ~> 4.6.3]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.40.0 ~> 3.40.0], `@semcore/icon` [3.1.1 ~> 3.1.2], `@semcore/flex-box` [4.6.2 ~> 4.6.3]).
 
 ## [4.2.0] - 2022-10-10
 
 ### Changed
 
-* Added support for React 18 🔥
-* Extended version range for dependency `@semcore/icons`.
+- Added support for React 18 🔥
+- Extended version range for dependency `@semcore/icons`.
 
 ## [4.1.6] - 2022-10-06
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [2.32.2 ~> 2.33.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [2.32.2 ~> 2.33.0]).
 
 ## [4.1.1] - 2022-09-07
 
 ### Fixed
 
-* Enforced inner text font line height to prevent possible bottom cut.
+- Enforced inner text font line height to prevent possible bottom cut.
 
 ## [4.1.0] - 2022-09-05
 
 ### Added
 
-* Added screen reader support
+- Added screen reader support
 
 ## [4.0.17] - 2022-08-30
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.37.0 ~> 3.37.1], `@semcore/icon` [2.30.1 ~> 2.30.2], `@semcore/flex-box` [4.5.10 ~> 4.5.11]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.37.0 ~> 3.37.1], `@semcore/icon` [2.30.1 ~> 2.30.2], `@semcore/flex-box` [4.5.10 ~> 4.5.11]).
 
 ## [4.0.16] - 2022-08-24
 
 ### Fixed
 
-* Update version `@semcore/utils` to use additional color changing functions.
+- Update version `@semcore/utils` to use additional color changing functions.
 
 ## [4.0.15] - 2022-08-18
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [2.30.0 ~> 2.30.1]).
+- Version patch update due to children dependencies update (`@semcore/icon` [2.30.0 ~> 2.30.1]).
 
 ## [4.0.6] - 2022-06-07
 
 ### Fixed
 
-* Fixed non default colors resolving.
+- Fixed non default colors resolving.
 
 ## [4.0.5] - 2022-06-02
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.32.2 ~> 3.33.0], `@semcore/icon` [2.26.1 ~> 2.27.0], `@semcore/flex-box` [4.5.4 ~> 4.5.5]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.32.2 ~> 3.33.0], `@semcore/icon` [2.26.1 ~> 2.27.0], `@semcore/flex-box` [4.5.4 ~> 4.5.5]).
 
 ## [4.0.0] - 2022-05-17
 
 ### BREAK
 
-* Updated styles according to the library redesign policy.
-* Set `primary` as default component theme.
+- Updated styles according to the library redesign policy.
+- Set `primary` as default component theme.
 
 ### Added
 
-* Added `additional` theme.
+- Added `additional` theme.
 
 ## [3.7.3] - 2022-05-16
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/icon` [2.21.0 ~> 2.24.0]).
+- Version patch update due to children dependencies update (`@semcore/icon` [2.21.0 ~> 2.24.0]).
 
 ## [3.7.0] - 2022-03-18
 
 ### Fixed
 
-* Fixed previously lost overflowed text ellipsis.
+- Fixed previously lost overflowed text ellipsis.
 
 ## [3.6.5] - 2022-03-14
 
 ### Changed
 
-* Version patch update due to children dependencies update (`@semcore/utils` [3.31.2 ~> 3.31.2], `@semcore/icon` [2.19.3 ~> 2.19.4], `@semcore/flex-box` [4.5.0 ~> 4.5.1]).
+- Version patch update due to children dependencies update (`@semcore/utils` [3.31.2 ~> 3.31.2], `@semcore/icon` [2.19.3 ~> 2.19.4], `@semcore/flex-box` [4.5.0 ~> 4.5.1]).
 
 ## [3.6.4] - 2022-02-24
 
 ### Added
 
-* Added repository field to package.json file.
+- Added repository field to package.json file.
 
 ## [3.6.3] - 2022-02-22
 
 ### Fixed
 
-* Fixed colors for `primary-warning`.
+- Fixed colors for `primary-warning`.
 
 ## [3.6.2] - 2022-01-18
 
 ### Fixed
 
-* Tag text vertical cut in some rare cases.
+- Tag text vertical cut in some rare cases.
 
 ## [3.6.0] - 2022-01-18
 
 ### Changed
 
-* Up version icons and use new icon.
+- Up version icons and use new icon.
 
 ## [3.5.4] - 2021-12-28
 
 ### Fixed
 
-* [ts] Added type `custom` in property `use`.
+- [ts] Added type `custom` in property `use`.
 
 ## [3.5.3] - 2021-12-23
 
 ### Changed
 
-* Changed `line-height` from 1.2 to 1.1 for correct display in all browsers.
+- Changed `line-height` from 1.2 to 1.1 for correct display in all browsers.
 
 ## [3.5.2] - 2021-12-17
 
 ### Fixed
 
-* Fixed hover for non-interactive tag
+- Fixed hover for non-interactive tag
 
 ## [3.5.1] - 2021-12-17
 
 ### Added
 
-* Added primary-muted theme
+- Added primary-muted theme
 
 ## [3.5.0] - 2021-12-08
 
 ### Added
 
-* Added property for Tag color
+- Added property for Tag color
 
 ### Changed
 
-* Changed the opacity of the Tag color from 0.15 to 0.5.
+- Changed the opacity of the Tag color from 0.15 to 0.5.
 
 ## [3.4.2] - 2021-8-26
 
 ### Changed
 
-* Add 'sideEffect=false' for more optimal build via webpack
+- Add 'sideEffect=false' for more optimal build via webpack
 
 ## [3.4.1] - 2021-07-30
 
 ### Added
 
-* Added line-height value
+- Added line-height value
 
 ## [3.4.0] - 2021-06-22
 
 ### Changed
 
-* Version of dependence `@semcore/core` has been changed to `1.11`.
-* Improved performance. Removed one component wrapper.
-* The style processing system has been changed.
-* Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
-* Rewrite from TS to JS code.
+- Version of dependence `@semcore/core` has been changed to `1.11`.
+- Improved performance. Removed one component wrapper.
+- The style processing system has been changed.
+- Removed the ability to apply media styles via a plugin `babel-plugin-react-semcore`.
+- Rewrite from TS to JS code.
 
 ## [3.3.0] - 2020-12-17
 
 ### Added
 
-* Added supported react@17.
+- Added supported react@17.
 
 ## [3.2.0] - 2020-11-05
 
 ### Added
 
-* Added new warning theme
+- Added new warning theme
 
 ## [3.1.2] - 2020-10-29
 
 ### Fixed
 
-* Added the placeholder for ID style tag to improve collision protection.
+- Added the placeholder for ID style tag to improve collision protection.
 
 ## [3.1.1] - 2020-10-14
 
 ### Fixed
 
-* fixed wrong path for ES6 build
+- fixed wrong path for ES6 build
 
 ## [3.1.0] - 2020-10-13
 
 ### Added
 
-* Added alternative API for inserting `Addon`.
+- Added alternative API for inserting `Addon`.
 
 ### Changed
 
-* Removed `neighbor-location` package dependency
+- Removed `neighbor-location` package dependency
 
 ## [3.0.2] - 2020-09-08
 
 ### Fixed
 
-* Fixed possible styles collisions between components with different versions, but same styles
+- Fixed possible styles collisions between components with different versions, but same styles
 
 ## [3.0.1] - 2020-05-29
 
 ### BREAK
 
-* Изменения описаны в [migration guide](/internal/migration-guide)
+- Изменения описаны в [migration guide](/internal/migration-guide)
 
 ## [2.2.1] - 2019-12-17
 
 ### Fixed
 
-* Исправлен транспайл цветовых переменных для стилей без префиксов (`build.css`)
+- Исправлен транспайл цветовых переменных для стилей без префиксов (`build.css`)
 
 ## [2.2.0] - 2019-12-12
 
 ### Added
 
-* Появилась возможность добавления различных стилистических тем через CSS переменные
-* Появилась возможность оптицонально подключать адаптивноссть
-* Появилась возможность изолировать стили даже в пределах одной страницы
+- Появилась возможность добавления различных стилистических тем через CSS переменные
+- Появилась возможность оптицонально подключать адаптивноссть
+- Появилась возможность изолировать стили даже в пределах одной страницы
 
 ### Changed
 
-* Изменен алгоритм вставки стилей в head
+- Изменен алгоритм вставки стилей в head
 
 ### Removed
 
-* Убраны относительные единицы измерения(rem), которые использовались для адаптивности
+- Убраны относительные единицы измерения(rem), которые использовались для адаптивности
 
 ## [2.1.0] - 2019-11-14
 
 ### Added
 
-* Добавлена адаптивность на маленьких экранах(<768px)
+- Добавлена адаптивность на маленьких экранах(<768px)
 
 ## [2.0.5] - 2019-09-30
 
 ### Changed
 
-* Нужные зависимости перенесены в `utils`, размер должен стать меньше
+- Нужные зависимости перенесены в `utils`, размер должен стать меньше
 
 ## [2.0.4] - 2019-09-13
 
 ### Fixed
 
-* Пользовательский цвет фона при состоянии active стал такой же как и при hover
+- Пользовательский цвет фона при состоянии active стал такой же как и при hover
 
 ## [2.0.3] - 2019-09-05
 
 ### Fixed
 
-* Исправлена ошибка в типизации `Tag.BoxWithNeighborLocation`
+- Исправлена ошибка в типизации `Tag.BoxWithNeighborLocation`
 
 ## [2.0.2] - 2019-08-29
 
 ### Fixed
 
-* Исправлено отображение для `size="m"`, текст больше не обрезается снизу
+- Исправлено отображение для `size="m"`, текст больше не обрезается снизу
 
 ## [2.0.1] - 2019-04-19
 
 ### Added
 
-* текст в `Tag.Text` сворачивается в `ellipsis`
+- текст в `Tag.Text` сворачивается в `ellipsis`
 
 ## [2.0.0] - 2019-03-21
 
 ### Added
 
-* компонет `Tag.Text`
-* стили для отображения `theme="invert" use="secondary"`
+- компонет `Tag.Text`
+- стили для отображения `theme="invert" use="secondary"`
 
 ### Changed
 
-* задание катомного цвета на `theme="нужный вам цвет"`
+- задание катомного цвета на `theme="нужный вам цвет"`
 
 ### Removed
 
-* поддержку свойства `loading`
-* компонет `Tag.Mask`
+- поддержку свойства `loading`
+- компонет `Tag.Mask`
 
 ## [1.0.1] - 2019-02-27
 
 ### Changed
 
-* Подняли версию @semcore/typography
-* Добавили исходники в сборку
+- Подняли версию @semcore/typography
+- Добавили исходники в сборку
 
 ## [1.0.0] - 2018-12-19
 
 ### Fixed
 
-* Исправлен баг покраски компонента через свойства `bg` и `color`
+- Исправлен баг покраски компонента через свойства `bg` и `color`
 
 ## [1.0.0-1] - 2018-11-22
 
 ### Added
 
-* Initial release
+- Initial release

--- a/semcore/tooltip/CHANGELOG.md
+++ b/semcore/tooltip/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [6.39.0] - 2024-07-17
+
+### Added
+
+- `aria-controls` to `DescriptionTooltip.Trigger`.
+
 ## [6.38.0] - 2024-07-16
 
 ### Added

--- a/semcore/tooltip/src/Tooltip.jsx
+++ b/semcore/tooltip/src/Tooltip.jsx
@@ -271,6 +271,7 @@ class DescriptionTooltipRoot extends TooltipRoot {
       'aria-haspopup': !(disabled || props.disabled) ? 'dialog' : 'false',
       'aria-expanded': visible,
       'aria-describedby': undefined,
+      'aria-controls': visible ? `igc-${this.asProps.uid}-popper` : undefined,
       onKeyDown: this.handleTriggerKeyDown,
     };
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

This simple PR adds missing aria attribute to description tooltip trigger

## How has this been tested?

I've manually ensured that attribute present in DOM and correctly reflected in a11y tree.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
