### PR TITLE
Update tooltip a11y final

### DIFF
--- a/website/docs/components/fullscreen-modal/fullscreen-modal-a11y.md
+++ b/website/docs/components/fullscreen-modal/fullscreen-modal-a11y.md
@@ -27,8 +27,8 @@ Table: Roles & attributes
 
 | Component    | Attribute | Usage                                                                                                                                                   |
 | ------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FullscreenModal`         | `role="dialog"`            | Identifies the element that serves as the dialog container. Gets this role from [Modal](/components/modal/modal). |
-| `FullscreenModal`         | `aria-modal="true"`        | Tells assistive technologies that the content underneath the current dialog isn't available for interaction (inert). Gets this attribute from [Modal](/components/modal/modal). |
+| `FullscreenModal`         | `role="dialog"`            | Identifies the element as a dialog, indicating to assistive technology that its content is grouped and separated from the rest of the page content. <br>Gets this role from [Modal](/components/modal/modal). |
+| `FullscreenModal`         | `aria-modal="true"`        | Tells assistive technologies that the content underneath the current dialog isn't available for interaction. <br>Gets this attribute from [Modal](/components/modal/modal). |
 | `FullscreenModal`         | `aria-labelledby="IDREF"`  | Gives the dialog an accessible name by referring to the content of `FullscreenModal.Title`. |
 | `FullscreenModal`         | `aria-describedby="IDREF"` | Gives the dialog an accessible description by referring to the content of `FullscreenModal.Description`. |
 | `FullscreenModal.Close`   | `aria-label="Close"`       | Sets an accessible name for the button that closes the dialog. |

--- a/website/docs/components/modal/modal-a11y.md
+++ b/website/docs/components/modal/modal-a11y.md
@@ -38,11 +38,11 @@ The list below describes roles and attributes that component already has.
 
 Table: Roles & attributes
 
-| Role | Attribute    | Usage                                                                                                                                                   |
-| ---- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dialog` |        | Identifies the element that serves as the dialog container. |
-|          | `aria-labelledby="IDREF"` | Gives the dialog an accessible name by referring to the element that provides the dialog title. |
-|      | `aria-modal="true"` | Tells assistive technologies that the windows underneath the current dialog are not available for interaction (inert). |
+| Attribute                  | Usage                                                                         |
+| -------------------------- | ----------------------------------------------------------------------------- |
+| `role="dialog"`            | Identifies the element as a dialog, indicating to assistive technology that its content is grouped and separated from the rest of the page content. |
+| `aria-labelledby="IDREF"`  | Gives the dialog an accessible name by referring to the element that provides the dialog title. |
+| `aria-modal="true"`        | Tells assistive technologies that the content underneath the current dialog isn't available for interaction. |
 
 ## Considerations for designers & developers
 

--- a/website/docs/components/side-panel/side-panel-a11y.md
+++ b/website/docs/components/side-panel/side-panel-a11y.md
@@ -25,7 +25,7 @@ Table: Default attributes
 
 | Component               | Attribute               | Usage                                       |
 | ----------------------- | ----------------------- | ---------------------------------------------- |
-| `SidePanel`             | `role="dialog"`         | Identifies the element that serves as the dialog container.     |
+| `SidePanel`             | `role="dialog"`         | Identifies the element as a dialog, indicating to assistive technology that its content is grouped and separated from the rest of the page content. |
 | `SidePanel`             | `aria-modal="true"`     | Tells assistive technologies that the content underneath the current dialog is not available for interaction. |
 | `SidePanel.Close`       | `aria-label="Close"`    | Sets the default accessible name for the **Close** button.     |
 

--- a/website/docs/components/tooltip/tooltip-a11y.md
+++ b/website/docs/components/tooltip/tooltip-a11y.md
@@ -85,10 +85,10 @@ Table: DescriptionTooltip default attributes
 
 | Component  | Attribute      | Usage                                                                       |
 | ---------- | -------------- | --------------------------------------------------------------------------- |
-| `Trigger`  | `aria-controls="IDREF"`      | Indicates which element this `Trigger` opens. |
-| `Trigger`  | `aria-expanded`              | Set to `true` when `Popper` is visible. Indicates that the popup is open. |
-| `Trigger`  | `aria-haspopup="true"`       | Indicates that the element triggers a popup. Will be changed to `dialog` in future updates. |
-| `Popper`   | `role="tooltip"`             | Indicates that this element is a tooltip. Will be changed to `dialog` in future updates. |
+| `Trigger`  | `aria-controls="IDREF"`     | Indicates which element this `Trigger` opens. |
+| `Trigger`  | `aria-expanded`             | Set to `true` when `Popper` is visible. Indicates that the popup is open. |
+| `Trigger`  | `aria-haspopup="dialog"`    | Indicates that the element triggers a dialog. |
+| `Popper`   | `role="dialog"`             | Identifies the element as a dialog, indicating to assistive technology that its content is grouped and separated from the rest of the page content.  |
 
 ## Other recommendations
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

1. Updated DescriptionTooltip default a11y properties (due to popper's role having been changed to "dialog").
2. Made `role=dialog` and `aria-modal` descriptions consistent on several component a11y pages.

<img width="755" alt="image" src="https://github.com/user-attachments/assets/e5771983-f9df-4f5d-bb84-4b4c4a02e323">
<img width="1145" alt="image" src="https://github.com/user-attachments/assets/d5b4e9b4-2e9f-489c-bafe-847e47b84723">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
