### PR TITLE
[86bzk6bje][scroll-area] fixed glitches if parend element has decimal value of height or width

### DIFF
--- a/semcore/scroll-area/CHANGELOG.md
+++ b/semcore/scroll-area/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.33.1] - 2024-07-22
+
+### Fixed
+
+- Glitches if the parent of scrollArea has a decimal height or width value.
+
 ## [5.33.0] - 2024-07-13
 
 ### Changed

--- a/semcore/scroll-area/src/ScrollArea.jsx
+++ b/semcore/scroll-area/src/ScrollArea.jsx
@@ -111,7 +111,9 @@ class ScrollAreaRoot extends Component {
 
     if (maxHeight) {
       if (hMax && parent.scrollHeight > parentRect.height) {
-        const diff = parent.scrollHeight - parentRect.height;
+        /** even if height is like 100.486px we should round it to 100, not 101 */
+        const diff =
+          Math.round(parent.scrollHeight.toFixed(1)) - Math.round(parentRect.height.toFixed(1));
 
         if (diff < maxHeight) {
           maxHeight = maxHeight - diff;
@@ -119,7 +121,6 @@ class ScrollAreaRoot extends Component {
           this.$wrapper.style.setProperty('max-height', `${maxHeight}px`);
         }
       }
-
       if (scrollHeight > maxHeight) {
         size.height = `${maxHeight}px`;
       } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
In some case with decimal value of height or width we could have recursion in calculation in scroll area. I've added some round for fix it.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
