### PR TITLE
[86bzmgp7x][scroll-area, dropdown-menu] hid scrollbars from screen readers in listboxes

### DIFF
--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.35.2] - 2024-07-31
+
+### Changed
+
+- Hidden scrollbars inside of listbox from screen readers to comply formal a11y requirements.
+
 ## [4.35.1] - 2024-07-30
 
 ### Changed

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -3,7 +3,7 @@ import cn from 'classnames';
 import createComponent, { Component, sstyled, Root } from '@semcore/core';
 import Dropdown from '@semcore/dropdown';
 import { Flex, useBox } from '@semcore/flex-box';
-import ScrollAreaComponent from '@semcore/scroll-area';
+import ScrollAreaComponent, { hideScrollBarsFromScreenReadersContext } from '@semcore/scroll-area';
 import uniqueIDEnhancement from '@semcore/utils/lib/uniqueID';
 import i18nEnhance from '@semcore/utils/lib/enhances/i18nEnhance';
 import { localizedMessages } from './translations/__intergalactic-dynamic-locales';
@@ -15,6 +15,12 @@ import { setFocus } from '@semcore/utils/lib/focus-lock/setFocus';
 import { isFocusInside } from '@semcore/utils/lib/focus-lock/isFocusInside';
 import { getFocusableIn } from '@semcore/utils/lib/focus-lock/getFocusableIn';
 import keyboardFocusEnhance from '@semcore/utils/lib/enhances/keyboardFocusEnhance';
+
+const ListBoxContextProvider = ({ children }) => (
+  <hideScrollBarsFromScreenReadersContext.Provider value={true}>
+    {children}
+  </hideScrollBarsFromScreenReadersContext.Provider>
+);
 
 class DropdownMenuRoot extends Component {
   static displayName = 'DropdownMenu';
@@ -432,13 +438,15 @@ function List(props) {
   const { uid } = props;
 
   return sstyled(props.styles)(
-    <SDropdownMenuList
-      render={ScrollAreaComponent}
-      tabIndex={null}
-      role='menu'
-      aria-labelledby={`igc-${uid}-trigger`}
-      shadow={true}
-    />,
+    <ListBoxContextProvider>
+      <SDropdownMenuList
+        render={ScrollAreaComponent}
+        tabIndex={null}
+        role='menu'
+        aria-labelledby={`igc-${uid}-trigger`}
+        shadow={true}
+      />
+    </ListBoxContextProvider>,
   );
 }
 
@@ -462,9 +470,11 @@ function Menu(props) {
     animationsDisabled,
   };
   return (
-    <DropdownMenu.Popper {...popperProps}>
-      <Root render={DropdownMenu.List} />
-    </DropdownMenu.Popper>
+    <ListBoxContextProvider>
+      <DropdownMenu.Popper {...popperProps}>
+        <Root render={DropdownMenu.List} />
+      </DropdownMenu.Popper>
+    </ListBoxContextProvider>
   );
 }
 
@@ -528,10 +538,16 @@ function NestingTrigger(props) {
 
   React.useEffect(() => {
     document.addEventListener('mouseover', handleMouseEvent, { capture: true });
-    document.addEventListener('keydown', handleKeyboardEvent, { capture: true });
+    document.addEventListener('keydown', handleKeyboardEvent, {
+      capture: true,
+    });
     return () => {
-      document.removeEventListener('mouseover', handleMouseEvent, { capture: true });
-      document.removeEventListener('keydown', handleKeyboardEvent, { capture: true });
+      document.removeEventListener('mouseover', handleMouseEvent, {
+        capture: true,
+      });
+      document.removeEventListener('keydown', handleKeyboardEvent, {
+        capture: true,
+      });
     };
   }, []);
 

--- a/semcore/scroll-area/CHANGELOG.md
+++ b/semcore/scroll-area/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.35.0] - 2024-07-31
+
+### Add
+
+- Context to hide scrollbars from screen readers.
+
 ## [5.34.1] - 2024-07-30
 
 ### Changed

--- a/semcore/scroll-area/src/ScrollBar.jsx
+++ b/semcore/scroll-area/src/ScrollBar.jsx
@@ -3,8 +3,11 @@ import { findDOMNode } from 'react-dom';
 import createComponent, { Component, sstyled, Root } from '@semcore/core';
 import { Box } from '@semcore/flex-box';
 import { getNodeByRef } from '@semcore/utils/lib/ref';
+import contextEnhance from '@semcore/utils/lib/enhances/contextEnhance';
 
 import style from './style/scroll-bar.shadow.css';
+
+export const hideScrollBarsFromScreenReadersContext = React.createContext(false);
 
 export const DEFAULT_SLIDER_SIZE = 50;
 
@@ -29,6 +32,9 @@ class ScrollBarRoot extends Component {
   static displayName = 'Bar';
 
   static style = style;
+  static enhance = [
+    contextEnhance(hideScrollBarsFromScreenReadersContext, 'hideFromScreenReaders'),
+  ];
 
   static defaultProps = () => {
     return {
@@ -279,7 +285,7 @@ class ScrollBarRoot extends Component {
 
   render() {
     const SScrollBar = Root;
-    const { styles, uid, position, container, orientation } = this.asProps;
+    const { styles, uid, position, container, orientation, hideFromScreenReaders } = this.asProps;
     const { visibleScroll } = this.state;
 
     let { leftOffset, rightOffset, topOffset, bottomOffset } = this.asProps;
@@ -332,11 +338,12 @@ class ScrollBarRoot extends Component {
         top={orientation === 'vertical' && topOffset ? `${topOffset}px` : undefined}
         bottom={orientation === 'vertical' && bottomOffset ? `${bottomOffset}px` : undefined}
         offsetSum={`${offsetSum}px`}
-        role='scrollbar'
+        role={hideFromScreenReaders ? undefined : 'scrollbar'}
+        aria-hidden={hideFromScreenReaders ? 'true' : undefined}
         ref={this.refBar}
-        aria-valuemin={0}
-        aria-controls={`igc-${uid}-scroll-container`}
-        aria-orientation={this.getOrientation()}
+        aria-valuemin={hideFromScreenReaders ? undefined : 0}
+        aria-controls={hideFromScreenReaders ? undefined : `igc-${uid}-scroll-container`}
+        aria-orientation={hideFromScreenReaders ? undefined : this.getOrientation()}
         onMouseDown={this.handleMouseDownBar}
         orientation={this.getOrientation()}
       />,

--- a/semcore/scroll-area/src/index.d.ts
+++ b/semcore/scroll-area/src/index.d.ts
@@ -72,5 +72,7 @@ declare const ScrollArea: Intergalactic.Component<'div', ScrollAreaProps, Scroll
 
 declare const eventCalculate: any;
 
-export { eventCalculate };
+declare const hideScrollBarsFromScreenReadersContext: React.Context<boolean>;
+
+export { eventCalculate, hideScrollBarsFromScreenReadersContext };
 export default ScrollArea;

--- a/semcore/scroll-area/src/index.js
+++ b/semcore/scroll-area/src/index.js
@@ -1,2 +1,3 @@
 export { default } from './ScrollArea';
 export * from './ScrollArea';
+export { hideScrollBarsFromScreenReadersContext } from './ScrollBar';


### PR DESCRIPTION
## Motivation and Context

To meet format requirements of a11y cehcking we need to hide from screen readers scrollbars that are placed inside of listboxes.

## How has this been tested?

Manually with axe web extention.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
