### PR TITLE
[86bztg9zr][popper] passing undefined to `zIndex` prop was removing d…

### DIFF
--- a/semcore/popper/CHANGELOG.md
+++ b/semcore/popper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.39.3] - 2024-08-07
+
+### Fixed
+
+- Passing undefined to `zIndex` prop was removing default `zIndex` value.
+
 ## [5.39.2] - 2024-08-02
 
 ### Added

--- a/semcore/popper/src/Popper.jsx
+++ b/semcore/popper/src/Popper.jsx
@@ -612,6 +612,7 @@ function PopperPopper(props) {
     focusMaster = false,
     handleFocusOut,
     role,
+    zIndex: providedZIndex,
   } = props;
   const ref = React.useRef(null);
   const zIndex = useZIndexStacking('z-index-popper');
@@ -719,7 +720,7 @@ function PopperPopper(props) {
             onInvalid={stopPropagation}
             onReset={stopPropagation}
             onSubmit={stopPropagation}
-            zIndex={zIndex}
+            use:zIndex={providedZIndex ?? zIndex}
           >
             <PortalProvider value={ref}>
               <Children />


### PR DESCRIPTION
…efault `zIndex` value

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Currently feature popover is broken because it always rendered in portal but without z-index.

## How has this been tested?

Manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
