### PR TITLE
[86bzuxqyt][tooltip] fixed too high z-index of tooltip

### DIFF
--- a/semcore/tooltip/CHANGELOG.md
+++ b/semcore/tooltip/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [6.40.3] - 2024-08-08
+
+### Fixed
+
+- `z-index` was too high (default value changed 1500 -> 800).
+
 ## [6.40.2] - 2024-08-02
 
 ### Changed

--- a/semcore/tooltip/src/Tooltip.jsx
+++ b/semcore/tooltip/src/Tooltip.jsx
@@ -131,7 +131,6 @@ function TooltipTrigger(props) {
 
 function TooltipPopper(props) {
   const {
-    visible,
     Children,
     styles,
     theme,
@@ -139,7 +138,6 @@ function TooltipPopper(props) {
     disablePortal,
     ignorePortalsStacking,
     'aria-live': ariaLive,
-    role,
     arrowBgColor,
     arrowShadowColor,
   } = props;
@@ -159,6 +157,7 @@ function TooltipPopper(props) {
             use:disablePortal
             use:theme={resolveColor(theme)}
             use:aria-live={undefined}
+            use:zIndex={undefined}
           >
             <Children />
             <SArrow


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Tooltip wraps popper into additional layer that already has z-index. We need this wrapper cause otherwise VO reads tooltip content twice. So, to remove too high z-index of inner popper (that is tooltip z-index + popper z-index) I've enforced clear of it.

## How has this been tested?

Manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
