### PR TITLE
[86bzxrcv5][accordion] fixed aria-atttributes for toggel element

### DIFF
--- a/semcore/accordion/CHANGELOG.md
+++ b/semcore/accordion/CHANGELOG.md
@@ -4,9 +4,9 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ## [5.38.3] - 2024-08-12
 
-### Changed
+### Added
 
-- Wrap toggle content with element with role `button` and `aria-attributes`.
+- `alignItems=center` property by default to the ToggleButton.
 
 ## [5.38.2] - 2024-08-05
 

--- a/semcore/accordion/CHANGELOG.md
+++ b/semcore/accordion/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.38.3] - 2024-08-12
+
+### Changed
+
+- Wrap toggle content with element with role `button` and `aria-attributes`.
+
 ## [5.38.2] - 2024-08-05
 
 ### Changed

--- a/semcore/accordion/src/Accordion.jsx
+++ b/semcore/accordion/src/Accordion.jsx
@@ -142,7 +142,7 @@ class Toggle extends Component {
   };
 
   render() {
-    const { styles, disabled, use, Children } = this.asProps;
+    const { styles, disabled, use } = this.asProps;
     const SItemToggle = Root;
 
     return sstyled(styles)(
@@ -152,11 +152,7 @@ class Toggle extends Component {
         render={Text}
         onKeyDown={this.handleKeyDown}
         aria-disabled={disabled ? 'true' : undefined}
-      >
-        <Item.ToggleButton>
-          <Children />
-        </Item.ToggleButton>
-      </SItemToggle>,
+      />,
     );
   }
 }

--- a/semcore/accordion/src/Accordion.jsx
+++ b/semcore/accordion/src/Accordion.jsx
@@ -142,7 +142,7 @@ class Toggle extends Component {
   };
 
   render() {
-    const { styles, disabled, use } = this.asProps;
+    const { styles, disabled, use, Children } = this.asProps;
     const SItemToggle = Root;
 
     return sstyled(styles)(
@@ -152,7 +152,11 @@ class Toggle extends Component {
         render={Text}
         onKeyDown={this.handleKeyDown}
         aria-disabled={disabled ? 'true' : undefined}
-      />,
+      >
+        <Item.ToggleButton>
+          <Children />
+        </Item.ToggleButton>
+      </SItemToggle>,
     );
   }
 }
@@ -168,7 +172,9 @@ function ToggleButton(props) {
   const { styles } = props;
 
   const SToggleButton = Root;
-  return sstyled(styles)(<SToggleButton render={Flex} role={'button'} {...props} />);
+  return sstyled(styles)(
+    <SToggleButton alignItems='center' render={Flex} role={'button'} {...props} />,
+  );
 }
 
 function Collapse(props) {

--- a/website/docs/components/accordion/examples/basic_usage.tsx
+++ b/website/docs/components/accordion/examples/basic_usage.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Accordion from 'intergalactic/accordion';
-import { Text } from 'intergalactic/typography';
-import { Flex, Box } from 'intergalactic/flex-box';
+import { Box } from 'intergalactic/flex-box';
 
 const Demo = () => {
   const [value, onChange] = React.useState([0]);
@@ -11,10 +10,8 @@ const Demo = () => {
       {[...new Array(3)].map((_, index) => (
         <Accordion.Item value={index} key={index} disabled={index === 2}>
           <Accordion.Item.Toggle pb={2}>
-            <Flex alignItems='center'>
-              <Accordion.Item.Chevron mr={2} />
-              <Text size={300} my={0}>{`Section ${index + 1}`}</Text>
-            </Flex>
+            <Accordion.Item.Chevron mr={2} />
+            Section {index + 1}
           </Accordion.Item.Toggle>
           <Accordion.Item.Collapse>
             <Box p='12px 24px 24px'>{`Hello Section ${index + 1}`}</Box>

--- a/website/docs/components/accordion/examples/basic_usage.tsx
+++ b/website/docs/components/accordion/examples/basic_usage.tsx
@@ -10,8 +10,10 @@ const Demo = () => {
       {[...new Array(3)].map((_, index) => (
         <Accordion.Item value={index} key={index} disabled={index === 2}>
           <Accordion.Item.Toggle pb={2}>
-            <Accordion.Item.Chevron mr={2} />
-            Section {index + 1}
+            <Accordion.Item.ToggleButton>
+              <Accordion.Item.Chevron mr={2} />
+              Section {index + 1}
+            </Accordion.Item.ToggleButton>
           </Accordion.Item.Toggle>
           <Accordion.Item.Collapse>
             <Box p='12px 24px 24px'>{`Hello Section ${index + 1}`}</Box>

--- a/website/docs/components/accordion/examples/custom_styles.tsx
+++ b/website/docs/components/accordion/examples/custom_styles.tsx
@@ -40,9 +40,7 @@ const Demo = () => {
                   )}
                 >
                   <Accordion.Item.Chevron mr={2} />
-                  <Accordion.Item.ToggleButton my={0}>{`Section ${
-                    index + 1
-                  }`}</Accordion.Item.ToggleButton>
+                  Section {index + 1}
                 </Accordion.Item.Toggle>
                 <Accordion.Item.Collapse>
                   <Box p='12px 32px'>{`Hello Section ${index + 1}`}</Box>

--- a/website/docs/components/accordion/examples/custom_styles.tsx
+++ b/website/docs/components/accordion/examples/custom_styles.tsx
@@ -39,8 +39,10 @@ const Demo = () => {
                     selected && 'styled-accordion-item-selected',
                   )}
                 >
-                  <Accordion.Item.Chevron mr={2} />
-                  Section {index + 1}
+                  <Accordion.Item.ToggleButton>
+                    <Accordion.Item.Chevron mr={2} />
+                    Section {index + 1}
+                  </Accordion.Item.ToggleButton>
                 </Accordion.Item.Toggle>
                 <Accordion.Item.Collapse>
                   <Box p='12px 32px'>{`Hello Section ${index + 1}`}</Box>

--- a/website/docs/components/accordion/examples/non_compact.tsx
+++ b/website/docs/components/accordion/examples/non_compact.tsx
@@ -8,8 +8,10 @@ const Demo = () => {
       {[...new Array(3)].map((_, index) => (
         <Accordion.Item value={index} key={index} disabled={index === 2}>
           <Accordion.Item.Toggle pb={2}>
-            <Accordion.Item.Chevron mr={2} />
-            Section {index + 1}
+            <Accordion.Item.ToggleButton>
+              <Accordion.Item.Chevron mr={2} />
+              Section {index + 1}
+            </Accordion.Item.ToggleButton>
           </Accordion.Item.Toggle>
           <Accordion.Item.Collapse>
             <Box p='12px 24px 24px'>{`Hello Section ${index + 1}`}</Box>

--- a/website/docs/components/accordion/examples/non_compact.tsx
+++ b/website/docs/components/accordion/examples/non_compact.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Accordion from 'intergalactic/accordion';
-import { Text } from 'intergalactic/typography';
-import { Flex, Box } from 'intergalactic/flex-box';
+import { Box } from 'intergalactic/flex-box';
 
 const Demo = () => {
   return (
@@ -9,10 +8,8 @@ const Demo = () => {
       {[...new Array(3)].map((_, index) => (
         <Accordion.Item value={index} key={index} disabled={index === 2}>
           <Accordion.Item.Toggle pb={2}>
-            <Flex alignItems='center'>
-              <Accordion.Item.Chevron mr={2} />
-              <Text size={300} my={0}>{`Section ${index + 1}`}</Text>
-            </Flex>
+            <Accordion.Item.Chevron mr={2} />
+            Section {index + 1}
           </Accordion.Item.Toggle>
           <Accordion.Item.Collapse>
             <Box p='12px 24px 24px'>{`Hello Section ${index + 1}`}</Box>

--- a/website/docs/components/accordion/examples/one_section_opening.tsx
+++ b/website/docs/components/accordion/examples/one_section_opening.tsx
@@ -9,8 +9,10 @@ const Demo = () => {
       {[...new Array(3)].map((_, index) => (
         <Accordion.Item value={index} key={index} disabled={index === 2}>
           <Accordion.Item.Toggle pb={2}>
-            <Accordion.Item.Chevron mr={2} />
-            Section {index + 1}
+            <Accordion.Item.ToggleButton tag={'h3'}>
+              <Accordion.Item.Chevron mr={2} />
+              Section {index + 1}
+            </Accordion.Item.ToggleButton>
           </Accordion.Item.Toggle>
           <Accordion.Item.Collapse>
             <Box p='12px 24px 24px'>{`Hello Section ${index + 1}`}</Box>

--- a/website/docs/components/accordion/examples/one_section_opening.tsx
+++ b/website/docs/components/accordion/examples/one_section_opening.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Accordion from 'intergalactic/accordion';
-import { Text } from 'intergalactic/typography';
-import { Box, Flex } from 'intergalactic/flex-box';
+import { Box } from 'intergalactic/flex-box';
 
 const Demo = () => {
   const [value, onChange] = React.useState(null); // or []
@@ -10,10 +9,8 @@ const Demo = () => {
       {[...new Array(3)].map((_, index) => (
         <Accordion.Item value={index} key={index} disabled={index === 2}>
           <Accordion.Item.Toggle pb={2}>
-            <Flex alignItems='center'>
-              <Accordion.Item.Chevron mr={2} />
-              <Text size={300} tag='h3' my={0}>{`Section ${index + 1}`}</Text>
-            </Flex>
+            <Accordion.Item.Chevron mr={2} />
+            Section {index + 1}
           </Accordion.Item.Toggle>
           <Accordion.Item.Collapse>
             <Box p='12px 24px 24px'>{`Hello Section ${index + 1}`}</Box>

--- a/website/docs/components/inline-edit/examples/simple_use.tsx
+++ b/website/docs/components/inline-edit/examples/simple_use.tsx
@@ -13,10 +13,7 @@ const Example = () => {
     <div>
       <Text mr={2}>Author:</Text>
       <InlineEdit editable={editable} onEditableChange={setEditable}>
-        <InlineEdit.View
-          style={{ display: 'flex', gap: 8, alignItems: 'center' }}
-          pr={2}
-        >
+        <InlineEdit.View style={{ display: 'flex', gap: 8, alignItems: 'center' }} pr={2}>
           {text} <EditM color='icon-secondary-neutral' />
         </InlineEdit.View>
         <InlineEdit.Edit>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
I've changed the Accordion examples to properly use `aria-*` attributes on the toggle.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
