### PR TITLE
[docs] Added button role to DescriptionTooltip Hintlink trigger

### DIFF
--- a/website/docs/components/tooltip/examples/basic_usage.tsx
+++ b/website/docs/components/tooltip/examples/basic_usage.tsx
@@ -39,7 +39,7 @@ const Demo = () => (
     <Flex gap={4} alignItems='center'>
       DescriptionTooltip:
       <DescriptionTooltip>
-        <DescriptionTooltip.Trigger tag={HintLink}>
+        <DescriptionTooltip.Trigger tag={HintLink} role={'button'}>
           About fastest animals
         </DescriptionTooltip.Trigger>
         <DescriptionTooltip.Popper aria-label='About fastest animals'>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

A tiny fix in the DescriptioinTooltip example, adding a "role=button" to the Hintlink acting as a DescriptionTooltip.Trigger.

_I have a feeling I've already commited this edit in another PR, don't be surprised if you come across the same edit elsewhere %)_

## How has this been tested?

Manually, with Firefox a11y inspector.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
