### PR TITLE
[notice] added new component(Button) for close, deprecated old(Icon)

### DIFF
--- a/semcore/feedback-form/CHANGELOG.md
+++ b/semcore/feedback-form/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [6.33.5] - 2024-08-16
+
+### Changed
+
+- Using `Notice.Close` instead of `Notice.CloseIcon`.
+
 ## [6.33.4] - 2024-08-16
 
 ### Fixed

--- a/semcore/feedback-form/src/component/feedback-rating/FeedbackRating.tsx
+++ b/semcore/feedback-form/src/component/feedback-rating/FeedbackRating.tsx
@@ -7,7 +7,6 @@ import i18nEnhance from '@semcore/utils/lib/enhances/i18nEnhance';
 import { useI18n } from '@semcore/utils/lib/enhances/WithI18n';
 import uniqueIDEnhancement from '@semcore/utils/lib/uniqueID';
 import Notice from '@semcore/notice';
-import CloseAltM from '@semcore/icon/Close/m';
 import CheckM from '@semcore/icon/Check/m';
 import WarnM from '@semcore/icon/Warning/m';
 import { Text } from '@semcore/typography';
@@ -267,7 +266,7 @@ class FeedbackRatingRoot extends Component<FeedbackRatingProps, {}, State, Enhan
               </Link>
             )}
           </Notice.Content>
-          <Notice.CloseIcon onClick={onNotificationClose} />
+          <Notice.Close onClick={onNotificationClose} />
         </Notice>
 
         <SFeedbackRating render={Modal} visible={visible} onClose={this.handelCloseModal} p={0}>

--- a/semcore/notice/__tests__/index.test.jsx
+++ b/semcore/notice/__tests__/index.test.jsx
@@ -32,7 +32,7 @@ describe('Notice', () => {
   test.concurrent('Should support custom close icon', () => {
     const component = (
       <Notice>
-        <Notice.CloseIcon data-testid='close'>Close Icon</Notice.CloseIcon>
+        <Notice.Close data-testid='close'>Close Icon</Notice.Close>
       </Notice>
     );
     const { getByTestId } = render(component);
@@ -68,7 +68,7 @@ describe('Notice', () => {
               <button type='button'>Wow, so cool!</button>
             </Notice.Actions>
           </Notice.Content>
-          <Notice.CloseIcon />
+          <Notice.Close />
         </Notice>
       </>
     );
@@ -88,7 +88,7 @@ describe('Notice', () => {
             <button type='button'>Wow, so cool!</button>
           </Notice.Actions>
         </Notice.Content>
-        <Notice.CloseIcon />
+        <Notice.Close />
       </Notice>
     );
     await expect(await snapshot(component)).toMatchImageSnapshot(task);

--- a/semcore/notice/src/Notice.jsx
+++ b/semcore/notice/src/Notice.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import createComponent, { Component, sstyled, Root } from '@semcore/core';
 import { Box } from '@semcore/flex-box';
 import Button from '@semcore/button';
-import Close from '@semcore/icon/Close/m';
+import CloseIconM from '@semcore/icon/Close/m';
 import resolveColorEnhance from '@semcore/utils/lib/enhances/resolveColorEnhance';
 import { FadeInOut } from '@semcore/animation';
 import logger from '@semcore/utils/lib/logger';
@@ -43,6 +43,12 @@ class RootNotice extends Component {
   }
 
   getCloseIconProps() {
+    const { getI18nText } = this.asProps;
+
+    return { getI18nText };
+  }
+
+  getCloseProps() {
     const { getI18nText } = this.asProps;
 
     return { getI18nText };
@@ -105,9 +111,16 @@ function Content({ styles }) {
 function CloseIcon({ styles, getI18nText }) {
   const SCloseIcon = Root;
   return sstyled(styles)(
+    <SCloseIcon render={Box} tag={CloseIconM} interactive aria-label={getI18nText('close')} />,
+  );
+}
+
+function Close({ styles, getI18nText }) {
+  const SCloseIcon = Root;
+  return sstyled(styles)(
     <SCloseIcon
       render={Button}
-      addonLeft={Close}
+      addonLeft={CloseIconM}
       use='tertiary'
       theme='muted'
       aria-label={getI18nText('close')}
@@ -120,4 +133,5 @@ export default createComponent(RootNotice, {
   Actions,
   Content,
   CloseIcon,
+  Close,
 });

--- a/semcore/notice/src/NoticeSmart.jsx
+++ b/semcore/notice/src/NoticeSmart.jsx
@@ -20,7 +20,7 @@ class NoticeSmart extends Component {
           <Children />
           {isNode(actions) && <Notice.Actions>{actions}</Notice.Actions>}
         </Notice.Content>
-        {closable && <Notice.CloseIcon onClick={onClose} />}
+        {closable && <Notice.Close onClick={onClose} />}
       </SNoticeSmart>
     );
   }

--- a/semcore/notice/src/index.d.ts
+++ b/semcore/notice/src/index.d.ts
@@ -1,6 +1,7 @@
 import { PropGetterFn, UnknownProperties, Intergalactic } from '@semcore/core';
 import { Box, BoxProps } from '@semcore/flex-box';
 import Button from '@semcore/button';
+import { IconProps } from '@semcore/icon';
 import { FadeInOutProps } from '@semcore/animation';
 
 export type NoticeTheme = 'danger' | 'warning' | 'success' | 'info' | 'muted';
@@ -65,7 +66,11 @@ declare const Notice: Intergalactic.Component<'div', NoticeProps, NoticeContext>
   Label: Intergalactic.Component<'div', NoticeLabelProps>;
   Actions: typeof Box;
   Content: typeof Box;
-  CloseIcon: typeof Button;
+  /**
+   * @deprecated Use Notice.Close instead of Notice.CloseIcon
+   */
+  CloseIcon: Intergalactic.Component<'div', IconProps>;
+  Close: typeof Button;
 };
 
 declare const NoticeSmart: Intergalactic.Component<'div', NoticeSmartProps>;

--- a/website/docs/components/notice/examples/custom_notice.tsx
+++ b/website/docs/components/notice/examples/custom_notice.tsx
@@ -24,7 +24,7 @@ const Demo = () => (
         </Button>
       </Notice.Actions>
     </Notice.Content>
-    <Notice.CloseIcon />
+    <Notice.Close />
   </Notice>
 );
 

--- a/website/docs/components/notice/notice-a11y.md
+++ b/website/docs/components/notice/notice-a11y.md
@@ -16,13 +16,13 @@ The list below describes roles and attributes that component already has.
 
 Table: Roles & attributes
 
-| Component          | Attribute                          | Usage                                                                                                                                                                                                                               |
-| ------------------ | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Notice`           | `role="region"`                    | Defines an ARIA landmark and allows users to navigate to the component easily and to have it listed in a summary of the page. |
-| `Notice`           | `aria-label`                       | Defines a default accessible name for the region: `"Notification"` for **info**, **success** and **warning** themes, and `"Critical notification"` for **danger** theme. |
-| `Notice`           | `aria-live="polite"`               | Defines a region which receives updates that are important for the user to receive, but not so rapid as to be annoying. The screen reader will speak changes whenever the user is idle.                    |
-| `Notice`           | `aria-live="assertive"` (only for `warning` and `danger` themes) | Tells assistive technologies to interrupt other processes to provide users with immediate notification of container changes. |
-| `Notice.CloseIcon` | `aria-label="Close notification"`  | Defines the default accessible name for the **Close** button. |
+| Component      | Attribute                          | Usage                                                                                                                                                                                                                               |
+| -------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Notice`       | `role="region"`                    | Defines an ARIA landmark and allows users to navigate to the component easily and to have it listed in a summary of the page. |
+| `Notice`       | `aria-label`                       | Defines a default accessible name for the region: `"Notification"` for **info**, **success** and **warning** themes, and `"Critical notification"` for **danger** theme. |
+| `Notice`       | `aria-live="polite"`               | Defines a region which receives updates that are important for the user to receive, but not so rapid as to be annoying. The screen reader will speak changes whenever the user is idle.                    |
+| `Notice`       | `aria-live="assertive"` (only for `warning` and `danger` themes) | Tells assistive technologies to interrupt other processes to provide users with immediate notification of container changes. |
+| `Notice.Close` | `aria-label="Close notification"`  | Defines the default accessible name for the **Close** button. |
 
 ## Considerations for developers
 

--- a/website/docs/components/notice/notice-api.md
+++ b/website/docs/components/notice/notice-api.md
@@ -39,13 +39,13 @@ import Notice from 'intergalactic/notice';
 <Notice.Content />;
 ```
 
-## Notice.CloseIcon
+## Notice.Close
 
-The component is inherited from `Box` and is used to insert the **Close** button.
+The component is inherited from `Button` and is used to insert the **Close** button.
 
 ```jsx
 import Notice from 'intergalactic/notice';
-<Notice.CloseIcon />;
+<Notice.Close />;
 ```
 
 ## NoticeSmart

--- a/website/docs/components/notice/notice.md
+++ b/website/docs/components/notice/notice.md
@@ -99,7 +99,7 @@ const Preview = (preview) => {
           </Notice.Actions>
         )}
       </Notice.Content>
-      {closable && <Notice.CloseIcon onClick={handlerClose} />}
+      {closable && <Notice.Close onClick={handlerClose} />}
     </Notice>
   );
 };
@@ -138,7 +138,7 @@ Component consists of the following:
 1. `Notice.Content`.
 2. `Notice.Label` (optional). It can be an [icon](/style/icon/icon), [badge](/components/badge/badge) or illustration that accompanies the message.
 3. `Notice.Actions` (optional).
-4. `Notice.CloseIcon` (optional).
+4. `Notice.Close` (optional).
 
 ## Notice content examples
 

--- a/website/docs/patterns/feedback-rating/feedback-rating-a11y.md
+++ b/website/docs/patterns/feedback-rating/feedback-rating-a11y.md
@@ -11,13 +11,13 @@ The list below describes roles and attributes that component already has.
 
 Table: Roles and attributes
 
-| Component          | Role     | Attribute                                                                                   |
-| ------------------ | -------- | ------------------------------------------------------------------------------------------- |
-| `Notice`           | `region` | `aria-label="Leave feedback"`                                                               |
-| `Notice.Label`     |          | `aria-hidden={true}`                                                                        |
-| `Notice.CloseIcon` | `button` | `aria-label` comes from [Notice](/components/notice/notice-a11y).                           |
-| `SliderRating`     | `slider` | `aria-label={notificationText}`                                                             |
-| `SliderRating`     | `slider` | All aria attributes are the same as those the [Slider](/components/slider/slider-a11y) has. |
+| Component      | Role     | Attribute                                                                                   |
+| -------------- | -------- | ------------------------------------------------------------------------------------------- |
+| `Notice`       | `region` | `aria-label="Leave feedback"`                                                               |
+| `Notice.Label` |          | `aria-hidden={true}`                                                                        |
+| `Notice.Close` | `button` | `aria-label` comes from [Notice](/components/notice/notice-a11y).                           |
+| `SliderRating` | `slider` | `aria-label={notificationText}`                                                             |
+| `SliderRating` | `slider` | All aria attributes are the same as those the [Slider](/components/slider/slider-a11y) has. |
 
 FeedbackRating form pattern consists of several components that have their own accessibility requirements. You can find more about each of them in their guides:
 

--- a/website/docs/patterns/feedback-yes-no/examples/feedbackyesno-example.tsx
+++ b/website/docs/patterns/feedback-yes-no/examples/feedbackyesno-example.tsx
@@ -197,7 +197,7 @@ class FeedbackYesNo extends React.PureComponent {
             </Button>
           </Box>
         </Notice.Content>
-        <Notice.CloseIcon onClick={() => this.changeVisible(false)} />
+        <Notice.Close onClick={() => this.changeVisible(false)} />
       </Notice>
     );
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
As we already have projects with `Notice.CloseIcon`, I marked it as deprecated and added new `Notice.Close` component with button styles.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
