### PR TITLE
[86bzykx3u][icon] always add role button to interactive icons

### DIFF
--- a/semcore/icon/CHANGELOG.md
+++ b/semcore/icon/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.43.3] - 2024-08-20
+
+### Fixed
+
+- Disabled role overwriting (from props) for interactive icons.
+
 ## [4.43.2] - 2024-08-05
 
 ### Changed

--- a/semcore/icon/__tests__/index.test.jsx
+++ b/semcore/icon/__tests__/index.test.jsx
@@ -114,6 +114,11 @@ describe('Icon', () => {
     expect(onClick).toHaveBeenCalledTimes(0);
   });
 
+  test('should always have role button if interactive', () => {
+    const { getByTestId } = render(<Icon data-testid='icon' interactive={true} role={undefined} />);
+    expect(getByTestId('icon').attributes['role'].value).toEqual('button');
+  });
+
   test('a11y', async () => {
     const { container } = render(
       <Icon width={22} height={22} viewBox='0 0 22 22' color='green'>

--- a/semcore/icon/src/Icon.jsx
+++ b/semcore/icon/src/Icon.jsx
@@ -65,9 +65,9 @@ function Icon(props, ref) {
 
   return (
     <SIcon
+      {...propsForElement(propsEnhance)}
       role={interactive ? 'button' : undefined}
       aria-hidden={interactive ? undefined : 'true'}
-      {...propsForElement(propsEnhance)}
       style={Object.assign({}, style, propsEnhance.style)}
       className={cn(className, propsEnhance.className) || undefined}
       onKeyDown={onKeyDown}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Now, if we pass `role=undefine` to icon, it will rewrite role from `interactive` props. I've fixed it.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually and with new test.
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
