### PR TITLE
[86c00cvw1][input-mask] backspace fix

### DIFF
--- a/semcore/input-mask/CHANGELOG.md
+++ b/semcore/input-mask/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.34.0] - 2024-08-21
+
+### Fixed
+
+- Curet was moving to the end of input after deleting characters in the middle of the input.
+
 ## [5.33.2] - 2024-08-05
 
 ### Changed

--- a/semcore/input-mask/src/InputMask.tsx
+++ b/semcore/input-mask/src/InputMask.tsx
@@ -289,14 +289,6 @@ class Value extends Component<InputMaskValueProps, {}, {}, UniqueIDProps> {
     }, 0);
   };
 
-  onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Backspace') {
-      setTimeout(() => {
-        this.setSelectionRange();
-      }, 0);
-    }
-  };
-
   setSelectionRange = () => {
     if (!this.inputRef.current) return;
     const { value } = this.inputRef.current;
@@ -384,7 +376,6 @@ class Value extends Component<InputMaskValueProps, {}, {}, UniqueIDProps> {
                   wMin={this.state.maskWidth}
                   aria-describedby={`hint-${uid}`}
                   {...controlProps}
-                  onKeyDown={callAllEventHandlers(this.onKeyDown, controlProps.onKeyDown)}
                   __excludeProps={['placeholder']}
                 />
                 <Children />


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Here I probably fixed wierd shift of caret position to the end of date picker input trigger when deleting characters in the middle of the date. I've removed part of changes introduced in https://github.com/semrush/intergalactic/pull/970 (it was fixing that in input phone mask was broken after characters deleting, like on the image below) and but I can't reproduce it. 

![image](https://github.com/user-attachments/assets/55198b84-daef-4497-b38c-39d82d63b494)


## How has this been tested?

Manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
