### PR TITLE
[86c02ajx9][icon] fixed interaction with aria-hidden icons in some focusable elements

### DIFF
--- a/semcore/icon/CHANGELOG.md
+++ b/semcore/icon/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.43.3] - 2024-08-22
+
+### Fixed
+
+- Browser error about trying to focus on the svg element with `aria-hidden` (in Button, for example).
+
 ## [4.43.2] - 2024-08-05
 
 ### Changed

--- a/semcore/icon/__tests__/index.test.jsx
+++ b/semcore/icon/__tests__/index.test.jsx
@@ -46,6 +46,11 @@ describe('Icon', () => {
     expect(getByTestId('icon').attributes['aria-hidden']?.value).toEqual(undefined);
   });
 
+  test('should have class with pointer-events=none if interactive is false ', () => {
+    const { getByTestId } = render(<Icon data-testid='icon' mr={2} interactive={false} />);
+    expect(getByTestId('icon').attributes['class'].value).toMatch(/noPointerEvents/);
+  });
+
   test('should support children', () => {
     const { getByTestId } = render(
       <Icon>

--- a/semcore/icon/src/Icon.jsx
+++ b/semcore/icon/src/Icon.jsx
@@ -37,6 +37,7 @@ function Icon(props, ref) {
     'use:color': color,
     interactive: interactive,
     keyboardFocused: keyboardFocused,
+    noPointerEvents: !interactive,
   });
 
   function onKeyDown(event) {

--- a/semcore/icon/src/style/icon.shadow.css
+++ b/semcore/icon/src/style/icon.shadow.css
@@ -20,3 +20,7 @@ SIcon[interactive] {
     filter: brightness(0.8);
   }
 }
+
+SIcon[noPointerEvents] {
+  pointer-events: none;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
We've had an error in browser about trying to focus to `aria-hidden` icon (in Button, for example).
I've fixed it by added `pointer-events: none` to non-interactive icons.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually and I've added unit test
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [X] I have added new unit tests on added of fixed functionality.
