### PR TITLE
[86bxfjmxr][dropdown-menu] added default timeout for interaction hover to fix infinite blinking

### DIFF
--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.36.0] - 2024-08-26
+
+### Changed
+
+- Now DropdownMenu with `interaction="hover"` has `timeout={[0, 100]}` (0 for showing, 100 for hiding) by default.
+
 ## [4.35.5] - 2024-08-20
 
 ### Fixed

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -35,7 +35,8 @@ class DropdownMenuRoot extends Component {
       i18n: localizedMessages,
       locale: 'en',
       interaction: 'click',
-      timeout: props.timeout || (props.interaction === 'hover' ? [0, 100] : undefined),
+      timeout: props.interaction === 'hover' ? [0, 100] : undefined,
+      ...props,
     };
   };
 

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -27,13 +27,16 @@ class DropdownMenuRoot extends Component {
   static style = style;
   static enhance = [uniqueIDEnhancement(), i18nEnhance(localizedMessages)];
 
-  static defaultProps = {
-    size: 'm',
-    defaultVisible: false,
-    defaultHighlightedIndex: null,
-    i18n: localizedMessages,
-    locale: 'en',
-    interaction: 'click',
+  static defaultProps = (props) => {
+    return {
+      size: 'm',
+      defaultVisible: false,
+      defaultHighlightedIndex: null,
+      i18n: localizedMessages,
+      locale: 'en',
+      interaction: 'click',
+      timeout: props.timeout || (props.interaction === 'hover' ? [0, 100] : undefined),
+    };
   };
 
   state = {

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -27,17 +27,13 @@ class DropdownMenuRoot extends Component {
   static style = style;
   static enhance = [uniqueIDEnhancement(), i18nEnhance(localizedMessages)];
 
-  static defaultProps = (props) => {
-    return {
-      size: 'm',
-      defaultVisible: false,
-      defaultHighlightedIndex: null,
-      i18n: localizedMessages,
-      locale: 'en',
-      interaction: 'click',
-      timeout: props.interaction === 'hover' ? [0, 100] : undefined,
-      ...props,
-    };
+  static defaultProps = {
+    size: 'm',
+    defaultVisible: false,
+    defaultHighlightedIndex: null,
+    i18n: localizedMessages,
+    locale: 'en',
+    interaction: 'click',
   };
 
   state = {
@@ -427,12 +423,12 @@ class DropdownMenuRoot extends Component {
   }
 
   render() {
-    const { Children } = this.asProps;
+    const { Children, interaction, timeout } = this.asProps;
 
     this.itemProps = [];
 
     return (
-      <Root render={Dropdown}>
+      <Root render={Dropdown} timeout={timeout || (interaction === 'hover' ? [0, 100] : undefined)}>
         <Children />
       </Root>
     );


### PR DESCRIPTION
## Motivation and Context

Fixed that behavior:


https://github.com/user-attachments/assets/f6c5b4f1-cd81-4365-b1b5-fd9f2bd8847e


## How has this been tested?

Manually, can't test it automatically.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
