### PR TITLE
[86bzughj1][utils] made focus lock not to fall into iframes

### DIFF
--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.33.0] - 2024-07-26
+
+### Fixed
+
+- Now focus lock is preventing focus from falling into iframes.
+
 ## [4.32.2] - 2024-07-22
 
 ### Fixed

--- a/semcore/utils/src/focus-lock/iframeBorders.ts
+++ b/semcore/utils/src/focus-lock/iframeBorders.ts
@@ -1,0 +1,55 @@
+const iframeBorders = new Set<HTMLElement>();
+
+export const addIframeBorders = () => {
+  const iframes = document.querySelectorAll('iframe');
+  iframes.forEach((iframe) => {
+    const iframeBefore = document.createElement('div');
+    iframeBefore.style.position = 'fixed';
+    iframeBefore.setAttribute('tabindex', '0');
+    const iframeAfter = document.createElement('div');
+    iframeAfter.style.position = 'fixed';
+    iframeAfter.setAttribute('tabindex', '0');
+    iframeBefore.addEventListener('focus', (event) => {
+      Promise.resolve().then(() => {
+        if (
+          document.activeElement === iframeBefore &&
+          event.relatedTarget !== iframeAfter && // prevent loop
+          event.relatedTarget // prevent initial focus
+        ) {
+          iframeAfter?.focus();
+        }
+      });
+    });
+    iframeAfter.addEventListener('focus', (event) => {
+      Promise.resolve().then(() => {
+        if (
+          document.activeElement === iframeAfter &&
+          event.relatedTarget !== iframeBefore && // prevent loop
+          event.relatedTarget // prevent initial focus
+        ) {
+          iframeBefore?.focus();
+        }
+      });
+    });
+    iframe.before(iframeBefore);
+    iframe.after(iframeAfter);
+    iframeBorders.add(iframeBefore);
+    iframeBorders.add(iframeAfter);
+  });
+};
+export const removeIframeBorders = () => {
+  iframeBorders.forEach((node) => node?.remove());
+  iframeBorders.clear();
+};
+export const areIframeBordersPlacedCorrectly = () => {
+  const iframes = Array.from(document.querySelectorAll('iframe'));
+
+  if (iframes.length * 2 === iframeBorders.size) return false;
+
+  return iframes.every((iframe) => {
+    const nodeBeforeIframe = iframe.previousSibling as any;
+    const nodeAfterIframe = iframe.nextSibling as any;
+
+    return iframeBorders.has(nodeBeforeIframe) && iframeBorders.has(nodeAfterIframe);
+  });
+};

--- a/semcore/utils/src/use/useFocusLock.ts
+++ b/semcore/utils/src/use/useFocusLock.ts
@@ -9,6 +9,11 @@ import {
   removeFocusBorders,
   areFocusBordersPlacedCorrectly,
 } from '../focus-lock/focusBorders';
+import {
+  addIframeBorders,
+  areIframeBordersPlacedCorrectly,
+  removeIframeBorders,
+} from '../focus-lock/iframeBorders';
 
 export { isFocusInside, setFocus };
 
@@ -49,11 +54,18 @@ const useFocusBorders = (React: ReactT, disabled?: boolean) => {
     }
 
     if (!areFocusBordersPlacedCorrectly()) removeFocusBorders();
-    if (focusBordersConsumers.size > 0) addFocusBorders();
+    if (!areIframeBordersPlacedCorrectly()) removeIframeBorders();
+    if (focusBordersConsumers.size > 0) {
+      addFocusBorders();
+      addIframeBorders();
+    }
 
     return () => {
       focusBordersConsumers.delete(id);
-      if (focusBordersConsumers.size === 0) removeFocusBorders();
+      if (focusBordersConsumers.size === 0) {
+        removeFocusBorders();
+        removeIframeBorders();
+      }
     };
   }, [disabled]);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

When browser focus is comming to iframe, we are loosing control of it. I tried to use `document.hasFocus()` api or react to events before browser focus is controlled by iframe, but found that it looks impossible. To resolve the issue, I've added process of adding invisible focusable elements that prevent browser focus from reaching iframe.

## How has this been tested?

I found no way to check which window has focus, root document always gets true from `document.hasFocus()`. So, only manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
