### PR TITLE
[86c06fdzp][utils] fixed that hidden elemts might be considered as focusable

### DIFF
--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.36.0] - 2024-09-12
+
+### Fixed
+
+- Hidden elements might be considered as focusable. It was breaking "Skip to content after plot" feature in d3-chart in some cases.
+
 ## [4.35.0] - 2024-09-06
 
 ### Added

--- a/semcore/utils/src/focus-lock/isFocusable.ts
+++ b/semcore/utils/src/focus-lock/isFocusable.ts
@@ -29,6 +29,7 @@ export const isFocusable = (node: Node) => {
     return false;
   if (node.hasAttribute('disabled')) return false;
   if (node.getAttribute('tabindex') === '-1') return false;
+  if (node.getAttribute('hidden') !== null) return false;
   const tagName = node.tagName;
   for (const params of focusable) {
     if (
@@ -37,8 +38,12 @@ export const isFocusable = (node: Node) => {
         if (typeof param === 'object' && param.has && node.hasAttribute(param.has)) return true;
         return false;
       })
-    )
+    ) {
+      const style = getComputedStyle(node);
+      if (style.display === 'none' || style.visibility === 'hidden') return false;
+
       return true;
+    }
   }
   return false;
 };


### PR DESCRIPTION
## Motivation and Context

Our utils concerns hiddne elements as focusable ones. It breaks "skip to content after plot" mechanism in d3 charts if any elemtns after the chart are invisible.

## How has this been tested?

Manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
