### PR TITLE
[86c09aw3f][side-panel] removed animation delay

### DIFF
--- a/semcore/side-panel/CHANGELOG.md
+++ b/semcore/side-panel/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [3.44.0] - 2024-08-29
+
+### Changed
+
+- Removed weird animation delay on `SidePanel` close that was causing animation fragmenting.
+
 ## [3.43.0] - 2024-08-29
 
 ### Changed

--- a/semcore/side-panel/src/SidePanel.jsx
+++ b/semcore/side-panel/src/SidePanel.jsx
@@ -72,22 +72,11 @@ class RootSidePanel extends Component {
     );
   }
 
-  calculateDelayAnimation(name) {
-    const delay = this.asProps.duration / 2;
-    const usedOverlay = this.isUsedOverlay();
-
-    return {
-      overlay: usedOverlay ? [0, delay] : 0,
-      panel: usedOverlay ? [delay, 0] : 0,
-    }[name];
-  }
-
   getOverlayProps() {
     const { visible, duration, animationsDisabled, disablePreventScroll } = this.asProps;
     return {
       visible,
       duration,
-      delay: this.calculateDelayAnimation('overlay'),
       animationsDisabled,
       disablePreventScroll,
     };
@@ -108,9 +97,8 @@ class RootSidePanel extends Component {
       visible,
       placement,
       closable,
-      duration,
+      duration: duration + duration / 2,
       disableEnforceFocus: !this.isUsedOverlay(),
-      delay: this.calculateDelayAnimation('panel'),
       onOutsideClick: this.handleOutsideClick,
       onKeyDown: this.handleSidebarKeyDown,
       animationsDisabled,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

The animation delay was added for an unclear purpose. Probably to show backdrop before side panel. I have remvoed it and now close animation is nor fragmented and feels much better.

## How has this been tested?

Manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
