### PR TITLE
[86c0484a6][utils] fixed that click outside utility was considering all clicks inside of shadow root as clicks outside

### DIFF
--- a/semcore/utils/CHANGELOG.md
+++ b/semcore/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.37.0] - 2024-09-30
+
+### Fixed
+
+* Click outside utility was considering all clicks inside of shadow root as clicks outside.
+
 ## [4.36.3] - 2024-09-26
 
 ### Changed
@@ -14,13 +20,11 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 * Moving focus in an iframe didn't remove visible focus from elements in the focus-locked container.
 
-
 ## [4.36.1] - 2024-09-25
 
 ### Fixed
 
 * Attribute `suppressHydrationWarning` was not appling to components.
-
 
 ## [4.36.0] - 2024-09-12
 

--- a/semcore/utils/src/getEventTarget.ts
+++ b/semcore/utils/src/getEventTarget.ts
@@ -1,6 +1,16 @@
 export const getEventTarget = (event: React.SyntheticEvent | Event): EventTarget | null => {
   if ('composedPath' in event) {
-    return event.composedPath()?.[0] || event.target;
+    const composedPath = event.composedPath();
+
+    if (composedPath) {
+      for (const element of composedPath) {
+        if ('shadowRoot' in element && element.shadowRoot) {
+          return element;
+        }
+      }
+    }
+
+    return composedPath?.[0] || event.target;
   }
   if (event.nativeEvent && 'composedPath' in event.nativeEvent) {
     return event.nativeEvent.composedPath()?.[0] || event.target;

--- a/semcore/utils/src/getEventTarget.ts
+++ b/semcore/utils/src/getEventTarget.ts
@@ -13,7 +13,16 @@ export const getEventTarget = (event: React.SyntheticEvent | Event): EventTarget
     return composedPath?.[0] || event.target;
   }
   if (event.nativeEvent && 'composedPath' in event.nativeEvent) {
-    return event.nativeEvent.composedPath()?.[0] || event.target;
+    const composedPath = event.nativeEvent.composedPath();
+
+    if (composedPath) {
+      for (const element of composedPath) {
+        if ('shadowRoot' in element && element.shadowRoot) {
+          return element;
+        }
+      }
+    }
+    return composedPath?.[0] || event.target;
   }
   return event.target;
 };


### PR DESCRIPTION
## Motivation and Context

Event target util was unable to get event target if event happend inside of nested document.

## How has this been tested?

Manually on this snippet:
```
import React from 'react';
import data from '@emoji-mart/data';
import { BaseEmoji, Picker } from 'emoji-mart';
import { FC, useEffect, useRef } from 'react';
import Button from 'intergalactic/button';
import Dropdown from 'intergalactic/dropdown';

const RenderPicker: FC = () => {
  const ref = useRef<HTMLDivElement>(null);

  useEffect(() => {
    if (!ref.current?.innerHTML) {
      new Picker({
        data,
        ref,
      });
    }
  }, []);

  return <div ref={ref} />;
};

const AddEmojiButton = () => (
  <div>
    <Dropdown>
      <Dropdown.Trigger tag={Button}>Emoji picker</Dropdown.Trigger>
      <Dropdown.Popper>
        <div>Area where outside click works well</div>
        <RenderPicker />
      </Dropdown.Popper>
    </Dropdown>
    <br />
    <br />
    <br />
    <br />
    <br />
    <br />
    <br />
    <br />
    <br />
    <br />
    <RenderPicker />
  </div>
);

export default AddEmojiButton;

```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
