### PR TITLE
[86c0fvubu][data-table] Fixed preventing defaults and propagation for pressing Enter on TableCell with focusable elements

### DIFF
--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.44.2] - 2024-10-04
+
+### Fixed
+
+- Preventing defaults and propagation for pressing Enter on TableCell with focusable elements.
+
 ## [4.44.1] - 2024-09-27
 
 ### Changed

--- a/semcore/data-table/src/Body.tsx
+++ b/semcore/data-table/src/Body.tsx
@@ -93,6 +93,8 @@ class Body extends Component<AsProps, {}, State> {
           e.stopPropagation();
         }
       } else if (e.key === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
         this.lockedCell[1] = true;
         focusableChildren[0]?.focus();
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Little fix with preventing events on table cells with focusable elements.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
