### PR TITLE
[docs] Added dialog vs listbox info to Select a11y docs

### DIFF
--- a/website/docs/components/select/select-a11y.md
+++ b/website/docs/components/select/select-a11y.md
@@ -29,10 +29,11 @@ Table: Roles and attributes
 | `Select.Trigger`           | `role="combobox"`                 | Identifies the element as a combobox, that is an input that opens a list of options or a grid.                                                                                      |
 |                            | `aria-activedescendant="IDREF"`   | When the list is open, indicates which option is currently highlighted.                                                                                                             |
 |                            | `aria-autocomplete="list"`        | **Only if an [Input](../input/input) is used as the trigger.** Indicates that a list of values that could complete the input is provided during input.                              |
-|                            | `aria-controls="IDREF"`           | Identifies the element controlled by the trigger. If `Select` is used with `Select.Menu` or without nested elements, refers to `Select.List`. Otherwise, refers to `Select.Popper`. |
+|                            | `aria-controls="IDREF"`           | Identifies the element controlled by the trigger. If `Select.Popper` is used explicitly, refers to `Select.Popper`. Otherwise, refers to `Select.List`.       |
 |                            | `aria-disabled="true/false"`      | Indicates whether the `Select` is disabled or enabled.                                                                                                                              |
 |                            | `aria-expanded="true/false"`      | Indicates whether the dropdown is open or closed.                                                                                                                                   |
-|                            | `aria-haspopup="listbox"`         | Indicates that the trigger opens a list of options.                                                                                                                                 |
+|                            | `aria-haspopup="dialog/listbox"`  | If `Select.Popper` is used explicitly, indicates that the trigger opens a dialog. Otherwise, indicates that the trigger opens a list of options.                                                                                                                                 |
+| `Select.Popper`            | `role="dialog"`                   | **Only if `Select.Popper` is used explicitly.** Identifies the popper as a dialog.                                                                                                                                        |
 | `Select.List`              | `role="listbox"`                  | Identifies the element as a list of options.                                                                                                                                        |
 |                            | `aria-label`                      | Defines an accessible name for the list of options. Automatically populated from the accessible name of the trigger.                                                                |
 |                            | `aria-multiselectable="true"`     | **Only if the `multiselect` property is set.** Indicates that multiple options can be selected.                                                                                     |
@@ -44,6 +45,10 @@ Table: Roles and attributes
 <!-- * For information about the dropdown behavior see [Keyboard support for dropdown](/core-principles/a11y/a11y-keyboard#keyboard_support_for_popper). -->
 
 ## Considerations for developers
+
+Only use `Select.Popper` explicitly if it must have additional elements beside the list, such as `InputSearch` or `Notice`, as in the [menu customization example](./select-code.md#menu-customization) and the [option filtering example](./select-code.md#options-filtering). In that case the popper will be presented as a dialog, which hints to the screen reader user to use the `Tab` key to navigate between the list of options and other elements. 
+
+If your `Select` is a list of options without additional features, use it without children or with `Select.Menu`, as in the [basic example](./select-code.md#basic-usage). This will let the screen reader user know that `Up` and `Down` keys are enough to navigate within the control.
 
 ### Roles and attributes
 

--- a/website/docs/components/select/select-code.md
+++ b/website/docs/components/select/select-code.md
@@ -72,7 +72,7 @@ In cases when you require deeper customization, you can "unfold" the component i
 
 :::
 
-## DropdownMenu customization
+## Menu customization
 
 Similar to [intergalactic/dropdown-menu](/components/dropdown-menu/dropdown-menu), the dropdown menu can be implemented in two ways:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Apparently, I forgot to write about the listbox vs dialog logic in the a11y docs. Added this info now.
Will be nice to publish this update before the announcement is posted.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
