### PR TITLE
[86c0gvr1h][switch] fixed animations in popovers

### DIFF
--- a/semcore/switch/CHANGELOG.md
+++ b/semcore/switch/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.35.2] - 2024-10-16
+
+### Fixed
+
+- Animations in some popovers (for example in dropdown menu items).
+
 ## [5.35.1] - 2024-10-11
 
 ### Fixed

--- a/semcore/switch/src/Switch.jsx
+++ b/semcore/switch/src/Switch.jsx
@@ -32,18 +32,12 @@ class Switch extends Component {
     this.forceUpdate = this.forceUpdate.bind(this);
   }
 
-  componentWillUnmount() {
-    if (!canUseDOM()) return;
-    window.removeEventListener('mouseup', this.handleMouseUp);
-  }
   handleMouseUp = () => {
     this.setState({ active: false });
-    window.removeEventListener('mouseup', this.handleMouseUp);
   };
   handleMouseDown = (event) => {
     if (event?.button !== 0) return;
     this.setState({ active: true });
-    window.addEventListener('mouseup', this.handleMouseUp);
   };
 
   getValueProps() {
@@ -71,7 +65,13 @@ class Switch extends Component {
     const checked = this.inputRef.current?.checked;
 
     return sstyled(styles)(
-      <SSwitch render={Box} tag='label' checked={checked} onMouseDown={this.handleMouseDown}>
+      <SSwitch
+        render={Box}
+        tag='label'
+        checked={checked}
+        onMouseDown={this.handleMouseDown}
+        onMouseUp={this.handleMouseUp}
+      >
         <NeighborLocation controlsLength={controlsLength}>
           <Children />
         </NeighborLocation>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
I just changed the animation triggers to work correctly in popups (because the portal has stopPropagation for all events, and the newly added events do not work)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
