### PR TITLE
[86c0r63f1][ellipsis] fixed logic of showing tooltip for trimmed in the middle texts - show only for cropped

### DIFF
--- a/semcore/ellipsis/CHANGELOG.md
+++ b/semcore/ellipsis/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [2.36.2] - 2024-10-21
+
+### Fixed
+
+- Logic of showing tooltip for trimmed in the middle texts - show only for cropped.
+
 ## [2.36.1] - 2024-10-16
 
 ### Added

--- a/semcore/ellipsis/src/Ellipsis.tsx
+++ b/semcore/ellipsis/src/Ellipsis.tsx
@@ -134,7 +134,7 @@ function isTextOverflowing(element: HTMLDivElement, multiline: boolean): boolean
     }
   } else {
     measuringElement.style.whiteSpace = 'nowrap';
-    isOverflowing = currentWidth < measuringElement.scrollWidth;
+    isOverflowing = Math.ceil(currentWidth) < measuringElement.scrollWidth;
   }
 
   document.body.removeChild(measuringElement);

--- a/semcore/ellipsis/src/Ellipsis.tsx
+++ b/semcore/ellipsis/src/Ellipsis.tsx
@@ -10,6 +10,7 @@ import style from './style/ellipsis.shadow.css';
 import reactToText from '@semcore/utils/lib/reactToText';
 import getOriginChildren from '@semcore/utils/lib/getOriginChildren';
 import pick from '@semcore/utils/lib/pick';
+import { forkRef } from '@semcore/utils/lib/ref';
 
 type AsProps = {
   maxLine?: number;
@@ -25,6 +26,7 @@ type AsProps = {
 
 type AsPropsMiddle = {
   text: string;
+  textRef: RefObject<HTMLElement>;
   tooltip?: boolean;
   styles?: React.CSSProperties;
   containerRect?: { width: number };
@@ -206,6 +208,10 @@ class RootEllipsis extends Component<AsProps> {
       (Ellipsis as any).Popper.displayName,
     ]);
     const tooltipProps = pick(this.asProps, includeTooltipProps as any) as TooltipProps;
+
+    tooltipProps.visible = visible;
+    tooltipProps.onVisibleChange = this.handlerVisibleChange;
+
     if (trim === 'middle') {
       return sstyled(styles)(
         <EllipsisMiddle
@@ -214,6 +220,7 @@ class RootEllipsis extends Component<AsProps> {
           tooltip={tooltip}
           containerRect={containerRect}
           containerRef={containerRef}
+          textRef={this.textRef}
           tooltipProps={tooltipProps}
           advanceMode={advanceMode}
           {...other}
@@ -227,8 +234,6 @@ class RootEllipsis extends Component<AsProps> {
         <SContainer
           interaction='hover'
           title={!advanceMode ? text : undefined}
-          visible={visible}
-          onVisibleChange={this.handlerVisibleChange}
           {...tooltipProps}
           {...(advanceMode ? forcedAdvancedMode : noAdvancedMode)}
         >
@@ -269,6 +274,7 @@ const EllipsisMiddle: React.FC<AsPropsMiddle> = (props) => {
     tooltip,
     containerRect,
     containerRef,
+    textRef,
     tooltipProps,
     children,
     advanceMode,
@@ -336,7 +342,7 @@ const EllipsisMiddle: React.FC<AsPropsMiddle> = (props) => {
       <SContainerMiddle
         interaction={interaction}
         title={text as any}
-        ref={ref}
+        ref={forkRef(ref, textRef)}
         tag={Tooltip}
         __excludeProps={['title']}
         {...tooltipProps}

--- a/semcore/ellipsis/src/Ellipsis.tsx
+++ b/semcore/ellipsis/src/Ellipsis.tsx
@@ -95,7 +95,7 @@ const createMeasurerElement = (element: HTMLDivElement, text?: string) => {
   const styleElement = window.getComputedStyle(element, null);
   const temporaryElement = document.createElement('temporary-block');
   temporaryElement.style.display = styleElement.getPropertyValue('display');
-  temporaryElement.style.padding = '0';
+  temporaryElement.style.padding = styleElement.getPropertyValue('padding');
   temporaryElement.style.position = 'absolute';
   temporaryElement.style.right = '0%';
   temporaryElement.style.bottom = '0%';

--- a/semcore/ellipsis/src/Ellipsis.tsx
+++ b/semcore/ellipsis/src/Ellipsis.tsx
@@ -91,10 +91,10 @@ const defaultTooltipProps = [
   'cursorAnchoring',
 ];
 
-const createMeasurerElement = (element: HTMLDivElement) => {
+const createMeasurerElement = (element: HTMLDivElement, text?: string) => {
   const styleElement = window.getComputedStyle(element, null);
   const temporaryElement = document.createElement('temporary-block');
-  temporaryElement.style.display = 'inline-block';
+  temporaryElement.style.display = styleElement.getPropertyValue('display');
   temporaryElement.style.padding = '0';
   temporaryElement.style.position = 'absolute';
   temporaryElement.style.right = '0%';
@@ -111,15 +111,15 @@ const createMeasurerElement = (element: HTMLDivElement) => {
     styleElement.getPropertyValue('font-feature-settings');
   temporaryElement.style.fontVariantNumeric = styleElement.getPropertyValue('font-variant-numeric');
 
-  temporaryElement.innerHTML = element.innerHTML;
+  temporaryElement.innerHTML = text ?? element.innerHTML;
   return temporaryElement;
 };
 
-function isTextOverflowing(element: HTMLDivElement, multiline: boolean): boolean {
+function isTextOverflowing(element: HTMLDivElement, multiline: boolean, text?: string): boolean {
   if (!element) return false;
 
   const { height: currentHeight, width: currentWidth } = element.getBoundingClientRect();
-  const measuringElement = createMeasurerElement(element);
+  const measuringElement = createMeasurerElement(element, text);
   let isOverflowing = false;
 
   document.body.appendChild(measuringElement);
@@ -162,8 +162,9 @@ class RootEllipsis extends Component<AsProps> {
   textRef = React.createRef<HTMLDivElement>();
 
   showTooltip() {
-    const { maxLine = 1 } = this.asProps;
-    return isTextOverflowing(this.textRef.current!, maxLine > 1);
+    const { maxLine = 1, Children } = this.asProps;
+    const text = reactToText(getOriginChildren(Children));
+    return isTextOverflowing(this.textRef.current!, maxLine > 1, text);
   }
 
   handlerVisibleChange = (visible: boolean) => {

--- a/website/docs/components/card/examples/ellipsis.tsx
+++ b/website/docs/components/card/examples/ellipsis.tsx
@@ -22,8 +22,8 @@ const Demo = () => (
         Very long description which should show ellipsis when there isn't enough space.
       </Card.Description>
     </Card.Header>
-    <Card.Body tag={Ellipsis}>
-      <Text size={200}>
+    <Card.Body>
+      <Text tag={Ellipsis} size={200}>
         Long body text which should show ellipsis when there isn't enough space.
       </Text>
     </Card.Body>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fixed showing tooltip in the middle cropped ellipsis
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
