### PR TITLE
[modal] changed added selector specificity for modal close button

### DIFF
--- a/semcore/modal/CHANGELOG.md
+++ b/semcore/modal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.49.1] - 2024-10-30
+
+### Changed
+
+- Added selector specificity for modal close button.
+
 ## [4.49.0] - 2024-10-28
 
 ### Changed

--- a/semcore/modal/src/style/modal.shadow.css
+++ b/semcore/modal/src/style/modal.shadow.css
@@ -24,6 +24,17 @@ SWindow {
   STitle[color] {
     color: var(--color)
   }
+
+  SClose {
+    display: inline-flex;
+    position: absolute;
+    right: var(--intergalactic-spacing-2x, 8px);
+    top: var(--intergalactic-spacing-2x, 8px);
+  }
+  SClose[ghost] {
+    right: 0;
+    top: 0;
+  }
 }
 
 SWindow[ghost] {
@@ -50,17 +61,6 @@ SOverlay {
   & SOverlay {
     background: var(--intergalactic-overlay-secondary, rgba(25, 27, 35, 0.4));
   }
-}
-
-SClose {
-  display: inline-flex;
-  position: absolute;
-  right: var(--intergalactic-spacing-2x, 8px);
-  top: var(--intergalactic-spacing-2x, 8px);
-}
-SClose[ghost] {
-  right: 0;
-  top: 0;
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
I moved SClose button class in SWindow for prevent rewrite them from another styles
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
