### PR TITLE
[UIK-2523][dropdown] Fix Tooltip singleton stretched to fullscreen width

### DIFF
--- a/semcore/dropdown/CHANGELOG.md
+++ b/semcore/dropdown/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.40.2] - 2024-10-30
+
+### Fixed
+
+- Fixed Signleton Tooltip example stretched to full width of window
+
 ## [4.40.1] - 2024-10-28
 
 ### Changed

--- a/semcore/dropdown/src/style/dropdown.shadow.css
+++ b/semcore/dropdown/src/style/dropdown.shadow.css
@@ -10,6 +10,7 @@ SDropdownPopper {
 }
 
 SDropdownItem {
+  display: block;
   position: relative;
   text-decoration: none;
   box-sizing: border-box;


### PR DESCRIPTION
## Motivation and Context

Fixed Singleton Tooltip example stretched to full width of window.

Might affect Select and Dropdown components.

## How has this been tested?

manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
