### PR TITLE
[UIK-2541][data-table] fixed unexpected focusing on the first element of table after first clicking on some interactive element inside it

### DIFF
--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.47.1] - 2024-11-01
+
+### Fixed
+
+- Unexpected focusing on the first element of table after first clicking on some interactive element inside it.
+
 ## [4.47.0] - 2024-10-28
 
 ### Changed

--- a/semcore/data-table/src/DataTable.tsx
+++ b/semcore/data-table/src/DataTable.tsx
@@ -31,6 +31,7 @@ import i18nEnhance from '@semcore/utils/lib/enhances/i18nEnhance';
 import style from './style/data-table.shadow.css';
 import { isFocusInside } from '@semcore/utils/lib/use/useFocusLock';
 import { hasFocusableIn } from '@semcore/utils/lib/use/useFocusLock';
+import { hasParent } from '@semcore/utils/lib/hasParent';
 
 const reversedSortDirection: { [direction in SortDirection]: SortDirection } = {
   desc: 'asc',
@@ -674,6 +675,7 @@ class RootDefinitionTable extends Component<AsProps> {
   };
 
   handleKeyDown = (e: React.KeyboardEvent) => {
+    this.lastInteraction = 'keyboard';
     switch (e.key) {
       case 'Tab': {
         this.setInert(true);
@@ -703,7 +705,10 @@ class RootDefinitionTable extends Component<AsProps> {
   };
 
   handleFocus = (e: React.FocusEvent<HTMLElement, HTMLElement>) => {
-    if (!e.relatedTarget || !isFocusInside(e.currentTarget, e.relatedTarget)) {
+    if (
+      (!e.relatedTarget || !isFocusInside(e.currentTarget, e.relatedTarget)) &&
+      this.lastInteraction !== 'mouse'
+    ) {
       if (this.cellsMap.size === 0) {
         this.fillCells();
 

--- a/semcore/data-table/src/DataTable.tsx
+++ b/semcore/data-table/src/DataTable.tsx
@@ -31,7 +31,7 @@ import i18nEnhance from '@semcore/utils/lib/enhances/i18nEnhance';
 import style from './style/data-table.shadow.css';
 import { isFocusInside } from '@semcore/utils/lib/use/useFocusLock';
 import { hasFocusableIn } from '@semcore/utils/lib/use/useFocusLock';
-import { hasParent } from '@semcore/utils/lib/hasParent';
+import focusSourceEnhance from '@semcore/utils/lib/enhances/focusSourceEnhance';
 
 const reversedSortDirection: { [direction in SortDirection]: SortDirection } = {
   desc: 'asc',
@@ -55,6 +55,7 @@ type AsProps = {
   uniqueKey: string;
   uid?: string;
   getI18nText?: (str: string) => string;
+  focusSourceRef?: React.RefObject<'mouse' | 'keyboard' | 'none'>;
 };
 
 type HeadAsProps = {
@@ -238,7 +239,7 @@ class RootDefinitionTable extends Component<AsProps> {
   static displayName = 'DefinitionTable';
 
   static style = style;
-  static enhance = [uniqueIDEnhancement(), i18nEnhance(localizedMessages)];
+  static enhance = [uniqueIDEnhancement(), i18nEnhance(localizedMessages), focusSourceEnhance()];
 
   static defaultProps = {
     use: 'primary',
@@ -249,7 +250,6 @@ class RootDefinitionTable extends Component<AsProps> {
 
   focusedCell: [RowIndex, ColIndex] = [0, 0];
   cellsMap = new Map<RowIndex, Map<ColIndex, HTMLElement>>();
-  lastInteraction: 'mouse' | 'keyboard' | null = null;
 
   columns: Column[] = [];
 
@@ -675,7 +675,6 @@ class RootDefinitionTable extends Component<AsProps> {
   };
 
   handleKeyDown = (e: React.KeyboardEvent) => {
-    this.lastInteraction = 'keyboard';
     switch (e.key) {
       case 'Tab': {
         this.setInert(true);
@@ -707,7 +706,7 @@ class RootDefinitionTable extends Component<AsProps> {
   handleFocus = (e: React.FocusEvent<HTMLElement, HTMLElement>) => {
     if (
       (!e.relatedTarget || !isFocusInside(e.currentTarget, e.relatedTarget)) &&
-      this.lastInteraction !== 'mouse'
+      this.asProps.focusSourceRef?.current === 'keyboard'
     ) {
       if (this.cellsMap.size === 0) {
         this.fillCells();
@@ -741,7 +740,6 @@ class RootDefinitionTable extends Component<AsProps> {
   };
 
   handleMouseMove = () => {
-    this.lastInteraction = 'mouse';
     this.setInert(false);
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
We've incorrectly set focus to table after interaction with mouse with some elements inside it. I've fixed it.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
