### PR TITLE
[UIK-2204][mini-chart] add option to pass second color

### DIFF
--- a/semcore/mini-chart/CHANGELOG.md
+++ b/semcore/mini-chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [0.25.1] - 2024-11-01
+
+### Added
+
+- `baseBgColor` option to specify pass second color as background for TrendLine and ScoreDonut
+
 ## [0.25.0] - 2024-11-01
 
 ### Changed

--- a/semcore/mini-chart/src/component/score/Donut.tsx
+++ b/semcore/mini-chart/src/component/score/Donut.tsx
@@ -28,6 +28,7 @@ class DonutRoot extends Component<ScoreDonutProps, {}, {}, typeof DonutRoot.enha
     const {
       value,
       styles,
+      baseBgColor = 'chart-grid-bar-chart-base-bg',
       color = 'chart-palette-order-1',
       resolveColor,
       isSemiDonut,
@@ -64,7 +65,7 @@ class DonutRoot extends Component<ScoreDonutProps, {}, {}, typeof DonutRoot.enha
               cy='12'
               r={radius}
               strokeWidth={strokeWidth}
-              stroke={resolveColor('chart-grid-bar-chart-base-bg')}
+              stroke={resolveColor(baseBgColor)}
               strokeDasharray={
                 loading ? undefined : `${greyStrokeDasharray} ${baseStrokeDasharray}`
               }

--- a/semcore/mini-chart/src/component/score/Line.tsx
+++ b/semcore/mini-chart/src/component/score/Line.tsx
@@ -49,6 +49,7 @@ class LineRoot extends Component<ScoreLineGaugeProps, {}, {}, typeof LineRoot.en
       value,
       styles,
       color = 'chart-palette-order-1',
+      baseBgColor,
       resolveColor,
       loading,
       children,
@@ -58,7 +59,7 @@ class LineRoot extends Component<ScoreLineGaugeProps, {}, {}, typeof LineRoot.en
 
     if (children !== undefined) {
       return sstyled(styles)(
-        <SLineGauge render={Box} segments>
+        <SLineGauge render={Box} segments baseBgColor={resolveColor(baseBgColor)}>
           <SLineGaugeSegment>
             <Children />
           </SLineGaugeSegment>
@@ -94,7 +95,7 @@ class LineRoot extends Component<ScoreLineGaugeProps, {}, {}, typeof LineRoot.en
     }
 
     return sstyled(styles)(
-      <SLineGauge render={Box}>
+      <SLineGauge render={Box} base-bg-color={resolveColor(baseBgColor)}>
         {!loading && <SLineValue w={percent} color={resolveColor(color)} />}
         {Boolean(SegmentItems.length) && <SLineGaugeSegment>{SegmentItems}</SLineGaugeSegment>}
         {animate && <SAnimationLine />}

--- a/semcore/mini-chart/src/component/score/Line.tsx
+++ b/semcore/mini-chart/src/component/score/Line.tsx
@@ -59,7 +59,7 @@ class LineRoot extends Component<ScoreLineGaugeProps, {}, {}, typeof LineRoot.en
 
     if (children !== undefined) {
       return sstyled(styles)(
-        <SLineGauge render={Box} segments baseBgColor={resolveColor(baseBgColor)}>
+        <SLineGauge render={Box} segments base-bg-color={resolveColor(baseBgColor)}>
           <SLineGaugeSegment>
             <Children />
           </SLineGaugeSegment>

--- a/semcore/mini-chart/src/component/score/Score.ts
+++ b/semcore/mini-chart/src/component/score/Score.ts
@@ -10,6 +10,11 @@ export type CommonScoreProps = {
   color?: string;
 
   /**
+   * Color of background
+   */
+  baseBgColor?: string;
+
+  /**
    * Flag to enable skeleton
    * @default false
    */

--- a/semcore/mini-chart/src/component/score/line.shadow.css
+++ b/semcore/mini-chart/src/component/score/line.shadow.css
@@ -2,7 +2,7 @@
 
 SLineGauge {
   height: 8px;
-  background-color: var(--intergalactic-chart-grid-bar-chart-base-bg, #e0e1e9);
+  background-color: var(--base-bg-color, var(--intergalactic-chart-grid-bar-chart-base-bg, #e0e1e9));
   border-radius: var(--intergalactic-chart-rounded, 2px);
   overflow: hidden;
   position: relative;

--- a/website/docs/data-display/mini-chart/examples/base_color.tsx
+++ b/website/docs/data-display/mini-chart/examples/base_color.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import MiniChart from '@semcore/mini-chart';
-import { Flex, Box } from 'intergalactic/flex-box';
+import { Flex, Box } from '@semcore/flex-box';
 
 const Demo = () => {
   const value = 30;

--- a/website/docs/data-display/mini-chart/examples/base_color.tsx
+++ b/website/docs/data-display/mini-chart/examples/base_color.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import MiniChart from '@semcore/mini-chart';
+import { Flex, Box } from 'intergalactic/flex-box';
+
+const Demo = () => {
+  const value = 30;
+
+  return (
+    <Flex gap={'40px'}>
+      <Box w={'300px'}>
+        <MiniChart.ScoreLine value={value} w={'120px'} baseBgColor={'chart-palette-order-5'} />
+        <br />
+        <MiniChart.ScoreLine
+          segments={5}
+          value={3}
+          w={'80px'}
+          animate={false}
+          baseBgColor={'chart-palette-order-2'}
+        />
+        <br />
+        <MiniChart.ScoreLine segments={3} value={2} baseBgColor={'chart-palette-order-4'} />
+        <br />
+        <MiniChart.ScoreDonut value={value} w={'50px'} baseBgColor={'chart-palette-order-5'} />
+        <br />
+        <MiniChart.ScoreSemiDonut value={value} w={'50px'} baseBgColor={'chart-palette-order-2'} />
+      </Box>
+    </Flex>
+  );
+};
+
+export default Demo;

--- a/website/docs/data-display/mini-chart/mini-chart-code.md
+++ b/website/docs/data-display/mini-chart/mini-chart-code.md
@@ -12,3 +12,13 @@ tabs: Design('mini-chart'), A11y('mini-chart-a11y'), API('mini-chart-api'), Exam
 </script>
 
 :::
+
+## Base color
+
+::: sandbox
+
+<script lang="tsx">
+  export Demo from './examples/base_color.tsx';
+</script>
+
+:::


### PR DESCRIPTION
## Motivation and Context

Added `baseBgColor` option to specify pass second color as background for TrendLine and ScoreDonut

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

manually

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
