### PR TITLE
[UIK-2201][dropdown, dropdown-menu] added DropdownPopperAriaProps for dialogs

### DIFF
--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.43.1] - 2024-11-05
+
+### Added
+
+- `DropdownPopperAriaProps` type for DropdownMenu.Popper props.
+
 ## [4.43.0] - 2024-11-01
 
 ### Changed

--- a/semcore/dropdown-menu/src/index.d.ts
+++ b/semcore/dropdown-menu/src/index.d.ts
@@ -4,6 +4,7 @@ import Dropdown, {
   DropdownProps,
   DropdownHandlers,
   DropdownTriggerProps,
+  DropdownPopperAriaProps,
 } from '@semcore/dropdown';
 import { Box, BoxProps, FlexProps, Flex } from '@semcore/flex-box';
 import { ScrollAreaProps } from '@semcore/scroll-area';
@@ -129,7 +130,7 @@ declare const DropdownMenu: Intergalactic.Component<
   [handlers: DropdownMenuHandlers]
 > & {
   Trigger: typeof Dropdown.Trigger;
-  Popper: Intergalactic.Component<'div', DropdownMenuProps>;
+  Popper: Intergalactic.Component<'div', DropdownMenuProps & DropdownPopperAriaProps>;
   List: Intergalactic.Component<
     'div',
     DropdownMenuListProps,

--- a/semcore/dropdown/CHANGELOG.md
+++ b/semcore/dropdown/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.41.1] - 2024-11-05
+
+### Added
+
+- Export for `DropdownPopperAriaProps` type.
+
 ## [4.41.0] - 2024-11-01
 
 ### Changed

--- a/semcore/dropdown/src/index.d.ts
+++ b/semcore/dropdown/src/index.d.ts
@@ -39,7 +39,7 @@ export type DropdownTriggerProps = PopperTriggerProps;
  * DropdownPopper must have an accessible name (aria-dialog-name).
  * It should describe popper content.
  */
-type DropdownPopperAriaProps = Intergalactic.RequireAtLeastOne<{
+export type DropdownPopperAriaProps = Intergalactic.RequireAtLeastOne<{
   'aria-label'?: string;
   'aria-labelledby'?: string;
   title?: string;

--- a/semcore/popper/__tests__/stands/disable-portal.tsx
+++ b/semcore/popper/__tests__/stands/disable-portal.tsx
@@ -9,7 +9,7 @@ const Demo = () => {
     <div>
       <DropdownMenu visible disablePortal>
         <DropdownMenu.Trigger tag={ButtonTrigger}>Disabled portal</DropdownMenu.Trigger>
-        <DropdownMenu.Popper p={5} data-testid='popper'>
+        <DropdownMenu.Popper p={5} data-testid='popper' aria-label={'Select popper'}>
           <input data-testid='input-in-popper' />
         </DropdownMenu.Popper>
       </DropdownMenu>

--- a/semcore/popper/__tests__/stands/dropdown.tsx
+++ b/semcore/popper/__tests__/stands/dropdown.tsx
@@ -9,7 +9,7 @@ const Demo = () => {
     <div>
       <DropdownMenu visible>
         <DropdownMenu.Trigger tag={ButtonTrigger}>Enabled portal</DropdownMenu.Trigger>
-        <DropdownMenu.Popper p={5} data-testid='popper'>
+        <DropdownMenu.Popper p={5} data-testid='popper' aria-label={'Select popper'}>
           <input data-testid='input-in-popper' />
         </DropdownMenu.Popper>
       </DropdownMenu>

--- a/semcore/select/__tests__/index.test.tsx
+++ b/semcore/select/__tests__/index.test.tsx
@@ -93,7 +93,7 @@ describe('Select Trigger', () => {
       const { getByTestId } = render(
         <Select multiselect onChange={spy} visible value={['1']}>
           <Select.Trigger />
-          <Select.Popper>
+          <Select.Popper aria-label={'Select popper'}>
             <Select.Option value='1' />
             <Select.Option data-testid='option' value='2' />
           </Select.Popper>
@@ -112,7 +112,7 @@ describe('Select Trigger', () => {
       render(
         <Select onVisibleChange={spy} interaction={'none'}>
           <Select.Trigger />
-          <Select.Popper>
+          <Select.Popper aria-label={'Select popper'}>
             <Select.Option value='1' />
             <Select.Option value='2' />
           </Select.Popper>
@@ -130,7 +130,7 @@ describe('Select Trigger', () => {
     const { getByTestId } = render(
       <Select visible onVisibleChange={spy}>
         <Select.Trigger />
-        <Select.Popper>
+        <Select.Popper aria-label={'Select popper'}>
           <Select.Option data-testid='option' value='test' />
         </Select.Popper>
       </Select>,
@@ -185,7 +185,7 @@ describe('Select Trigger', () => {
     const component = (
       <Select onChange={spyChange}>
         <Select.Trigger tag={'button'} data-testid='buttonTrigger' />
-        <Select.Popper>
+        <Select.Popper aria-label={'Select popper'}>
           <Select.Option value={1}>Option1</Select.Option>
           <Select.Option value={2}>Option2</Select.Option>
           <Select.Option value={3}>Option3</Select.Option>
@@ -240,7 +240,7 @@ describe('Select Trigger', () => {
       <div style={{ position: 'relative', width: '150px', height: '100px' }}>
         <Select {...props} size={size} visible disablePortal value='1'>
           <Select.Trigger />
-          <Select.Popper>
+          <Select.Popper aria-label={'Select popper'}>
             <Select.Option value='1'>
               <Select.Option.Checkbox theme={theme} />
               size {size ?? 'default'} selected
@@ -273,7 +273,7 @@ describe('Select Trigger', () => {
       <div style={{ position: 'relative', width: '150px', height: '100px' }}>
         <Select {...props} visible disablePortal>
           <Select.Trigger />
-          <Select.Popper>
+          <Select.Popper aria-label={'Select popper'}>
             <Select.Option value='1' id='option'>
               <Select.Option.Checkbox theme={theme} />
               size m selected

--- a/website/docs/components/dropdown-menu/dropdown-menu-a11y.md
+++ b/website/docs/components/dropdown-menu/dropdown-menu-a11y.md
@@ -11,14 +11,14 @@ tabs: Design('dropdown-menu'), A11y('dropdown-menu-a11y'), API('dropdown-menu-ap
 
 Table: Keyboard support
 
-| Key                              | Function                                                                                                                                                   |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Tab`                            | Moves focus to the next focusable element.                                                                                                                 |
-| `Shift + Tab`                    | Moves focus to the previous focusable element.                                                                                                             |
-| `Space`, `Enter`, <nobr>`Up Arrow`</nobr>, <nobr>`Down Arrow`</nobr> | When focus is on the trigger, opens the dropdown.                                                                                                          |
-| <nobr>`Up Arrow`</nobr>, <nobr>`Down Arrow`</nobr>        | Moves selection between the list options in the dropdown. If selection is on the last/first option, moves selection to the first/last option respectively. |
-| `Space`, `Enter`                | Selects the option and closes the dropdown.                                                                                                                |
-| `Esc`                            | Closes the dropdown.                                                                                                                                       |
+| Key                              | Function                                                                                                             |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `Tab`                            | Moves focus to the next focusable element.                                                                           |
+| `Shift + Tab`                    | Moves focus to the previous focusable element.                                                                       |
+| `Space`, `Enter`, <nobr>`Up Arrow`</nobr>, <nobr>`Down Arrow`</nobr> | When focus is on the trigger, opens the dropdown.                                |
+| <nobr>`Up Arrow`</nobr>, <nobr>`Down Arrow`</nobr> | Moves selection between the list options in the dropdown. If selection is on the last/first option, moves selection to the first/last option respectively. |
+| `Space`, `Enter`                 | Selects the option and closes the dropdown.                                                                          |
+| `Esc`                            | Closes the dropdown.                                                                                                 |
 
 When dropdown is closed, the focus stays on the trigger.
 
@@ -26,24 +26,41 @@ When dropdown is closed, the focus stays on the trigger.
 
 The following list describes roles and attributes that component already has.
 
-| Component / element                              | Role / Attribute             | Usage                                                                                                                                            |
-| ------------------------------------------------ | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `DropdownMenu.Trigger`                           | `button`                     | Tells the screen reader the element is a button.                                                                                                 |
-|                                                  | `aria-haspopup="true"`       | Indicates that the element triggers a dialog.                                                                                                    |
-|                                                  | `aria-expanded="true/false"` | Set to `true` when dialog is visible. Indicates that the dialog is open.                                                                         |
-|                                                  | `aria-controls="IDREF"`      | Indicates which element this `Trigger` opens.                                                                                                    |
-| `DropdownMenu.Menu`                              | `menu`                       | The `menu` role is a type of composite widget that offers a list of choices to the user.                                                         |
-|                                                  | `aria-labelledby="IDREF"`    | Identifies the title for the menu.                                                                                                               |
-| `DropdownMenu.Item`, `DropdownMenu.Item.Content` | `menuitem`                   | Indicates the element is an option in a set of choices contained by a `menu`.                                                                    |
+| Component / element                              | Role / Attribute             | Usage                                                              |
+| ------------------------------------------------ | ---------------------------- | ------------------------------------------------------------------ |
+| `DropdownMenu.Trigger`                           | `button`                     | Tells the screen reader the element is a button.                   |
+|                                                  | `aria-haspopup="true"`       | Indicates that the element triggers a dialog.                      |
+|                                                  | `aria-expanded="true/false"` | Set to `true` when dialog is visible. Indicates that the dialog is open. |
+|                                                  | `aria-controls="IDREF"`      | Indicates which element this `Trigger` opens.                      |
+| `DropdownMenu.Menu`                              | `menu`                       | The `menu` role is a type of composite widget that offers a list of choices to the user.            |
+|                                                  | `aria-labelledby="IDREF"`    | Identifies the title for the menu.                                 |
+| `DropdownMenu.Popper`                            | `dialog`                     | **Only if `DropdownMenu.Popper` is used explicitly.** Identifies the popper as a dialog. |
+| `DropdownMenu.Item`, `DropdownMenu.Item.Content` | `menuitem`                   | Indicates the element is an option in a set of choices contained by a `menu`.       |
 |                                                  | `aria-describedby="IDREF"`   | Gives the item an accessible description by referring to the `Item.Hint`, the tooltip, or both, describing the primary message or purpose of the item.               |
-| `DropdownMenu.Item.Hint`                         | `aria-hidden="true"`         | Hides element from assistive technologies.                                                                                                       |
-| `DropdownMenu.Item.Content`                      | `aria-haspopup="dialog"`     | Indicates that the element triggers a dialog.                                                                                                    |
-|                                                  | `aria-expanded="true/false"` | Set to `true` when dialog is visible. Indicates that the dialog is open.                                                                         |
-| `DropdownMenu.Group`                             | `group`                      | Identifies a set of user interface objects that is not intended to be included in a page summary or table of contents by assistive technologies. |
-|                                                  | `aria-labeledby="IDREF"`     | Identifies the title for the content group.                                                                                                      |
+| `DropdownMenu.Item.Hint`                         | `aria-hidden="true"`         | Hides element from assistive technologies.                         |
+| `DropdownMenu.Item.Content`                      | `aria-haspopup="dialog"`     | Indicates that the element triggers a dialog.                      |
+|                                                  | `aria-expanded="true/false"` | Set to `true` when dialog is visible. Indicates that the dialog is open. |
+| `DropdownMenu.Group`                             | `group`                      | Identifies a set of user interface objects that's not intended to be included in a page summary or table of contents by assistive technologies. |
+|                                                  | `aria-labeledby="IDREF"`     | Identifies the title for the content group.                        |
+
+## Considerations for developers
+
+Only use `DropdownMenu.Popper` explicitly if it must have additional elements beside the menu, as in [the example with a Notice](./dropdown-menu-code.md#second-method). In that case the popper will be presented as a dialog, which hints to the screen reader user to use the `Tab` key to navigate between the menu and other elements.
+
+If your `DropdownMenu` is a list of options without additional features, use it with `DropdownMenu.Menu`, as in the [basic example](./dropdown-menu-code.md#basic-usage). This will let the screen reader user know that `Up` and `Down` keys are enough to navigate within the control.
+
+### Roles and attributes
+
+The following list will help you to keep in mind the necessary roles and attributes to make our components fully accessible in the particular cases in your interfaces.
+
+Table: Roles and attributes
+
+| Component             | Attribute                         | Usage                                                     |
+| --------------------- | --------------------------------- | --------------------------------------------------------- |
+| `DropdownMenu.Popper` | `aria-label` or `aria-labelledby` | **Only if `DropdownMenu.Popper` is used explicitly.** Defines an accessible name for the popper. |
 
 ## Other recommendations
 
-See more accessibility recommendations in the common [Accessibility guide](/core-principles/a11y/a11y).
+For more accessibility recommendations, refer to the common [Accessibility guide](/core-principles/a11y/a11y).
 
 <!--@include: ./dropdown-menu-a11y-report.md-->

--- a/website/docs/components/dropdown-menu/dropdown-menu-code.md
+++ b/website/docs/components/dropdown-menu/dropdown-menu-code.md
@@ -29,6 +29,22 @@ There are a few ways to display the dropdown menu in this component.
 
 ### First method
 
+The easiest way is to use `DropdownMenu.Menu`.
+
+This is best when you only need to manage the content within the options list.
+
+`DropdownMenu.Menu` is a wrapper around `DropdownMenu.Popper` and `DropdownMenu.List`, and all props pass through to `DropdownMenu.List`.
+
+::: sandbox
+
+<script lang="tsx">
+  export Demo from './examples/the_second_method.tsx';
+</script>
+
+:::
+
+### Second method
+
 Use a combination of two components:
 
 - `DropdownMenu.Popper`—for the dropdown layout
@@ -40,22 +56,6 @@ This method works well when you need flexible customization of the dropdown menu
 
 <script lang="tsx">
   export Demo from './examples/dropdown-menu.tsx';
-</script>
-
-:::
-
-### Second method
-
-The easiest way is to use `DropdownMenu.Menu`.
-
-This is best when you only need to manage the content within the options list.
-
-`DropdownMenu.Menu` is a wrapper around `DropdownMenu.Popper` and `DropdownMenu.List`, and all props pass through to `DropdownMenu.List`.
-
-::: sandbox
-
-<script lang="tsx">
-  export Demo from './examples/the_second_method.tsx';
 </script>
 
 :::

--- a/website/docs/components/dropdown-menu/examples/dropdown-menu.tsx
+++ b/website/docs/components/dropdown-menu/examples/dropdown-menu.tsx
@@ -23,7 +23,7 @@ const Demo = () => {
         </Button.Addon>
         <Button.Text>Export</Button.Text>
       </DropdownMenu.Trigger>
-      <DropdownMenu.Popper wMax='256px'>
+      <DropdownMenu.Popper wMax='256px' aria-label={'Export options'}>
         <SpinContainer loading={loading}>
           <DropdownMenu.List>
             <DropdownMenu.Item onClick={handleClick}>Excel</DropdownMenu.Item>

--- a/website/docs/components/dropdown-menu/examples/nested-with-focusable.tsx
+++ b/website/docs/components/dropdown-menu/examples/nested-with-focusable.tsx
@@ -30,7 +30,7 @@ const Demo = () => {
                   {item}
                   <DropdownMenu.Item.Addon tag={ChevronRightIcon} color='icon-secondary-neutral' />
                 </DropdownMenu.Item.Content>
-                <DropdownMenu.Popper w={150}>
+                <DropdownMenu.Popper w={150} aria-label={'Some item 4 options and controls'}>
                   <DropdownMenu.List>
                     <DropdownMenu.Item>Item 4.1.1</DropdownMenu.Item>
                     <DropdownMenu.Item>Item 4.1.2</DropdownMenu.Item>

--- a/website/docs/components/input-phone/examples/known_country_and_number_format.tsx
+++ b/website/docs/components/input-phone/examples/known_country_and_number_format.tsx
@@ -54,7 +54,7 @@ const Demo = () => {
               </Select.Trigger.Addon>
             </Select.Trigger>
 
-            <Select.Popper tabIndex={-1}>
+            <Select.Popper tabIndex={-1} aria-label={'Phone countries with search'}>
               <>
                 <InputSearch
                   placeholder='Search'

--- a/website/docs/components/select/examples/advanced_filtering_control.tsx
+++ b/website/docs/components/select/examples/advanced_filtering_control.tsx
@@ -21,7 +21,7 @@ const Demo = () => {
       </Text>
       <Select placeholder='Select a fruit'>
         <Select.Trigger id='options-filtering-advanced' mr='auto' mt={2} />
-        <Select.Popper>
+        <Select.Popper aria-label={'Fruit options with search'}>
           <InputSearch value={filter} onChange={setFilter}>
             <InputSearch.SearchIcon />
             <InputSearch.Value

--- a/website/docs/components/select/examples/dropdownmenu_customization.tsx
+++ b/website/docs/components/select/examples/dropdownmenu_customization.tsx
@@ -21,7 +21,7 @@ const Demo = () => (
     </Text>
     <Select placeholder={'Select something'}>
       <Select.Trigger mt={2} mr='auto' id='customized-dropdown-select' />
-      <Select.Popper>
+      <Select.Popper aria-label={'Options and notice'}>
         <Select.List hMax='240px'>
           {options.map((option, index) => (
             <Select.Option value={option} key={index}>

--- a/website/docs/components/select/examples/options_filtering.tsx
+++ b/website/docs/components/select/examples/options_filtering.tsx
@@ -21,7 +21,7 @@ const Demo = () => {
       </Text>
       <Select placeholder='Select a fruit'>
         <Select.Trigger id='options-filtering-select' mr='auto' mt={2} />
-        <Select.Popper>
+        <Select.Popper aria-label={'Fruits with search'}>
           <Select.InputSearch
             value={filter}
             onChange={setFilter}

--- a/website/docs/components/select/select-a11y.md
+++ b/website/docs/components/select/select-a11y.md
@@ -46,7 +46,7 @@ Table: Roles and attributes
 
 ## Considerations for developers
 
-Only use `Select.Popper` explicitly if it must have additional elements beside the list, such as `InputSearch` or `Notice`, as in the [menu customization example](./select-code.md#menu-customization) and the [option filtering example](./select-code.md#options-filtering). In that case the popper will be presented as a dialog, which hints to the screen reader user to use the `Tab` key to navigate between the list of options and other elements. 
+Only use `Select.Popper` explicitly if it must have additional elements beside the list, such as `InputSearch` or `Notice`, as in the [menu customization example](./select-code.md#menu-customization) and the [option filtering example](./select-code.md#options-filtering). In that case the popper will be presented as a dialog, which hints to the screen reader user to use the `Tab` key to navigate between the list of options and other elements.
 
 If your `Select` is a list of options without additional features, use it without children or with `Select.Menu`, as in the [basic example](./select-code.md#basic-usage). This will let the screen reader user know that `Up` and `Down` keys are enough to navigate within the control.
 
@@ -56,9 +56,10 @@ The following list will help you to keep in mind the necessary roles and attribu
 
 Table: Roles and attributes
 
-| Component            | Attribute                  | Usage                                                                                                                                                                             |
-| -------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Select.InputSearch` | `aria-describedby="IDREF"` | Defines an accessible description for the **Search** input. Use it to announce the number of search results, as demonstrated in the [options filtering example](./select-code.md#options-filtering). |
+| Component            | Attribute                         | Usage                                                     |
+| -------------------- | --------------------------------- | --------------------------------------------------------- |
+| `Select.Popper`      | `aria-label` or `aria-labelledby` | **Only if `Select.Popper` is used explicitly.** Defines an accessible name for the popper. |
+| `Select.InputSearch` | `aria-describedby="IDREF"`        | Defines an accessible description for the **Search** input. Use it to announce the number of search results, as demonstrated in the [options filtering example](./select-code.md#options-filtering). |
 
 ## Resources
 

--- a/website/docs/data-display/d3-chart/examples/export-to-image.tsx
+++ b/website/docs/data-display/d3-chart/examples/export-to-image.tsx
@@ -79,7 +79,7 @@ const Demo = () => {
           </Button.Addon>
           <Button.Text>Export</Button.Text>
         </DropdownMenu.Trigger>
-        <DropdownMenu.Popper wMax='257px'>
+        <DropdownMenu.Popper wMax='257px' aria-label={'Extensions'}>
           <DropdownMenu.List>
             {extensions.map((name) => (
               <DropdownMenu.Item onClick={downloadImage(name)}>{name}</DropdownMenu.Item>

--- a/website/docs/filter-group/filter-serp-features/examples/serp-filter.tsx
+++ b/website/docs/filter-group/filter-serp-features/examples/serp-filter.tsx
@@ -141,7 +141,7 @@ const Demo = () => {
         onVisibleChange={handleChangeVisible}
       >
         <Select.Trigger tag={FilterTrigger}>{triggerValue}</Select.Trigger>
-        <Select.Popper>
+        <Select.Popper aria-label={'Options with search'}>
           {({ highlightedIndex }) => (
             <>
               <InputSearch

--- a/website/docs/patterns/validation-form/examples/form-validation-example-by-`unfocus`.tsx
+++ b/website/docs/patterns/validation-form/examples/form-validation-example-by-`unfocus`.tsx
@@ -194,7 +194,7 @@ class Demo extends React.Component {
                             }}
                           >
                             <Select.Trigger w={'100%'} onBlur={(e) => input.onBlur(e)} />
-                            <Select.Popper>
+                            <Select.Popper aria-label={'Options'}>
                               <Select.Option value={1}>Morning</Select.Option>
                               <Select.Option value={2}>Afternoon</Select.Option>
                               <Select.Option value={3}>Evening</Select.Option>

--- a/website/docs/table-group/data-table/examples/export-in-image.tsx
+++ b/website/docs/table-group/data-table/examples/export-in-image.tsx
@@ -62,7 +62,7 @@ const Demo = () => {
           </Button.Addon>
           <Button.Text>Export</Button.Text>
         </DropdownMenu.Trigger>
-        <DropdownMenu.Popper wMax='257px'>
+        <DropdownMenu.Popper wMax='257px' aria-label={'Extensions'}>
           <DropdownMenu.List>
             {extensions.map((name) => (
               <DropdownMenu.Item key={name} onClick={downloadImage(name)}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
I added required aria-* props for `Select.Popper` and `DropdownMenu.Popper` if they has role `dialog`.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manyally
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
