### PR TITLE
[UIK-2631][docs] Replaced Validation example with link to Form, linted texts

### DIFF
--- a/website/docs/patterns/validation-form/validation-form-a11y.md
+++ b/website/docs/patterns/validation-form/validation-form-a11y.md
@@ -13,7 +13,7 @@ Refer to [Form](/patterns/form/form-a11y) for the recommendations on how to make
 
 ### Keyboard support
 
-See detailed information about the keyboard support for the all form elements in the [Keyboard control guide](/core-principles/a11y/a11y-keyboard).
+Find detailed information about keyboard support for all form elements in the [Keyboard control guide](/core-principles/a11y/a11y-keyboard).
 
 ## Considerations for designers
 
@@ -26,4 +26,4 @@ See detailed information about the keyboard support for the all form elements in
 
 ## Other recommendations
 
-See more accessibility recommendations in the common [Accessibility guide](/core-principles/a11y/a11y).
+For more accessibility recommendations, refer to the common [Accessibility guide](/core-principles/a11y/a11y).

--- a/website/docs/patterns/validation-form/validation-form-code.md
+++ b/website/docs/patterns/validation-form/validation-form-code.md
@@ -3,12 +3,6 @@ title: Validation
 tabs: Design('validation-form'), A11y('validation-form-a11y'), Example('validation-form-code')
 ---
 
-## Form validation example by `unFocus`
-
-::: sandbox
-
-<script lang="tsx">
-  export Demo from './examples/form-validation-example-by-`unfocus`.tsx';
-</script>
-
+::: info
+Refer to [Form](../form/form-code.md) for examples of form validation.
 :::

--- a/website/docs/patterns/validation-form/validation-form.md
+++ b/website/docs/patterns/validation-form/validation-form.md
@@ -31,13 +31,13 @@ The message should explain why the input is invalid or gives steps to fix it. Tr
 - If the browser checks the input, the `invalid` state goes away as soon as the input is correct.
 - If the server checks the input, the `invalid` state goes away each time the input is changed.
 
-If user fixes inputs in a different order, all inputs that are still invalid will stay marked until they are changed.
+If user fixes inputs in a different order, all inputs that are still invalid will stay marked until they're changed.
 
 ## unFocus validation
 
 Where deductions of paid limits and backend complexities are absent, immediate validation can be applied as users complete forms. Use this validation approach to facilitate form and filter completion. Displaying correction cues before submitting the form is recommended.
 
-Where there's no need to consider limits or complex backend rules, check inputs right away as they are filled out. Use this method to help users complete forms and filters. It's better to show messages on how to correct inputs before user submits the form.
+Where there's no need to consider limits or complex backend rules, check inputs right away as they're filled out. Use this method to help users complete forms and filters. It's better to show messages on how to correct inputs before user submits the form.
 
 ![](static/immediate-validation.png)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Validation pattern example had the same functionality as Form example.

I removed Validation example from the Example page and replaced it with a link to Form.

Also fixed some small issues in text.

## Screenshots (if appropriate):

<img width="751" alt="image" src="https://github.com/user-attachments/assets/a3af38fb-be4d-443c-9de4-7d7b4f1860ce">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
