### PR TITLE
[UIK-2946][date-picker][VPAT] removed compobobox role from inputs in comparator's popper

### DIFF
--- a/semcore/date-picker/CHANGELOG.md
+++ b/semcore/date-picker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [4.54.7] - 2024-12-16
+
+### Removed
+
+- Unnecessary `role=combobox` for all inputs from popper in any Comparator.
+
 ## [4.54.6] - 2024-12-09
 
 ### Changed

--- a/semcore/date-picker/src/components/DateRangeComparatorAbstract.jsx
+++ b/semcore/date-picker/src/components/DateRangeComparatorAbstract.jsx
@@ -387,6 +387,12 @@ class DateRangeComparatorAbstract extends Component {
     throw new Error('not implemented');
   }
 
+  getRangeInputProps() {
+    return {
+      inputRole: null,
+    };
+  }
+
   getValueDateRangeProps() {
     const {
       value,

--- a/semcore/date-picker/src/components/InputTrigger.jsx
+++ b/semcore/date-picker/src/components/InputTrigger.jsx
@@ -486,6 +486,7 @@ const MaskedInput = ({
   animationsDisabled,
   getI18nText,
   inputId,
+  inputRole = 'combobox',
 
   __excludeProps,
 
@@ -870,7 +871,7 @@ const MaskedInput = ({
       onChange={handleChange}
       noHumanizedDate={!humanizedDate}
       animationsDisabled={animationsDisabled}
-      inputRole='combobox'
+      inputRole={inputRole}
     >
       {humanizedDate && <SHumanizedDate>{humanizedDate}</SHumanizedDate>}
     </InputMask.Value>,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
