### PR TITLE
[UIK-2217][link] fixed render hint's popper on Link with addonLeft as props and no children

### DIFF
--- a/semcore/link/CHANGELOG.md
+++ b/semcore/link/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [5.42.1] - 2024-12-18
+
+### Fixed
+
+- Render hint's popper on Link with addonLeft as props and no children.
+
 ## [5.42.0] - 2024-11-29
 
 ### Changed

--- a/semcore/link/src/Link.jsx
+++ b/semcore/link/src/Link.jsx
@@ -22,6 +22,7 @@ class RootLink extends Component {
 
   state = {
     ariaLabelledByContent: '',
+    visibleHint: false,
   };
 
   componentDidMount() {
@@ -43,6 +44,13 @@ class RootLink extends Component {
     }
   }
 
+  handleMouseEnterOnlyAddon = () => {
+    this.setState({ visibleHint: true });
+  };
+  handleMouseLeaveOnlyAddon = () => {
+    this.setState({ visibleHint: false });
+  };
+
   renderChildren() {
     const { Children, styles, addonLeft: AddonLeft, addonRight: AddonRight } = this.asProps;
 
@@ -62,12 +70,19 @@ class RootLink extends Component {
       addonRight: AddonRight,
       title,
       ['aria-label']: ariaLabel,
+      keyboardFocused,
     } = this.asProps;
+    const { visibleHint } = this.state;
 
     const hintContent = title ?? ariaLabel ?? this.state.ariaLabelledByContent ?? '';
 
     return sstyled(styles)(
-      <Link.Addon tag={Hint} title={hintContent} timeout={[250, 50]}>
+      <Link.Addon
+        tag={Hint}
+        title={hintContent}
+        timeout={[250, 50]}
+        visible={keyboardFocused || visibleHint}
+      >
         {AddonLeft && <AddonLeft />}
         {AddonRight && <AddonRight />}
       </Link.Addon>,
@@ -99,6 +114,8 @@ class RootLink extends Component {
         use:noWrap={false}
         ref={this.containerRef}
         __excludeProps={['disabled', 'aria-disabled']}
+        onMouseEnter={this.handleMouseEnterOnlyAddon}
+        onMouseLeave={this.handleMouseLeaveOnlyAddon}
       >
         {hasChildren !== undefined ? this.renderChildren() : this.renderOnlyAddons()}
       </SLink>,

--- a/stories/components/link/docs/examples/color_links.tsx
+++ b/stories/components/link/docs/examples/color_links.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import Link from 'intergalactic/link';
+import Link from '@semcore/link';
 
-class Demo extends React.PureComponent {
-  render() {
+const Demo = () => {
     return (
       <div>
         <Link color='text-critical' href='#' size={300}>
@@ -15,7 +14,6 @@ class Demo extends React.PureComponent {
         </Link>
       </div>
     );
-  }
 }
 
 export default Demo;

--- a/stories/components/link/docs/examples/link_addon.tsx
+++ b/stories/components/link/docs/examples/link_addon.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import Link from 'intergalactic/link';
-import CheckM from 'intergalactic/icon/Check/m';
-import ChevronRightM from 'intergalactic/icon/ChevronRight/m';
-import FormatText from 'intergalactic/format-text';
+import Link from '@semcore/link';
+import CheckM from '@semcore/icon/Check/m';
+import ChevronRightM from '@semcore/icon/ChevronRight/m';
+import FormatText from '@semcore/format-text';
 
 const Demo = () => {
   return (

--- a/stories/components/link/docs/examples/link_as_button.tsx
+++ b/stories/components/link/docs/examples/link_as_button.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import Button from 'intergalactic/button';
-import PlusM from 'intergalactic/icon/MathPlus/m';
+import Button from '@semcore/button';
+import PlusM from '@semcore/icon/MathPlus/m';
 
 const Demo = () => {
   return (

--- a/stories/components/link/docs/examples/link_disabled.tsx
+++ b/stories/components/link/docs/examples/link_disabled.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import Link from 'intergalactic/link';
-import ChevronRightM from 'intergalactic/icon/ChevronRight/m';
-import FormatText from 'intergalactic/format-text';
+import Link from '@semcore/link';
+import ChevronRightM from '@semcore/icon/ChevronRight/m';
+import FormatText from '@semcore/format-text';
 
 const Demo = () => {
   return (

--- a/stories/components/link/docs/examples/link_inside_the_content.tsx
+++ b/stories/components/link/docs/examples/link_inside_the_content.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import FormatText from 'intergalactic/format-text';
-import { List } from 'intergalactic/typography';
-import Link from 'intergalactic/link';
-import LinkExternalM from 'intergalactic/icon/LinkExternal/m';
+import FormatText from '@semcore/format-text';
+import { List } from '@semcore/typography';
+import Link from '@semcore/link';
+import LinkExternalM from '@semcore/icon/LinkExternal/m';
 
-class Demo extends React.PureComponent {
-  render() {
+const Demo = () => {
     return (
       <div>
         <FormatText size={'l'}>
@@ -44,7 +43,6 @@ class Demo extends React.PureComponent {
         </List>
       </div>
     );
-  }
 }
 
 export default Demo;

--- a/stories/components/link/docs/examples/link_without_text.tsx
+++ b/stories/components/link/docs/examples/link_without_text.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import Link from 'intergalactic/link';
-import HomeM from 'intergalactic/icon/Home/m';
-import LinkExternalM from 'intergalactic/icon/LinkExternal/m';
-import { Hint } from 'intergalactic/tooltip';
+import Link from '@semcore/link';
+import HomeM from '@semcore/icon/Home/m';
+import LinkExternalM from '@semcore/icon/LinkExternal/m';
+import { Hint } from '@semcore/tooltip';
 
 const Demo = () => {
   return (

--- a/stories/components/link/docs/examples/links_with_ellipsis.tsx
+++ b/stories/components/link/docs/examples/links_with_ellipsis.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { Flex } from 'intergalactic/flex-box';
-import { Text } from 'intergalactic/typography';
-import Divider from 'intergalactic/divider';
-import Link from 'intergalactic/link';
-import LinkExternalM from 'intergalactic/icon/LinkExternal/m';
+import { Flex } from '@semcore/flex-box';
+import { Text } from '@semcore/typography';
+import Divider from '@semcore/divider';
+import Link from '@semcore/link';
+import LinkExternalM from '@semcore/icon/LinkExternal/m';
 
-class Demo extends React.PureComponent {
-  render() {
+const Demo = () => {
     return (
       <Flex>
         <Text flex='0 0 auto'>Sep 3</Text>
@@ -27,7 +26,6 @@ class Demo extends React.PureComponent {
         </Link>
       </Flex>
     );
-  }
 }
 
 export default Demo;

--- a/stories/components/link/docs/link.stories.tsx
+++ b/stories/components/link/docs/link.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Link from '@semcore/link';
+
+import ColorLinksExample from './examples/color_links';
+import LinkAddonExample from './examples/link_addon';
+import LinkAsButtonExample from './examples/link_as_button';
+import LinkDisabledExample from './examples/link_disabled';
+import LinkInsideTheContentExample from './examples/link_inside_the_content';
+import LinkWithoutTextExample from './examples/link_without_text';
+import LinkWithEllipsisExample from './examples/links_with_ellipsis';
+
+const meta: Meta<typeof Link> = {
+  title: 'Components/Link/Documentation',
+  component: Link,
+};
+
+export default meta;
+type Story = StoryObj<typeof Link>;
+
+export const ColorLinks: Story = {
+  render: ColorLinksExample,
+};
+
+export const LinkAddon: Story = {
+  render: LinkAddonExample,
+};
+
+export const LinkAsButton: Story = {
+  render: LinkAsButtonExample,
+};
+
+export const LinkDisabled: Story = {
+  render: LinkDisabledExample,
+};
+
+export const LinkInsideTheContent: Story = {
+  render: LinkInsideTheContentExample,
+};
+
+export const LinkWithoutText: Story = {
+    render: LinkWithoutTextExample,
+};
+
+export const LinkWithEllipsis: Story = {
+    render: LinkWithEllipsisExample,
+};

--- a/website/docs/components/link/link-code.md
+++ b/website/docs/components/link/link-code.md
@@ -10,7 +10,7 @@ By default, links are displayed as `inline-block` and don’t wrap properly with
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/link_inside_the_content.tsx';
+  export Demo from 'stories/components/link/docs/examples/link_inside_the_content.tsx';
 </script>
 
 :::
@@ -22,7 +22,7 @@ You can add addons to link either by specifying the desired tag in the `addonLef
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/link_addon.tsx';
+  export Demo from 'stories/components/link/docs/examples/link_addon.tsx';
 </script>
 
 :::
@@ -34,7 +34,7 @@ Links can be colored for specific purposes. You can apply a specific color to li
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/color_links.tsx';
+  export Demo from 'stories/components/link/docs/examples/color_links.tsx';
 </script>
 
 :::
@@ -50,7 +50,7 @@ If you need to display disabled link as a `Button` you should remove `href` prop
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/link_as_button.tsx';
+  export Demo from 'stories/components/link/docs/examples/link_as_button.tsx';
 </script>
 
 :::
@@ -65,7 +65,7 @@ There are two moments you need to consider when using link with addons and ellip
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/links_with_ellipsis.tsx';
+  export Demo from 'stories/components/link/docs/examples/links_with_ellipsis.tsx';
 </script>
 
 :::
@@ -77,7 +77,7 @@ If a link has no visible text, it's important to add a [Hint](/components/toolti
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/link_without_text.tsx';
+  export Demo from 'stories/components/link/docs/examples/link_without_text.tsx';
 </script>
 
 :::
@@ -87,7 +87,7 @@ If a link has no visible text, it's important to add a [Hint](/components/toolti
 ::: sandbox
 
 <script lang="tsx">
-  export Demo from './examples/link_disabled.tsx';
+  export Demo from 'stories/components/link/docs/examples/link_disabled.tsx';
 </script>
 
 :::


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
I added render as a Hint to all Link if there are only addon and no children
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly or it's not required.
- [X] Unit tests are not broken.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
