### PR TITLE
[UIK-3022][stories, docs] remove aria-errormessage from confirmation modal example

### DIFF
--- a/stories/patterns/ux-patterns/confirmation-modal-dialog/docs/__tests__/ConfirmationModalDialog.test.tsx
+++ b/stories/patterns/ux-patterns/confirmation-modal-dialog/docs/__tests__/ConfirmationModalDialog.test.tsx
@@ -5,4 +5,51 @@ export async function ConfirmationModalDialogTest({ canvasElement }: { canvasEle
 
   const button = canvas.getByRole('button', { name: 'Open modal' });
   await userEvent.click(button);
+  
+  //Check modal attributes
+  const modal = await canvas.findByRole('dialog');
+  await expect(modal).toHaveAttribute('aria-modal', 'true');
+  await expect(modal).toHaveAttribute('aria-labelledby', 'igc-ui-kit-r0-title');
+
+  const title = await canvas.findByText('Delete project?');
+  await expect(title).toBeInTheDocument();
+
+   //Check Marks attributes
+   const markers = await canvas.findAllByText('•', { selector: 'span' });
+   await expect(markers.length).toBeGreaterThan(0);
+   for (const marker of markers) {
+     await expect(marker).toHaveAttribute('aria-hidden', 'true');
+     await expect(marker).not.toHaveAttribute('tabindex');
+   }
+
+  //Check Close attributes
+  const closeButton = await canvas.findByRole('button', { name: /close/i });
+  await expect(closeButton).toHaveAttribute('data-ui-name', 'Modal.Close');
+  await expect(closeButton).toHaveAttribute('type', 'button');
+  await expect(closeButton).toHaveAttribute('tabindex', '0');
+  await expect(closeButton).toHaveAttribute('aria-label', 'Close');
+
+  //Check Delete attributes
+  const deleteButton = await canvas.findByRole('button', { name: /delete/i });
+  await expect(deleteButton).toHaveAttribute('data-ui-name', 'Button');
+  await expect(deleteButton).toHaveAttribute('type', 'submit');
+  await expect(deleteButton).toHaveAttribute('tabindex', '0');
+  await expect(deleteButton).toHaveAttribute('tabindex', '0');
+
+  //Check Input attributes - without and with error
+  const inputField = await canvas.findByPlaceholderText('Enter project name');
+  await expect(inputField).toHaveAttribute('aria-invalid', 'false');
+  await expect(inputField).toHaveAttribute('tabindex', '0');
+  await expect(inputField).not.toHaveAttribute('aria-errormessage');
+  await userEvent.type(inputField, 'Project');
+  await userEvent.click(deleteButton);
+  await expect(inputField).toHaveAttribute('aria-invalid', 'true');
+  await expect(inputField).toHaveAttribute('aria-describedby', 'form-project-error');
+  await  expect(document.activeElement).toBe(inputField);
+
+//Check Cancel attributes
+  const cancelButton = await canvas.findByRole('button', { name: /cancel/i });
+  await expect(cancelButton).toHaveAttribute('data-ui-name', 'Button');
+  await expect(cancelButton).toHaveAttribute('type', 'button');
+  await expect(cancelButton).toHaveAttribute('tabindex', '0');
 }

--- a/stories/patterns/ux-patterns/confirmation-modal-dialog/docs/examples/confirmation-modal-example.tsx
+++ b/stories/patterns/ux-patterns/confirmation-modal-dialog/docs/examples/confirmation-modal-example.tsx
@@ -119,8 +119,7 @@ const Demo = () => {
                   w={'100%'}
                   onFocus={() => setFocusedFieldName(fieldName)}
                   aria-invalid={hasError()}
-                  aria-describedby={hasError() ? 'form-project-error' : undefined}
-                  aria-errormessage={hasError() ? 'form-project-error' : undefined}
+                  aria-describedby={showErrorTooltip() ? 'form-project-error' : undefined}
                 />
               </Input>
             </Tooltip>


### PR DESCRIPTION
Removed `aria-errormessage` from input in ConfirmationModal example.

## Motivation and Context

Fixes double Error Tooltip reading in NVDA.
Also, `aria-describedby` connects to Tooltip, only when Tooltip is in the DOM

## How has this been tested?

manually with VO and NVDA

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
