### PR TITLE
[UIK-2881][docs] Hid easings section from Motion page

### DIFF
--- a/website/docs/core-principles/motion-principles-guide/easing.module.css
+++ b/website/docs/core-principles/motion-principles-guide/easing.module.css
@@ -68,7 +68,7 @@
   transition-timing-function: ease-in-out;
 }
 
-.container:hover .sliderThumb {
+.container:hover .sliderThumb, .container:focus .sliderThumb {
   transition-duration: 1000ms;
   left: calc(100% - 12px - 32px);
 }

--- a/website/docs/core-principles/motion-principles-guide/motion-principles-guide.md
+++ b/website/docs/core-principles/motion-principles-guide/motion-principles-guide.md
@@ -38,7 +38,10 @@ Table: Durations
 | fast             | `200ms` | Should be used for more complex effects (such as Dropdown or Accordion)                                                           |
 | extra-fast       | `100ms` | Should be used for simpler effects and relatively small-sized animations (such as fades or color changes)                         |
 
-## Easing
+<!-- hidden because value isn't clear right now, we use standard CSS values for timing-function
+## Animation functions
+
+Hover or focus the following blocks to play the animations.
 
 ::: react-view
 
@@ -70,7 +73,7 @@ const Easing = ({ cssFunc, jsFunc, name, description }) => {
   }, [jsFunc]);
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} tabIndex={0}>
       <svg width={chartSize} height={chartSize + 2} className={styles.chart}>
         <path d={pathD} strokeWidth={2} />
       </svg>
@@ -117,6 +120,7 @@ const App = EasingsDemo;
 </script>
 
 :::
+-->
 
 ## Accessibility
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

I commented out the Easings section on the Motion page, because its value isn't clear right now. 

We don't use custom bezier timing functions, and the example didn't use our Animation component, so it didn't show anything useful in context of Intergalactic.

Before hiding, I made the animated blocks focusable and enabled animation on focus, for keyboard accessibility. I also added a small instruction before the example.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
