### PR TITLE
[grid] fix test

### DIFF
--- a/semcore/grid/__tests__/grid.browser-test.tsx
+++ b/semcore/grid/__tests__/grid.browser-test.tsx
@@ -60,8 +60,11 @@ test.describe('Grid base tests', () => {
         if (spanMatches && spanMatches.length > 1) {
           secondSpanValue = spanMatches[1].match(/\d+/)[0];
         }
+        // added this logic because sometimes the class can contain two spans, where the second one is correct, and sometimes it contains only one correct span in the class.
         const spanValue =
-          spanMatches && spanMatches.length > 1 ? spanMatches[1].match(/\d+/)[0] : null;
+          spanMatches?.length > 1
+            ? spanMatches[1].match(/\d+/)?.[0]
+            : spanMatches?.[0]?.match(/\d+/)?.[0] ?? null;
         expect(spanValue).toBe(expectedSpanValues[i]);
         const offset = await column.evaluate(
           (el) => el.getAttribute('offset') || getComputedStyle(el).getPropertyValue('offset'),


### PR DESCRIPTION
i fixed test for grid - added logic for both cases when class contains 1 span and 2 spans (because sometimes class has 2 spans like  ___SCol_3xc3r_gg_ __span_3xc3r_gg_ _span_1_3xc3r_gg_ _offset_11_3xc3r_gg_, sometimes with 1 span like  - ___SCol_3xc3r_gg_ _span_1_3xc3r_gg_ _offset_11_3xc3r_gg_ )

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
