### PR TITLE
[data-table] renamed sideIndents value from l to wide

### DIFF
--- a/semcore/data-table/src/components/Body/Body.types.ts
+++ b/semcore/data-table/src/components/Body/Body.types.ts
@@ -61,7 +61,7 @@ export type BodyPropsInner = DataTableBodyProps & {
     event?: React.SyntheticEvent<HTMLElement>,
   ) => void;
   renderEmptyData: () => React.ReactNode;
-  sideIndents?: 'l';
+  sideIndents?: 'wide';
   getFixedStyle: (
     cell: Pick<DTColumn, 'name' | 'fixed'>,
   ) => [side: 'left' | 'right', style: string | number] | [side: undefined, style: undefined];

--- a/semcore/data-table/src/components/Body/Row.types.ts
+++ b/semcore/data-table/src/components/Body/Row.types.ts
@@ -52,7 +52,7 @@ export type RowPropsInner = JSX.IntrinsicElements['div'] & {
 
   scrollAreaRef: React.RefObject<HTMLDivElement>;
   uid: string;
-  sideIndents?: 'l';
+  sideIndents?: 'wide';
   getFixedStyle: (
     cell: Pick<DTColumn, 'name' | 'fixed'>,
   ) => [side: 'left' | 'right', style: string | number] | [side: undefined, style: undefined];

--- a/semcore/data-table/src/components/Body/style.shadow.css
+++ b/semcore/data-table/src/components/Body/style.shadow.css
@@ -247,7 +247,7 @@ SEmptyData {
   grid-column: 1 / -1;
 }
 
-SRow[sideIndents='l'] {
+SRow[sideIndents='wide'] {
   SCell:first-child {
     padding-left: var(--intergalactic-spacing-5x, 20px);
   }

--- a/semcore/data-table/src/components/DataTable/DataTable.types.ts
+++ b/semcore/data-table/src/components/DataTable/DataTable.types.ts
@@ -71,7 +71,7 @@ export type DataTableProps<D extends DataTableData> = DataTableAriaProps &
     /**
      * Size of paddings for the first and last columns in the table
      */
-    sideIndents?: 'l';
+    sideIndents?: 'wide';
 
     /**
      * Flag for showing spinner on table body

--- a/semcore/data-table/src/components/Head/Head.types.ts
+++ b/semcore/data-table/src/components/Head/Head.types.ts
@@ -37,7 +37,7 @@ export type HeadPropsInner<D extends DataTableData> = {
   gridAreaGroupMap: Map<number, string>;
   gridTemplateColumns: string[];
   gridTemplateAreas: string[];
-  sideIndents?: 'l';
+  sideIndents?: 'wide';
 
   totalRows: number;
   selectedRows?: number[];

--- a/semcore/data-table/src/components/Head/style.shadow.css
+++ b/semcore/data-table/src/components/Head/style.shadow.css
@@ -166,7 +166,7 @@ SSortButton {
   transition: opacity 0.3s ease;
 }
 
-SHead[sideIndents='l'] {
+SHead[sideIndents='wide'] {
   SColumn:first-child {
     padding-left: var(--intergalactic-spacing-5x, 20px);
   }

--- a/stories/components/data-table/advanced/examples/side-indents.tsx
+++ b/stories/components/data-table/advanced/examples/side-indents.tsx
@@ -2,74 +2,74 @@ import React from 'react';
 import { DataTable } from '@semcore/data-table';
 
 const Demo = () => {
-    return (
-        <DataTable
-            data={data}
-            aria-label={'Base table example'}
-            defaultGridTemplateColumnWidth={'auto'}
-            wMax={'800px'}
-            sideIndents={'l'}
-            headerProps={{
-                sticky: true,
-            }}
-            columns={[
-                {
-                    name: 'keyword',
-                    children: 'keyword'
-                },
-                {
-                    name: 'kd',
-                    children: 'KD,%'
-                },
-                {
-                    name: 'cpc',
-                    children: 'CPC'
-                },
-                {
-                    name: 'hiddenColumn',
-                    children: 'HC'
-                },
-                {
-                    name: 'vol',
-                    children: 'Vol.',
-                    justifyContent: 'flex-end'
-                }
-            ]}
-        />
-    );
+  return (
+    <DataTable
+      data={data}
+      aria-label={'Base table example'}
+      defaultGridTemplateColumnWidth={'auto'}
+      wMax={'800px'}
+      sideIndents={'wide'}
+      headerProps={{
+        sticky: true,
+      }}
+      columns={[
+        {
+          name: 'keyword',
+          children: 'keyword',
+        },
+        {
+          name: 'kd',
+          children: 'KD,%',
+        },
+        {
+          name: 'cpc',
+          children: 'CPC',
+        },
+        {
+          name: 'hiddenColumn',
+          children: 'HC',
+        },
+        {
+          name: 'vol',
+          children: 'Vol.',
+          justifyContent: 'flex-end',
+        },
+      ]}
+    />
+  );
 };
 
 const data = [
-    {
-        keyword: 'ebay buy',
-        kd: '77.8',
-        cpc: '$1.25',
-        vol: '32,500,000',
-    },
-    {
-        keyword: 'www.ebay.com',
-        kd: '11.2',
-        cpc: '$3.4',
-        vol: '65,457,920',
-    },
-    {
-        keyword: 'www.ebay.com',
-        kd: '10',
-        cpc: '$0.65',
-        vol: '47,354,640',
-    },
-    {
-        keyword: 'ebay buy',
-        kd: '-',
-        cpc: '$0',
-        vol: 'n/a',
-    },
-    {
-        keyword: 'ebay buy',
-        kd: '75.89',
-        cpc: '$0',
-        vol: '21,644,290',
-    },
+  {
+    keyword: 'ebay buy',
+    kd: '77.8',
+    cpc: '$1.25',
+    vol: '32,500,000',
+  },
+  {
+    keyword: 'www.ebay.com',
+    kd: '11.2',
+    cpc: '$3.4',
+    vol: '65,457,920',
+  },
+  {
+    keyword: 'www.ebay.com',
+    kd: '10',
+    cpc: '$0.65',
+    vol: '47,354,640',
+  },
+  {
+    keyword: 'ebay buy',
+    kd: '-',
+    cpc: '$0',
+    vol: 'n/a',
+  },
+  {
+    keyword: 'ebay buy',
+    kd: '75.89',
+    cpc: '$0',
+    vol: '21,644,290',
+  },
 ];
 
 export default Demo;

--- a/stories/components/data-table/tests/examples/header-tests/secondary-header.tsx
+++ b/stories/components/data-table/tests/examples/header-tests/secondary-header.tsx
@@ -29,10 +29,14 @@ const Demo = () => {
   );
 
   return (
-
     <DataTable
-      data={sortedData} use='secondary' aria-label={'Column expanded'} hMax={200} sort={sort} onSortChange={setSort}
-      sideIndents={'l'}
+      data={sortedData}
+      use='secondary'
+      aria-label={'Column expanded'}
+      hMax={200}
+      sort={sort}
+      onSortChange={setSort}
+      sideIndents={'wide'}
       columns={[
         {
           name: 'keyword',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Can we rename the sideIndents value from "l" to "wide"?
"l" has a specific meaning and this can give a wrong idea that this is connected to L-size controls.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
