### PR TITLE
[divider] fixed styles for theme invert

### DIFF
--- a/semcore/divider/CHANGELOG.md
+++ b/semcore/divider/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.2] - 2025-06-11
+
+### Fixed
+
+- Divider styles for `invert` theme.
+
 ## [16.0.1] - 2025-05-30
 
 ### Changed

--- a/semcore/divider/src/style/divider.shadow.css
+++ b/semcore/divider/src/style/divider.shadow.css
@@ -81,7 +81,7 @@ SDivider[orientation='vertical'] {
   flex-shrink: 0;
 }
 
-SDivider[theme]:not([theme='default'], [theme='default']) {
+SDivider[theme]:not([theme='default']):not([theme='invert']) {
   &[use='primary'] {
     background-color: var(--theme);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

The `Divider` component does not render correctly when `theme="invert"` is applied.

## How has this been tested?

It's been tested using browser tests.

## Screenshots (if appropriate):
<img width="2051" alt="Screenshot 2025-06-11 at 20 22 53" src="https://github.com/user-attachments/assets/b70baf67-dc19-4921-93a2-c5b307be72fe" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly or it's not required.
- [ ] Unit tests are not broken.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
