### PR TITLE
[slider] fix issue with value > max not clamping or decreasing on key

### DIFF
--- a/semcore/slider/CHANGELOG.md
+++ b/semcore/slider/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.2] - 2025-06-12
+
+### Fixed
+
+- Slider knob did not move to max value or decrease when entering a value greater than max in the input, focusing the knob, and pressing the Left Arrow key.
+
 ## [16.0.1] - 2025-05-30
 
 ### Changed

--- a/semcore/slider/__tests__/slider.browser-test.tsx
+++ b/semcore/slider/__tests__/slider.browser-test.tsx
@@ -236,5 +236,15 @@ test.describe('Slider', () => {
     await expect(input).toHaveValue('10');
     await expect(slider).toHaveAttribute('aria-valuenow', '10');
     await expect(inputValue).toHaveValue('10');
+
+    await page.keyboard.press('Tab');
+    inputValue.fill('110');
+    await expect(inputValue).toHaveAttribute('aria-invalid', 'true');
+    await page.keyboard.press('Shift+Tab');
+    await page.keyboard.press('ArrowLeft');
+    await expect(input).toHaveValue('100');
+    await expect(slider).toHaveAttribute('aria-valuenow', '100');
+    await expect(inputValue).toHaveValue('100');
+    await expect(inputValue).toHaveAttribute('aria-invalid', 'false');
   });
 });

--- a/semcore/slider/src/Slider.jsx
+++ b/semcore/slider/src/Slider.jsx
@@ -147,7 +147,13 @@ class SliderRoot extends Component {
 
   getNumericValue = () => {
     const { value, options, min, max, defaultValue } = this.asProps;
-    if (!options) return value;
+
+    if (!options) {
+      const numericValue = parseInt(value);
+
+      return isNaN(numericValue) ? defaultValue : numericValue;
+    };
+
     const resolvedIndex = options.findIndex((option) => option.value === value);
     if (resolvedIndex === -1) return defaultValue;
     if (resolvedIndex < min) return min;

--- a/stories/components/slider/docs/examples/numeric_slider.tsx
+++ b/stories/components/slider/docs/examples/numeric_slider.tsx
@@ -21,6 +21,16 @@ const Demo = () => {
     }
   };
 
+  const handleSliderInput = (value: number) => {
+    if (value > max || value < min) {
+      setError('Please enter a valid value');
+      setValue(value);
+    } else {
+      setError('');
+      setValue(value);
+    }
+  };
+
   return (
     <Flex direction='column'>
       <Text tag='label' size={200} htmlFor='slider-represantation'>
@@ -31,7 +41,7 @@ const Demo = () => {
           id='slider-represantation'
           mb={4}
           value={value}
-          onChange={setValue}
+          onChange={handleSliderInput}
           step={1}
           min={min}
           max={max}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

When a user entered a value greater than the slider's maximum via the input field, the slider knob did not clamp to the maximum value. Additionally, when the knob was focused, pressing the Left Arrow key did not decrease the value as expected.

This fix ensures the value is clamped to the maximum if the input exceeds it, and that the knob responds correctly to arrow key navigation.

## How has this been tested?

It's been tested manually.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly or it's not required.
- [x] Unit tests are not broken.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new unit tests on added of fixed functionality.
