### PR TITLE
[UIK-3858][data-table] Fixed interact with the table using the keyboard after clicking the mouse in a certain cell

### DIFF
--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -17,6 +17,10 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 - Types for `defaultGridTemplateColumnWidth` set to string - any `grid-template-column` css value.
 - `selectedRows` from indexes to `UNIQ_ROW_KEY` values.
 
+### Fixed
+
+- Interact with the table using the keyboard after clicking the mouse in a certain cell.
+
 ## [16.0.4] - 2025-05-30
 
 ### Fixed

--- a/semcore/data-table/src/components/Body/Body.tsx
+++ b/semcore/data-table/src/components/Body/Body.tsx
@@ -273,7 +273,7 @@ class BodyRoot extends Component<DataTableBodyProps, {}, State, [], BodyPropsInn
 
       const handleClick = (e: React.SyntheticEvent<HTMLButtonElement>) => {
         e.stopPropagation();
-
+        onCellClick(e, { colIndex: props.columnIndex, rowIndex, row });
         this.handleExpandRow(row, rowIndex);
       };
 

--- a/semcore/data-table/src/components/Body/Body.tsx
+++ b/semcore/data-table/src/components/Body/Body.tsx
@@ -186,6 +186,7 @@ class BodyRoot extends Component<DataTableBodyProps, {}, State, [], BodyPropsInn
       tableRef,
       flatRows,
       accordionDuration,
+      onCellClick,
     } = this.asProps;
     const SAccordionToggle = ButtonLink;
 
@@ -215,6 +216,7 @@ class BodyRoot extends Component<DataTableBodyProps, {}, State, [], BodyPropsInn
       tableRef,
       children: props.children ?? defaultRender(),
       accordionDuration,
+      onClick: onCellClick,
     };
 
     if (renderCell) {

--- a/semcore/data-table/src/components/Body/Body.tsx
+++ b/semcore/data-table/src/components/Body/Body.tsx
@@ -90,9 +90,9 @@ class BodyRoot extends Component<DataTableBodyProps, {}, State, [], BodyPropsInn
     }
   };
 
-  handleClickCell = (row: DTRow, index: number) => (e: React.SyntheticEvent<HTMLElement>) => {
+  handleClickCell = (e: React.SyntheticEvent<HTMLElement>, opt: { row: DTRow; rowIndex: number }) => {
     if (!isInteractiveElement(e.target)) {
-      this.handleExpandRow(row, index);
+      this.handleExpandRow(opt.row, opt.rowIndex);
     }
   };
 
@@ -237,7 +237,11 @@ class BodyRoot extends Component<DataTableBodyProps, {}, State, [], BodyPropsInn
         extraProps.children = external;
       } else {
         for (const key in external) {
-          extraProps[key] = external[key];
+          if (key === 'onClick') {
+            extraProps[key] = callAllEventHandlers(external[key], extraProps[key]);
+          } else {
+            extraProps[key] = external[key];
+          }
         }
       }
     }
@@ -276,7 +280,7 @@ class BodyRoot extends Component<DataTableBodyProps, {}, State, [], BodyPropsInn
       if (value?.[ACCORDION] || (cellValue instanceof MergedRowsCell && cellValue.accordion)) {
         extraProps.onClick = callAllEventHandlers(
           extraProps.onClick,
-          this.handleClickCell(row, rowIndex),
+          this.handleClickCell,
         );
       }
 

--- a/semcore/data-table/src/components/Body/Body.types.ts
+++ b/semcore/data-table/src/components/Body/Body.types.ts
@@ -1,3 +1,5 @@
+import type * as React from 'react';
+
 import type { Theme } from './Cell.types';
 import type { DTRow, UniqRowKey } from './Row.types';
 import type { DTUse, VirtualScroll } from '../DataTable/DataTable.types';
@@ -66,4 +68,5 @@ export type BodyPropsInner = DataTableBodyProps & {
     cell: Pick<DTColumn, 'name' | 'fixed'>,
   ) => [side: 'left' | 'right', style: string | number] | [side: undefined, style: undefined];
   accordionDuration?: number | [number, number];
+  onCellClick: (e: React.SyntheticEvent, rowIndex: number, colIndex: number) => void;
 };

--- a/semcore/data-table/src/components/Body/Body.types.ts
+++ b/semcore/data-table/src/components/Body/Body.types.ts
@@ -1,6 +1,6 @@
 import type * as React from 'react';
 
-import type { Theme } from './Cell.types';
+import type { CellPropsInner, Theme } from './Cell.types';
 import type { DTRow, UniqRowKey } from './Row.types';
 import type { DTUse, VirtualScroll } from '../DataTable/DataTable.types';
 import type { DTColumn } from '../Head/Column.types';
@@ -68,5 +68,5 @@ export type BodyPropsInner = DataTableBodyProps & {
     cell: Pick<DTColumn, 'name' | 'fixed'>,
   ) => [side: 'left' | 'right', style: string | number] | [side: undefined, style: undefined];
   accordionDuration?: number | [number, number];
-  onCellClick: (e: React.SyntheticEvent, rowIndex: number, colIndex: number) => void;
+  onCellClick: CellPropsInner['onClick'];
 };

--- a/semcore/data-table/src/components/Body/Cell.tsx
+++ b/semcore/data-table/src/components/Body/Cell.tsx
@@ -115,10 +115,10 @@ class CellRoot extends Component<DataTableCellProps, {}, {}, [], CellPropsInner>
     return { duration, delay };
   }
 
-  onClickCell = (e: React.SyntheticEvent) => {
-    const { rowIndex, columnIndex, onClick } = this.asProps;
+  handleClickCell = (e: React.SyntheticEvent) => {
+    const { rowIndex, columnIndex, onClick, row } = this.asProps;
 
-    onClick(e, rowIndex, columnIndex);
+    onClick(e, { rowIndex, colIndex: columnIndex, row });
   };
 
   render() {
@@ -177,7 +177,7 @@ class CellRoot extends Component<DataTableCellProps, {}, {}, [], CellPropsInner>
           tabIndex={-1}
           onKeyDown={this.handleKeyDown}
           onFocus={this.onFocusCell}
-          onClick={this.onClickCell}
+          use:onClick={this.handleClickCell}
           name={cellName.toString()}
           role='gridcell'
           aria-colindex={columnIndex + 1}

--- a/semcore/data-table/src/components/Body/Cell.tsx
+++ b/semcore/data-table/src/components/Body/Cell.tsx
@@ -115,6 +115,12 @@ class CellRoot extends Component<DataTableCellProps, {}, {}, [], CellPropsInner>
     return { duration, delay };
   }
 
+  onClickCell = (e: React.SyntheticEvent) => {
+    const { rowIndex, columnIndex, onClick } = this.asProps;
+
+    onClick(e, rowIndex, columnIndex);
+  };
+
   render() {
     const SCellWrapper = Box;
     const SCell = Root;
@@ -171,6 +177,7 @@ class CellRoot extends Component<DataTableCellProps, {}, {}, [], CellPropsInner>
           tabIndex={-1}
           onKeyDown={this.handleKeyDown}
           onFocus={this.onFocusCell}
+          onClick={this.onClickCell}
           name={cellName.toString()}
           role='gridcell'
           aria-colindex={columnIndex + 1}

--- a/semcore/data-table/src/components/Body/Cell.types.ts
+++ b/semcore/data-table/src/components/Body/Cell.types.ts
@@ -31,5 +31,5 @@ export type CellPropsInner = {
   virtualScroll: boolean;
   tableRef: React.RefObject<HTMLDivElement>;
   accordionDuration?: number | [number, number];
-  onClick: (e: React.SyntheticEvent, rowIndex: number, colIndex: number) => void;
+  onClick: (e: React.SyntheticEvent, opt: { rowIndex: number; colIndex: number; row: DTRow }) => void;
 };

--- a/semcore/data-table/src/components/Body/Cell.types.ts
+++ b/semcore/data-table/src/components/Body/Cell.types.ts
@@ -1,3 +1,5 @@
+import type * as React from 'react';
+
 import type { DTRow, DTRows } from './Row.types';
 import type { DTUse } from '../DataTable/DataTable.types';
 import type { DTColumn } from '../Head/Column.types';
@@ -29,4 +31,5 @@ export type CellPropsInner = {
   virtualScroll: boolean;
   tableRef: React.RefObject<HTMLDivElement>;
   accordionDuration?: number | [number, number];
+  onClick: (e: React.SyntheticEvent, rowIndex: number, colIndex: number) => void;
 };

--- a/semcore/data-table/src/components/Body/Cell.types.ts
+++ b/semcore/data-table/src/components/Body/Cell.types.ts
@@ -31,5 +31,5 @@ export type CellPropsInner = {
   virtualScroll: boolean;
   tableRef: React.RefObject<HTMLDivElement>;
   accordionDuration?: number | [number, number];
-  onClick: (e: React.SyntheticEvent, opt: { rowIndex: number; colIndex: number; row: DTRow }) => void;
+  onClick: (e: React.SyntheticEvent, opt: { rowIndex: number; colIndex: number; row?: DTRow }) => void;
 };

--- a/semcore/data-table/src/components/DataTable/DataTable.tsx
+++ b/semcore/data-table/src/components/DataTable/DataTable.tsx
@@ -297,9 +297,10 @@ class DataTableRoot<D extends DataTableData> extends Component<
     };
   }
 
-  handleCellClick = (e: React.SyntheticEvent, rowIndex: number, colIndex: number) => {
+  handleCellClick = (e: React.SyntheticEvent, opt: { rowIndex: number; colIndex: number; row: DTRow }) => {
     if (lastInteraction.isMouse()) {
-      this.initFocusableCell([this.hasFocusableInHeader() ? rowIndex + 1 : rowIndex, colIndex]);
+      console.log('click on cell in data table handler');
+      this.initFocusableCell([this.hasFocusableInHeader() ? opt.rowIndex + 1 : opt.rowIndex, opt.colIndex]);
     }
   };
 
@@ -537,6 +538,8 @@ class DataTableRoot<D extends DataTableData> extends Component<
 
     const initRow = initCell?.[0] ?? 0;
     const initCol = initCell?.[1] ?? 0;
+
+    console.log(initCell);
 
     if (hasFocusable) {
       this.focusedCell = [initRow, initCol];

--- a/semcore/data-table/src/components/DataTable/DataTable.tsx
+++ b/semcore/data-table/src/components/DataTable/DataTable.tsx
@@ -10,7 +10,6 @@ import { isFocusInside, hasFocusableIn } from '@semcore/core/lib/utils/use/useFo
 import { NoData } from '@semcore/widget-empty';
 import type { ReactElement } from 'react';
 import * as React from 'react';
-import init from 'typescript-plugin-css-modules';
 
 import style from './dataTable.shadow.css';
 import type {

--- a/semcore/data-table/src/components/DataTable/DataTable.tsx
+++ b/semcore/data-table/src/components/DataTable/DataTable.tsx
@@ -239,6 +239,7 @@ class DataTableRoot<D extends DataTableData> extends Component<
         }
       },
       getFixedStyle: this.getFixedStyle,
+      onCellClick: this.handleCellClick,
       ...headerProps,
     };
   }
@@ -297,9 +298,9 @@ class DataTableRoot<D extends DataTableData> extends Component<
     };
   }
 
-  handleCellClick = (e: React.SyntheticEvent, opt: { rowIndex: number; colIndex: number; row: DTRow }) => {
+  handleCellClick = (e: React.SyntheticEvent, opt: { rowIndex: number; colIndex: number; row?: DTRow }) => {
     if (lastInteraction.isMouse()) {
-      console.log('click on cell in data table handler');
+      console.log('click on cell in data table handler', opt);
       this.initFocusableCell([this.hasFocusableInHeader() ? opt.rowIndex + 1 : opt.rowIndex, opt.colIndex]);
     }
   };
@@ -538,8 +539,6 @@ class DataTableRoot<D extends DataTableData> extends Component<
 
     const initRow = initCell?.[0] ?? 0;
     const initCol = initCell?.[1] ?? 0;
-
-    console.log(initCell);
 
     if (hasFocusable) {
       this.focusedCell = [initRow, initCol];

--- a/semcore/data-table/src/components/DataTable/DataTable.tsx
+++ b/semcore/data-table/src/components/DataTable/DataTable.tsx
@@ -10,6 +10,7 @@ import { isFocusInside, hasFocusableIn } from '@semcore/core/lib/utils/use/useFo
 import { NoData } from '@semcore/widget-empty';
 import type { ReactElement } from 'react';
 import * as React from 'react';
+import init from 'typescript-plugin-css-modules';
 
 import style from './dataTable.shadow.css';
 import type {
@@ -292,8 +293,15 @@ class DataTableRoot<D extends DataTableData> extends Component<
       selectedRows,
       onSelectRow: this.handleSelectRow,
       getFixedStyle: this.getFixedStyle,
+      onCellClick: this.handleCellClick,
     };
   }
+
+  handleCellClick = (e: React.SyntheticEvent, rowIndex: number, colIndex: number) => {
+    if (lastInteraction.isMouse()) {
+      this.initFocusableCell([this.hasFocusableInHeader() ? rowIndex + 1 : rowIndex, colIndex]);
+    }
+  };
 
   handleSelectRow = (
     isSelected: boolean,
@@ -522,13 +530,18 @@ class DataTableRoot<D extends DataTableData> extends Component<
     }
   };
 
-  initFocusableCell = () => {
+  initFocusableCell(): void;
+  initFocusableCell(initCell: [row: number, cell: number]): void;
+  initFocusableCell(initCell?: [row: number, cell: number]) {
     const hasFocusable = this.hasFocusableInHeader();
 
+    const initRow = initCell?.[0] ?? 0;
+    const initCol = initCell?.[1] ?? 0;
+
     if (hasFocusable) {
-      this.focusedCell = [0, 0];
+      this.focusedCell = [initRow, initCol];
     } else {
-      this.focusedCell = [1, 0];
+      this.focusedCell = [initRow + 1, initCol];
     }
   };
 

--- a/semcore/data-table/src/components/Head/Column.tsx
+++ b/semcore/data-table/src/components/Head/Column.tsx
@@ -201,7 +201,7 @@ export class Column<D extends DataTableData> extends Component<
     }
   };
 
-  handleSortClick = (e: React.SyntheticEvent<HTMLButtonElement>) => {
+  handleSortClick = (e: React.SyntheticEvent<HTMLElement>) => {
     const { sort, onSortChange, name, sortable } = this.asProps;
 
     if (
@@ -270,6 +270,15 @@ export class Column<D extends DataTableData> extends Component<
     });
   };
 
+  handleClick = (e: React.SyntheticEvent<HTMLElement>) => {
+    const { sortable, onClick, columnIndex } = this.asProps;
+    if (sortable) {
+      this.handleSortClick(e);
+    }
+
+    onClick?.(e, { rowIndex: -1, colIndex: columnIndex });
+  };
+
   render() {
     const SColumn = Root;
     const SSortWrapper = 'div';
@@ -310,7 +319,7 @@ export class Column<D extends DataTableData> extends Component<
         innerOutline
         aria-describedby={ariaDescribedBy.length > 0 ? ariaDescribedBy.join(' ') : undefined}
         aria-sort={ariaSortValue}
-        onClick={sortable ? this.handleSortClick : undefined}
+        use:onClick={this.handleClick}
       >
         <Children />
 

--- a/semcore/data-table/src/components/Head/Column.types.ts
+++ b/semcore/data-table/src/components/Head/Column.types.ts
@@ -1,5 +1,6 @@
 import type { Property } from 'csstype';
 
+import type { CellPropsInner } from '../Body/Cell.types';
 import type {
   ColumnGroupConfig,
   ColumnItemConfig,
@@ -84,4 +85,5 @@ export type ColumnPropsInner<D extends DataTableData> = {
   gridTemplateColumns: string[];
   gridTemplateAreas: string[];
   sticky: boolean;
+  onClick: CellPropsInner['onClick'];
 };

--- a/semcore/data-table/src/components/Head/Head.tsx
+++ b/semcore/data-table/src/components/Head/Head.tsx
@@ -55,6 +55,7 @@ class HeadRoot<D extends DataTableData> extends Component<
       selectedRows,
       h,
       getFixedStyle,
+      onCellClick,
     } = this.asProps;
     const column = columns[index];
 
@@ -92,6 +93,7 @@ class HeadRoot<D extends DataTableData> extends Component<
       gridTemplateColumns,
       gridTemplateAreas,
       h,
+      'onClick': onCellClick,
     };
   }
 

--- a/semcore/data-table/src/components/Head/Head.types.ts
+++ b/semcore/data-table/src/components/Head/Head.types.ts
@@ -1,4 +1,5 @@
 import type { DTColumn } from './Column.types';
+import type { CellPropsInner } from '../Body/Cell.types';
 import type { UniqRowKey } from '../Body/Row.types';
 import type { DataTableData, DataTableProps, DTUse } from '../DataTable/DataTable.types';
 
@@ -47,4 +48,5 @@ export type HeadPropsInner<D extends DataTableData> = {
   getFixedStyle: (
     cell: Pick<DTColumn, 'name' | 'fixed'>,
   ) => [side: 'left' | 'right', style: string | number] | [side: undefined, style: undefined];
+  onCellClick: CellPropsInner['onClick'];
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
We have and internal `focusedCell` in the Table, so, I added logic to set in it clicked cell.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
