### PR TITLE
[UIK-3841] added EU to iso2 codes

### DIFF
--- a/semcore/flags/CHANGELOG.md
+++ b/semcore/flags/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.0] - 2025-06-20
+
+### Added
+
+- `EU` (European Union) to the list of ISO2 codes.
+
 ## [16.0.2] - 2025-06-16
 
 ### Changed

--- a/semcore/flags/src/countries.json
+++ b/semcore/flags/src/countries.json
@@ -73,6 +73,7 @@
     "ER": "Eritrea",
     "EE": "Estonia",
     "ET": "Ethiopia",
+    "EU": "European Union",
     "FK": "Falkland Islands",
     "FO": "Faroes",
     "FJ": "Fiji",

--- a/semcore/flags/src/index.d.ts
+++ b/semcore/flags/src/index.d.ts
@@ -285,7 +285,6 @@ export declare const nameWithoutIso: {
   canary_islands: string;
   common_wealth: string;
   england: string;
-  european_union: string;
   mars: string;
   nagorno_karabakh: string;
   nato: string;
@@ -302,7 +301,6 @@ export declare const nameWithoutIso: {
   CANARY_ISLANDS: string;
   COMMON_WEALTH: string;
   ENGLAND: string;
-  EUROPEAN_UNION: string;
   MARS: string;
   NAGORNO_KARABAKH: string;
   NATO: string;
@@ -408,6 +406,7 @@ export type FlagsIso2 =
   | 'ER'
   | 'EE'
   | 'ET'
+  | 'EU'
   | 'FK'
   | 'FO'
   | 'FJ'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

We already had the EU flag in the assets, but we didn't have a corresponding code in the ISO2 list.
I just added "EU" to the ISO2 list. Even though EU isn't part of ISO 3166-1 alpha-2, it's an "exceptional reservation", which should mean that it won't be assigned to anything else, so it's safe to use as a code for European Union.

## How has this been tested?

Manually. EU flag now appears on [the example page](http://localhost:5173/intergalactic/components/flags/flags).

## Screenshots (if appropriate):

<img width="463" alt="imagen" src="https://github.com/user-attachments/assets/9a277cfa-66e5-4fc2-a053-3e4caaf7eaff" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
