### PR TITLE
[UIK-3441][modal] allow ESC to close modal even without focus inside

### DIFF
--- a/semcore/modal/CHANGELOG.md
+++ b/semcore/modal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.3] - 2025-06-21
+
+### Fixed
+
+- Modal doesn't close on ESC key press when no element inside is focused.
+
 ## [16.1.2] - 2025-06-16
 
 ### Changed

--- a/semcore/modal/__tests__/modal.browser-test.tsx
+++ b/semcore/modal/__tests__/modal.browser-test.tsx
@@ -51,6 +51,16 @@ test.describe('Modal interactions', () => {
       await expect(modal).toHaveCount(0);
       await expect(trigger).toBeFocused();
     });
+
+    await test.step('Verify modal closed when you firstly click on a modal and then pressing ESC', async () => {
+      await trigger.click();
+      await modal.waitFor({ state: 'attached' });
+
+      await modal.click();
+      await page.keyboard.press('Escape');
+
+      await expect(modal).toHaveCount(0);
+    });
   });
 
   test('Verify basic usage mouse interactions', async ({ page, browserName }) => {

--- a/semcore/modal/src/Modal.jsx
+++ b/semcore/modal/src/Modal.jsx
@@ -146,6 +146,7 @@ function Window(props) {
       aria-modal={true}
       duration={duration}
       ref={windowRef}
+      tabIndex={-1}
     >
       <ZIndexStackingContextProvider designToken='z-index-modal'>
         <PortalProvider value={windowRef}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Previously, if no element inside the Modal has focus, pressing the ESC key would not close the modal.
The fix ensures that the ESC key closes the modal regardless of the current focus state, as long as the modal is open.

## How has this been tested?

I've added a browser test.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
