### PR TITLE
[UIK-3832][core, dropdown-menu] fixed missing focus outline in Safari during mixed mouse and keyboard interaction

### DIFF
--- a/semcore/core/CHANGELOG.md
+++ b/semcore/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.2] - 2025-06-23
+
+### Added
+
+- `focusVisible` option to `setFocus` util method with value from last interaction type.
+
 ## [16.0.1] - 2025-06-16
 
 ### Added

--- a/semcore/core/src/utils/focus-lock/setFocus.ts
+++ b/semcore/core/src/utils/focus-lock/setFocus.ts
@@ -1,3 +1,4 @@
+import { lastInteraction } from '../../LastInteractionType';
 import canUseDOM from '../canUseDOM';
 import { getFocusableIn } from './getFocusableIn';
 
@@ -25,7 +26,11 @@ const unsafeSetFocus = (
     target = focusable[focusable.length - 1];
   }
 
-  target?.focus(focusOptions);
+  target?.focus({
+    // @ts-ignore. set focus-visible in FF and Safari
+    focusVisible: lastInteraction.isKeyboard(),
+    ...focusOptions,
+  });
 };
 
 /** "safe" focus movement means that function wrapper tries

--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.4] - 2025-06-23
+
+### Fixed
+
+- Missing focus outline in Safari during mixed mouse and keyboard interaction.
+
 ## [16.1.3] - 2025-06-16
 
 ### Fixed

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -2,6 +2,7 @@ import ButtonComponent from '@semcore/button';
 import { createComponent, sstyled, Root, lastInteraction } from '@semcore/core';
 import { callAllEventHandlers } from '@semcore/core/lib/utils/assignProps';
 import { isAdvanceMode } from '@semcore/core/lib/utils/findComponent';
+import { setFocus } from '@semcore/core/lib/utils/focus-lock/setFocus';
 import { forkRef } from '@semcore/core/lib/utils/ref';
 import { useUID } from '@semcore/core/lib/utils/uniqueID';
 import Dropdown, { AbstractDropdown, selectedIndexContext, enhance } from '@semcore/dropdown';
@@ -211,7 +212,9 @@ class DropdownMenuRoot extends AbstractDropdown {
           (inlineActions && (e.key === 'Escape' || this.asProps.highlightedIndex === 0))
         ) {
           this.handlers.visible(false);
-          this.triggerRef.current?.focus();
+          if (this.triggerRef.current) {
+            setFocus(this.triggerRef.current);
+          }
 
           e.preventDefault();
           e.stopPropagation();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
I added `focusVisible` to our `setFocus` utilities to fix how outlines work after setting focus programmatically. And use this method in one place in DDMenu where we return focus to trigger to fix bug in FF.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
