### PR TITLE
[UIK-3884][d3-chart] fixed svg pattern elements without accessible name

### DIFF
--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.6] - 2025-06-30
+
+### Fixed
+
+- a11y error - "SVG element missing accessible name".
+
 ## [16.0.5] - 2025-06-23
 
 ### Changed

--- a/semcore/d3-chart/src/Pattern.tsx
+++ b/semcore/d3-chart/src/Pattern.tsx
@@ -689,6 +689,7 @@ export const PatternSymbol: React.FC<
         viewBox={viewBox}
         strokeWidth='1'
         {...propsForElement(props, 'svg')}
+        aria-hidden={true}
       >
         {children}
       </svg>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
I just added `aria-hidden` for svg with pattern template in charts.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
