### PR TITLE
[UIK-3824][website] fixed correct section expanding on internal navigation

### DIFF
--- a/website/docs/.vitepress/theme/VPSidebarItem.vue
+++ b/website/docs/.vitepress/theme/VPSidebarItem.vue
@@ -3,7 +3,7 @@ To remove after merge of https://github.com/vuejs/vitepress/issues/2257
 Same to https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/components/VPSidebarItem.vue but also support `activeMatch`
 -->
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import type { DefaultTheme } from 'vitepress/theme'
 import { useSidebarControl } from 'vitepress/dist/client/theme-default/composables/sidebar.js';
 import VPIconChevronRight from 'vitepress/dist/client/theme-default/components/icons/VPIconChevronRight.vue';
@@ -25,8 +25,8 @@ const computeChildrenActiveMatch = (item: Item) => {
 }
 
 const { page } = useData();
-const activeMatch = computed(() => computeActiveMatch(props.item));
 
+const activeMatch = computed(() => computeActiveMatch(props.item));
 const activeMatchedChildrenUncollapse = ref(computeChildrenActiveMatch(props.item))
 
 const {
@@ -38,6 +38,10 @@ const {
   hasChildren,
   toggle,
 } = useSidebarControl(computed(() => props.item))
+
+watch(page, () => {
+  activeMatchedChildrenUncollapse.value = computeChildrenActiveMatch(props.item);
+})
 
 const sectionTag = computed(() => (hasChildren.value ? 'section' : `div`))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

When navigating to a page using an internal link from another section, the corresponding section in the menu remained collapsed.
The fix ensures that the correct section is automatically expanded upon navigation.

## How has this been tested?

It's been tested manually.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
