### PR TITLE
[UIK-3523][website] added unique titles for Loom frames

### DIFF
--- a/website/docs/.vitepress/renderLoomVideo.ts
+++ b/website/docs/.vitepress/renderLoomVideo.ts
@@ -1,17 +1,13 @@
 export const renderLoomVideo = (tokenList: any[], index: number) => {
   const renderFunc = (tokens: any[], idx: number) => {
     const token = tokens[idx];
-    if (token.type === 'container_loom_video_open') {
-      let url = token.info.split(' ')[2];
-      if (!url) return [];
+    if (token.nesting === 1) {
+      const title = token.info.replace('loom_video', '').trim() || 'video';
+      const url = tokens[idx + 2].content;
 
-      if (url.startsWith('https://www.loom.com/share/')) {
-        url = `https://www.loom.com/embed/${url.substring('https://www.loom.com/share/'.length)}`;
-      }
-
-      return `<div class="embedded-video-container"><iframe src="${url}" frameborder='0' webkitAllowFullScreen mozAllowFullScreen allowFullScreen class="embedded-video-iframe" title='video' /></div>`;
+      return `<div class="embedded-video-container"><iframe src='${url}' frameborder='0' webkitAllowFullScreen mozAllowFullScreen allowFullScreen class="embedded-video-iframe" title='${title}'>`;
     }
-    return [];
+    return '</iframe></div>';
   };
   return renderFunc(tokenList, index);
 };

--- a/website/docs/get-started-guide/dis-starter-guide/dis-starter-guide.md
+++ b/website/docs/get-started-guide/dis-starter-guide/dis-starter-guide.md
@@ -6,17 +6,17 @@ title: For designers
 
 <!-- Welcome to a series of quick video guides to help you get started with the Intergalactic Design System for your product designs. -->
 
-::: loom_video https://www.loom.com/share/70c05f1fbadc457ebcd74af6c31bfbe7?sid=d13fc781-66aa-4fb8-8758-aeba64bb67a8 :::
+::: loom_video Introduction to Intergalactic Design System
+https://www.loom.com/embed/70c05f1fbadc457ebcd74af6c31bfbe7
+:::
 
 <!-- ## How to contribute?
 
 If you're interested in contributing to the Intergalactic Design System, check out this video.
 
-::: loom_video https://www.loom.com/share/2d935c96e823486384cf22142418a72b ::: -->
+::: loom_video https://www.loom.com/embed/2d935c96e823486384cf22142418a72b ::: -->
 
 ## Principles
-
-<!-- ::: loom_video https://www.loom.com/share/7fe17765621346ddbbf0b32c7d57d6bb ::: -->
 
 Great data visualization is key to our UI, so handle charts and tables with care.
 

--- a/website/docs/get-started-guide/work-figma/work-figma.md
+++ b/website/docs/get-started-guide/work-figma/work-figma.md
@@ -4,11 +4,15 @@ title: Figma libraries
 
 ## Introduction
 
-::: loom_video https://www.loom.com/share/9cdb9e91f56a4d50accd96f08c5e4d90?sid=a55dba9e-88b3-4d19-826f-60f3c8b5dcf5 :::
+::: loom_video Introduction to Intergalactic Figma Libraries
+https://www.loom.com/embed/9cdb9e91f56a4d50accd96f08c5e4d90
+:::
 
 ## Detaching and updating components
 
-::: loom_video https://www.loom.com/share/7955fcb33bad47a6bf73c131c14cc446 :::
+::: loom_video Detaching and updating components
+https://www.loom.com/embed/7955fcb33bad47a6bf73c131c14cc446
+:::
 
 ## Core libraries
 
@@ -18,25 +22,37 @@ title: Figma libraries
 - Charts: **[Internal](https://www.figma.com/file/eODzGSSSlI8fl0x5fsv9cf/%E2%9C%A8-Charts), [Public](https://www.figma.com/community/file/1104055641569356920)**
 - Table Components: **[Internal](https://www.figma.com/file/R3kShIAwBMr9K5XSqXuQ3R/%E2%9C%A8-Table-components?type=design&t=n91YMTeTXAEyz6Cp-6), [Public](https://www.figma.com/community/file/1274029407972533900/semrush-table-components-library)**
 
-::: loom_video https://www.loom.com/share/593126f16b494b719949649d1d7fa331 :::
+::: loom_video Core Libraries, part 1
+https://www.loom.com/embed/593126f16b494b719949649d1d7fa331
+:::
 
-::: loom_video https://www.loom.com/share/f31be4be9b9649899661b6139b31b3d7 :::
+::: loom_video Core Libraries, part 2
+https://www.loom.com/embed/f31be4be9b9649899661b6139b31b3d7
+:::
 
-::: loom_video https://www.loom.com/share/d2b51d7b370f4a7cabcca1b09b7910e6 :::
+::: loom_video Core Libraries, part 3
+https://www.loom.com/embed/d2b51d7b370f4a7cabcca1b09b7910e6
+:::
 
 ## Start designing with libraries
 
 How to start designing with the Intergalactic Design System Figma libraries? Where you should start from?
 
-::: loom_video https://www.loom.com/share/f63d948f2a6543e89d7b980033216098 :::
+::: loom_video How to start designing with Figma libraries
+https://www.loom.com/embed/f63d948f2a6543e89d7b980033216098
+:::
 
-::: loom_video https://www.loom.com/share/91042725e5f3425a80b62c1e82cab152 :::
+::: loom_video UX Patterns Figma library (for Semrush designers)
+https://www.loom.com/embed/91042725e5f3425a80b62c1e82cab152
+:::
 
 ## Charts library
 
 How to choose the right visualization for your task?
 
-::: loom_video https://www.loom.com/share/0793a430c4bb4784ad0bb6cec9199af5 :::
+::: loom_video Getting started with Charts library (and choosing data visualization)
+https://www.loom.com/embed/0793a430c4bb4784ad0bb6cec9199af5
+:::
 
 ## Additional libraries
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Changed our custom `loom_video` plugin to insert specified title into the iframe.

Now loom videos should be embedded like this:
_(title is optional, default one is "video")_
<img width="469" alt="imagen" src="https://github.com/user-attachments/assets/d8278375-5f9a-46ce-931a-f88720fe7cf9" />

For existing videos on our website, I copied titles from the videos themselves, as per [Axe's recommendation](https://dequeuniversity.com/rules/axe/4.10/frame-title-unique):

> best practice is to give the enclosed document a title element with content identical to the title attribute. Some screen readers will replace the contents of the title attribute on the frame with the contents of the title element inside the frame. As a result, it’s safest and most accessible to have the same text in both locations.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
