### PR TITLE
[UIK-3879][ellipsis] fixed trim=middle behavior

### DIFF
--- a/semcore/ellipsis/src/Ellipsis.tsx
+++ b/semcore/ellipsis/src/Ellipsis.tsx
@@ -188,7 +188,6 @@ class RootEllipsis extends Component<AsProps> {
   render() {
     const SEllipsis = this.Root;
     const SContainer = Tooltip;
-    const SNoTooltipContainer = Box;
     const {
       styles,
       Children,
@@ -232,28 +231,14 @@ class RootEllipsis extends Component<AsProps> {
         </EllipsisMiddle>,
       );
     }
-    if (tooltip) {
-      return sstyled(styles)(
-        <SContainer
-          interaction='hover'
-          title={!advanceMode ? text : undefined}
-          {...tooltipProps}
-          {...(advanceMode ? forcedAdvancedMode : noAdvancedMode)}
-        >
-          {advanceMode
-            ? (
-                <Children />
-              )
-            : (
-                <SEllipsis render={Box} ref={this.textRef} maxLine={maxLine} {...other}>
-                  <Children />
-                </SEllipsis>
-              )}
-        </SContainer>,
-      );
-    }
+
     return sstyled(styles)(
-      <SNoTooltipContainer>
+      <SContainer
+        interaction={tooltip ? 'hover' : 'none'}
+        title={!advanceMode ? text : undefined}
+        {...tooltipProps}
+        {...(advanceMode ? forcedAdvancedMode : noAdvancedMode)}
+      >
         {advanceMode
           ? (
               <Children />
@@ -263,7 +248,7 @@ class RootEllipsis extends Component<AsProps> {
                 <Children />
               </SEllipsis>
             )}
-      </SNoTooltipContainer>,
+      </SContainer>,
     );
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
I changed the usage of two different components (Tooltip and Box) to one `Tooltip` always with disabling its behavior via interaction . This fixed a bug in `useResizeObserver` that did not track the change of the ref. But I thought it was more logical to leave the only one component and just change its behavior via props.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
