### PR TITLE
Draft: Add Intergalactic CSS layer (for tailwindcss compatibility)

### DIFF
--- a/semcore/core/src/styled/sstyled.tsx
+++ b/semcore/core/src/styled/sstyled.tsx
@@ -14,7 +14,7 @@ const getStyles = () => ({
   get css() {
     let serverStyles = '';
     for (const id in serverMap) {
-      serverStyles += `<style type='text/css' id='${id}'>${serverMap[id]}</style>`;
+      serverStyles += `<style type='text/css' id='${id}'>@layer semcore {${serverMap[id]}}</style>`
     }
     return serverStyles;
   },
@@ -53,7 +53,7 @@ function insert(code: any, hash: any) {
     container.appendChild(css);
   }
 
-  css.innerHTML = code;
+  css.innerHTML = `@layer semcore {${code}}`;
 }
 
 function merge(s1 = {}, s2 = {}) {


### PR DESCRIPTION
Wrap every intergalactic style into the layers. In this case, any unlayered author-defined classes will have more specificity.

## Motivation and Context

While using custom classes with intergalactic, it's sometimes issues with styles cascading (the intergalactic classes and author classes have the same specificity, therefore total styles depend on the builder).

When authors define their classes, they have the same specificity as intergalactic; therefore, they will not have any effect when they appear before intergalactic ones. (i.e., using tailwindcss with intergalactic).

## How has this been tested?

There's no any testing, only draft for consideration.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
