### PR TITLE
[UIK-3603][slider] fixed support for Home and Key key navigation

### DIFF
--- a/semcore/slider/CHANGELOG.md
+++ b/semcore/slider/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.5] - 2025-07-07
+
+### Fixed
+
+- `Slider` didn't respond to Home and End keyboard keys.
+
 ## [16.0.4] - 2025-07-04
 
 ### Changed

--- a/semcore/slider/__tests__/slider.browser-test.tsx
+++ b/semcore/slider/__tests__/slider.browser-test.tsx
@@ -160,12 +160,11 @@ test.describe('Slider', () => {
     await expect(input).toHaveValue('medium');
     await expect(slider).toHaveAttribute('aria-valuenow', '2');
 
-    // BUG - thpse actions dont work
-    // await page.keyboard.press('Home');
-    // await expect(slider).toHaveAttribute('aria-valuenow', '1');
+    await page.keyboard.press('Home');
+    await expect(slider).toHaveAttribute('aria-valuenow', '1');
 
-    // await page.keyboard.press('End');
-    // await expect(slider).toHaveAttribute('aria-valuenow', '3');
+    await page.keyboard.press('End');
+    await expect(slider).toHaveAttribute('aria-valuenow', '3');
   });
 
   test('Verify slider with input by mouse', async ({ page }) => {

--- a/semcore/slider/src/Slider.jsx
+++ b/semcore/slider/src/Slider.jsx
@@ -128,8 +128,6 @@ class SliderRoot extends Component {
   handleDragStart = () => false;
 
   handleKeyDown = (event) => {
-    event.preventDefault();
-
     if (['ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown'].includes(event.key)) {
       this.handleSlideStep(event);
     }
@@ -144,6 +142,8 @@ class SliderRoot extends Component {
   };
 
   handleSlideStep(event) {
+    event.preventDefault();
+
     const { min, max, step, options } = this.asProps;
     const direction = event.key === 'ArrowLeft' || event.key === 'ArrowDown' ? -1 : 1;
     let value = this.getNumericValue() + step * direction;
@@ -159,6 +159,8 @@ class SliderRoot extends Component {
   }
 
   slideToMinValue(event) {
+    event.preventDefault();
+
     const { min, options } = this.asProps;
     let value = min;
 
@@ -170,6 +172,8 @@ class SliderRoot extends Component {
   }
 
   slideToMaxValue(event) {
+    event.preventDefault();
+
     const { max, options } = this.asProps;
     let value = max;
 

--- a/semcore/slider/src/Slider.jsx
+++ b/semcore/slider/src/Slider.jsx
@@ -128,9 +128,22 @@ class SliderRoot extends Component {
   handleDragStart = () => false;
 
   handleKeyDown = (event) => {
-    if (!['ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown'].includes(event.key)) return;
     event.preventDefault();
 
+    if (['ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown'].includes(event.key)) {
+      this.handleSlideStep(event);
+    }
+
+    if (event.key === 'Home') {
+      this.slideToMinValue(event);
+    }
+
+    if (event.key === 'End') {
+      this.slideToMaxValue(event);
+    }
+  };
+
+  handleSlideStep(event) {
     const { min, max, step, options } = this.asProps;
     const direction = event.key === 'ArrowLeft' || event.key === 'ArrowDown' ? -1 : 1;
     let value = this.getNumericValue() + step * direction;
@@ -143,7 +156,29 @@ class SliderRoot extends Component {
     } else {
       this.handlers.value(value, event);
     }
-  };
+  }
+
+  slideToMinValue(event) {
+    const { min, options } = this.asProps;
+    let value = min;
+
+    if (options) {
+      value = options[0].value;
+    }
+
+    this.handlers.value(value, event);
+  }
+
+  slideToMaxValue(event) {
+    const { max, options } = this.asProps;
+    let value = max;
+
+    if (options) {
+      value = options[options.length - 1].value;
+    }
+
+    this.handlers.value(value, event);
+  }
 
   getNumericValue = () => {
     const { value, options, min, max, defaultValue } = this.asProps;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

The `Slider` doesn't handle Home and End keyboard keys, which are expected to move the thumb to the minimum and maximum values, respectively.
This fix adds proper keyboard handling.

## How has this been tested?

It's been tested manually + uncommented lines which check this case.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
