### PR TITLE
[UIK-3901][data-table] fixed row hover effect for empty state

### DIFF
--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.7] - 2025-07-08
+
+### Fixed
+
+- Row hover effect for empty state.
+
 ## [16.0.6] - 2025-07-04
 
 ### Changed

--- a/semcore/data-table/src/components/Body/Body.tsx
+++ b/semcore/data-table/src/components/Body/Body.tsx
@@ -437,7 +437,7 @@ class BodyRoot extends Component<DataTableBodyProps, {}, State, [], BodyPropsInn
 
     return sstyled(styles)(
       <SBody render={Box} __excludeProps={['data']}>
-        {emptyRow && <Body.Row row={emptyRow} />}
+        {emptyRow && <Body.Row row={emptyRow} isEmptyRow />}
         {typeof virtualScroll === 'boolean' && rowMarginTop && <Box h={rowMarginTop} />}
         {rowsToRender.map((row, index) => {
           if (Array.isArray(row)) {

--- a/semcore/data-table/src/components/Body/Row.types.ts
+++ b/semcore/data-table/src/components/Body/Row.types.ts
@@ -22,6 +22,7 @@ export type DataTableRowProps = {
   isAccordionRow?: DataTableCellProps['isAccordionRow'];
   animationExpand?: DataTableCellProps['animationExpand'];
   accordionRowIndex?: DataTableCellProps['accordionRowIndex'];
+  isEmptyRow?: boolean;
 };
 
 export type RowPropsInner = JSX.IntrinsicElements['div'] & {

--- a/semcore/data-table/src/components/Body/style.shadow.css
+++ b/semcore/data-table/src/components/Body/style.shadow.css
@@ -47,6 +47,10 @@ SCollapseRow > SCellWrapper > SCell:not([theme]), SRow[isAccordionRow] > SCellWr
 
 /* we need a media query here because of the postcssHoverMediaFeature plugin. it doesn't handle this type of selectors correctly */
 @media (hover: hover) {
+  SRow[isEmptyRow] > SCellWrapper > SCell {
+    background-color: unset !important;
+  }
+
   SRow:not([accordionType='row'][expanded]):hover > SCellWrapper > SCell:not([theme]):not([expanded][withAccordion]),
   SRowGroup:has(SCell[data-grouped-by='rowgroup']:hover) > SRow > SCellWrapper > SCell:not([theme]):not([expanded][withAccordion]),
   SRowGroup:has(SCell:hover) > SRow > SCellWrapper > SCell[data-grouped-by='rowgroup']:not([theme]):not([expanded][withAccordion]) {


### PR DESCRIPTION
## Motivation and Context

The row hover effect is still applied for empty state. It fixed the hover background for that empty row.

## How has this been tested?

I've added a browser test for that.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
