### PR TITLE
[UIK-3887][data-table] fixed incorrect 'Select all' checkbox behavior with pagination

### DIFF
--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.7] - 2025-07-08
+
+### Fixed
+
+- Incorrect 'Select all' checkbox behavior with pagination.
+
 ## [16.0.6] - 2025-07-04
 
 ### Changed

--- a/semcore/data-table/__tests__/data-table-pagination.browser-test.tsx
+++ b/semcore/data-table/__tests__/data-table-pagination.browser-test.tsx
@@ -30,4 +30,69 @@ test.describe('Pagination', () => {
     await page.keyboard.press('Shift+Tab');
     await expect(page.getByRole('gridcell', { name: 'ebay buy last' })).toBeFocused();
   });
+
+  test('Verify row selection works correctly', async ({ page, browser }) => {
+    const standPath = 'stories/components/data-table/docs/examples/checkbox-in-table.tsx';
+    const htmlContent = await e2eStandToHtml(standPath, 'en');
+
+    await page.setContent(htmlContent);
+
+    const collapse = page.locator('[data-ui-name="Collapse"]');
+    const selectedRowsCount = collapse.locator('[data-ui-name="Text"]').nth(1);
+    const deselectAllButton = collapse.locator('button');
+    const selectAllCheckbox = page.locator('[data-ui-name="DataTable.Head"] [data-ui-name="Checkbox"]');
+    const nextButton = page.locator('[data-ui-name="Pagination.NextPage"]');
+    const prevButton = page.locator('[data-ui-name="Pagination.PrevPage"]');
+    const rowCheckboxes = page.locator('[data-ui-name="DataTable.Body"] [data-ui-name="Checkbox"]');
+
+    await expect(collapse).toBeHidden();
+    await expect(selectedRowsCount).toBeHidden();
+    await expect(selectAllCheckbox).not.toBeChecked();
+    await page.waitForTimeout(10000);
+    await selectAllCheckbox.click();
+
+    await expect(collapse).toBeVisible();
+    await expect(selectedRowsCount).toHaveText('5');
+    await expect(selectAllCheckbox).toBeChecked();
+
+    await nextButton.click();
+
+    await expect(collapse).toBeVisible();
+    await expect(selectedRowsCount).toHaveText('5');
+    await expect(selectAllCheckbox).not.toBeChecked();
+
+    await selectAllCheckbox.click();
+
+    await expect(selectedRowsCount).toHaveText('10');
+    await expect(selectAllCheckbox).toBeChecked();
+
+    await rowCheckboxes.first().click();
+
+    await expect(rowCheckboxes.first()).not.toBeChecked();
+    await expect(selectedRowsCount).toHaveText('9');
+    await expect(selectAllCheckbox).toHaveClass(/indeterminate/);
+
+    await nextButton.click();
+
+    await expect(selectAllCheckbox).not.toBeChecked();
+    await expect(selectedRowsCount).toHaveText('9');
+
+    await prevButton.click();
+    await expect(selectAllCheckbox).toHaveClass(/indeterminate/);
+
+    await prevButton.click();
+    await expect(selectAllCheckbox).toBeChecked();
+
+    await deselectAllButton.click();
+
+    await expect(collapse).toBeHidden();
+    await expect(selectedRowsCount).toBeHidden();
+    await expect(selectAllCheckbox).not.toBeChecked();
+
+    await nextButton.click();
+    await expect(selectAllCheckbox).not.toBeChecked();
+
+    await nextButton.click();
+    await expect(selectAllCheckbox).not.toBeChecked();
+  });
 });

--- a/semcore/data-table/__tests__/data-table-states.browser-test.tsx
+++ b/semcore/data-table/__tests__/data-table-states.browser-test.tsx
@@ -81,7 +81,7 @@ test.describe('Loading states', () => {
 
 test.describe('Additional states', () => {
   test('Verify table with checkbox attributes and mouse interaction', async ({ page }) => {
-    const standPath = 'stories/components/data-table/docs/examples/checkbox-in-table.tsx';
+    const standPath = 'stories/components/data-table/tests/examples/checkbox-tests/checkbox-in-table.tsx';
     const htmlContent = await e2eStandToHtml(standPath, 'en');
 
     await page.setContent(htmlContent);
@@ -128,7 +128,7 @@ test.describe('Additional states', () => {
   });
 
   test('Verify table with checkbox keyboard interaction', async ({ page, browserName }) => {
-    const standPath = 'stories/components/data-table/docs/examples/checkbox-in-table.tsx';
+    const standPath = 'stories/components/data-table/tests/examples/checkbox-tests/checkbox-in-table.tsx';
     const htmlContent = await e2eStandToHtml(standPath, 'en');
 
     await page.setContent(htmlContent);

--- a/semcore/data-table/__tests__/data-table.axe-test.tsx
+++ b/semcore/data-table/__tests__/data-table.axe-test.tsx
@@ -171,7 +171,7 @@ test.describe('DataTable', () => {
     expect(violations).toEqual([]);
   });
   test('checkbox in table', async ({ page }) => {
-    const standPath = 'stories/components/data-table/docs/examples/checkbox-in-table.tsx';
+    const standPath = 'stories/components/data-table/tests/examples/checkbox-tests/checkbox-in-table.tsx';
     const violations = await checkAxe(page, standPath);
 
     expect(violations).toEqual([]);

--- a/semcore/data-table/src/components/DataTable/DataTable.tsx
+++ b/semcore/data-table/src/components/DataTable/DataTable.tsx
@@ -91,6 +91,8 @@ class DataTableRoot<D extends DataTableData> extends Component<
 
   private headerNodesMap = new Map();
 
+  private persistedSelectedRows = new Set<UniqRowKey>();
+
   constructor(props: DataTableProps<D>) {
     super(props);
 
@@ -119,11 +121,15 @@ class DataTableRoot<D extends DataTableData> extends Component<
   }
 
   componentDidMount() {
-    const { headerProps, loading } = this.asProps;
+    const { headerProps, loading, selectedRows } = this.asProps;
     if ((headerProps?.sticky && !headerProps.h) || loading || this.columns.some((c) => c.fixed)) {
       requestAnimationFrame(() => {
         this.forceUpdate();
       });
+    }
+
+    if (selectedRows && selectedRows.length > 0) {
+      selectedRows.forEach(this.persistedSelectedRows.add, this.persistedSelectedRows);
     }
   }
 
@@ -145,6 +151,7 @@ class DataTableRoot<D extends DataTableData> extends Component<
         this.setSelectAllMessage(true);
       } else if (prevProps.selectedRows.length > 0 && selectedRows.length === 0) {
         this.setSelectAllMessage(false);
+        this.persistedSelectedRows.clear();
       }
     }
   }
@@ -228,14 +235,14 @@ class DataTableRoot<D extends DataTableData> extends Component<
       gridTemplateAreas,
       sideIndents,
       totalRows: this.totalRows,
-      selectedRows: selectedRows,
+      selectedRows,
+      persistedSelectedRows: this.persistedSelectedRows,
+      flatRows: this.flatRows,
       onChangeSelectAll: (value, e) => {
-        if (value === false) {
-          onSelectedRowsChange?.([], e);
-        } else {
-          const selectedRows = this.flatRows.map((row) => row[UNIQ_ROW_KEY]);
-          onSelectedRowsChange?.(selectedRows, e);
-        }
+        const selectedRows = this.flatRows.map((row) => row[UNIQ_ROW_KEY]);
+        selectedRows.forEach(value ? this.persistedSelectedRows.add : this.persistedSelectedRows.delete, this.persistedSelectedRows);
+
+        onSelectedRowsChange?.([...this.persistedSelectedRows], e);
       },
       getFixedStyle: this.getFixedStyle,
       onCellClick: this.handleCellClick,
@@ -312,21 +319,15 @@ class DataTableRoot<D extends DataTableData> extends Component<
   ) => {
     const { selectedRows, onSelectedRowsChange } = this.asProps;
 
-    if (selectedRows && onSelectedRowsChange) {
-      const newSelectedRows = new Set(selectedRows);
+    if (!selectedRows || !onSelectedRowsChange) return;
 
-      if (isSelected && !newSelectedRows.has(row[UNIQ_ROW_KEY])) {
-        newSelectedRows.add(row[UNIQ_ROW_KEY]);
-      } else if (!isSelected && newSelectedRows.has(row[UNIQ_ROW_KEY])) {
-        newSelectedRows.delete(row[UNIQ_ROW_KEY]);
-      }
-
-      onSelectedRowsChange([...newSelectedRows], event, {
-        selectedRowIndex,
-        isSelected,
-        row,
-      });
+    if (this.persistedSelectedRows.has(row[UNIQ_ROW_KEY])) {
+      this.persistedSelectedRows.delete(row[UNIQ_ROW_KEY]);
+    } else {
+      this.persistedSelectedRows.add(row[UNIQ_ROW_KEY]);
     }
+
+    onSelectedRowsChange([...this.persistedSelectedRows], event, { selectedRowIndex, isSelected, row });
   };
 
   setSelectAllMessage = (selectedAll: boolean) => {

--- a/semcore/data-table/src/components/Head/Head.tsx
+++ b/semcore/data-table/src/components/Head/Head.tsx
@@ -10,7 +10,7 @@ import { Group } from './Group';
 import type { DataTableGroupProps } from './Group.type';
 import type { DataTableHeadProps, HeadPropsInner } from './Head.types';
 import style from './style.shadow.css';
-import { DataTableInternal, SELECT_ALL } from '../DataTable/DataTable';
+import { DataTableInternal, SELECT_ALL, UNIQ_ROW_KEY } from '../DataTable/DataTable';
 import type { DataTableData } from '../DataTable/DataTable.types';
 
 class HeadRoot<D extends DataTableData> extends Component<
@@ -103,25 +103,36 @@ class HeadRoot<D extends DataTableData> extends Component<
     this.asProps.onChangeSelectAll?.(value, event);
   };
 
+  get areAllRowsSelected() {
+    const { selectedRows, flatRows } = this.asProps;
+
+    return flatRows.every((row) => selectedRows?.includes(row[UNIQ_ROW_KEY]));
+  }
+
+  get isIndeterminate() {
+    const { flatRows, persistedSelectedRows } = this.asProps;
+
+    return flatRows.some((row) => persistedSelectedRows.has(row[UNIQ_ROW_KEY]));
+  }
+
   render() {
     const SHead = Root;
     const SHeadCheckboxCol = Head.Column;
-    const { Children, styles, getI18nText, children, treeColumns, selectedRows, totalRows } =
-      this.asProps;
+    const { Children, styles, getI18nText, children, treeColumns, selectedRows, sticky } = this.asProps;
 
-    const checked = selectedRows && selectedRows.length === totalRows && totalRows > 0;
-    const indeterminate = selectedRows && selectedRows.length > 0 && !checked;
+    const areAllRowsSelected = this.areAllRowsSelected;
+    const indeterminate = this.isIndeterminate && !areAllRowsSelected;
 
     return sstyled(styles)(
       <>
-        <SHead render={Box} role='row' aria-rowindex={1}>
+        <SHead render={Box} role='row' aria-rowindex={1} use:sticky={sticky}>
           {selectedRows && (
             <SHeadCheckboxCol
               name={SELECT_ALL.toString()}
-              onClick={this.handleClickSelectAll(!checked)}
+              onClick={this.handleClickSelectAll(!areAllRowsSelected)}
             >
               <Checkbox
-                checked={checked}
+                checked={areAllRowsSelected}
                 indeterminate={indeterminate}
                 aria-label={getI18nText('DataTable.Header.selectAllCheckbox:aria-label')}
                 onChange={this.handleSelectAll}

--- a/semcore/data-table/src/components/Head/Head.types.ts
+++ b/semcore/data-table/src/components/Head/Head.types.ts
@@ -1,6 +1,6 @@
 import type { DTColumn } from './Column.types';
 import type { CellPropsInner } from '../Body/Cell.types';
-import type { UniqRowKey } from '../Body/Row.types';
+import type { DTRow, UniqRowKey } from '../Body/Row.types';
 import type { DataTableData, DataTableProps, DTUse } from '../DataTable/DataTable.types';
 
 export type DataTableHeadProps = {
@@ -44,6 +44,8 @@ export type HeadPropsInner<D extends DataTableData> = {
   totalRows: number;
   selectedRows?: UniqRowKey[];
   onChangeSelectAll?: (value: boolean, event?: React.SyntheticEvent<HTMLElement>) => void;
+  flatRows: DTRow[];
+  persistedSelectedRows: Set<UniqRowKey>;
 
   getFixedStyle: (
     cell: Pick<DTColumn, 'name' | 'fixed'>,

--- a/stories/components/data-table/docs/examples/checkbox-in-table.tsx
+++ b/stories/components/data-table/docs/examples/checkbox-in-table.tsx
@@ -1,24 +1,15 @@
 import { Box, Flex, Collapse, ScreenReaderOnly } from '@semcore/base-components';
 import Button from '@semcore/button';
-import { sstyled } from '@semcore/core';
 import { DataTable } from '@semcore/data-table';
+import Pagination from '@semcore/pagination';
 import { Text } from '@semcore/typography';
 import React from 'react';
-
-const style = sstyled.css`
-  SDataTable > [aria-rowindex='1'] > div {
-    transition: top 150ms ease-out;
-  }
-  SDataTable[activePanel] > [aria-rowindex='1'] > div {
-    top: 44px;
-    transition-delay: 80ms;
-  }
-`;
 
 const Demo = () => {
   const [selectedRows, setSelectedRows] = React.useState<string[]>([]);
   const [selectedRowsDisplay, setSelectedRowsDisplay] = React.useState(0);
   const [ariaMessage, setAriaMessage] = React.useState('');
+  const [currentPage, setCurrentPage] = React.useState(0);
   const tableRef = React.useRef<HTMLDivElement>(null);
 
   const handleChangeSelectedRows = (value: string[]) => {
@@ -37,13 +28,16 @@ const Demo = () => {
     return () => clearTimeout(timer);
   }, [ariaMessage]);
 
+  const limit = 5;
+  const tableData = data.slice(currentPage * limit, currentPage * limit + limit);
+
   return (
     <Box
       // need this for FF
       tabIndex={-1}
       wMax={800}
       h='100%'
-      hMax={400}
+      hMax={250}
       style={{ overflow: 'auto', scrollPaddingTop: selectedRows.length ? '44px' : undefined }}
     >
       <ScreenReaderOnly role='status' aria-live='polite'>
@@ -76,179 +70,57 @@ const Demo = () => {
         </Flex>
       </Collapse>
       <DataTable
-        data={data}
+        data={tableData}
         aria-label='Table example with selectable rows'
         defaultGridTemplateColumnWidth='auto'
         selectedRows={selectedRows}
         onSelectedRowsChange={handleChangeSelectedRows}
         ref={tableRef}
-        headerProps={{ sticky: true }}
+        headerProps={{ sticky: true, top: selectedRows.length ? 44 : 0 }}
         columns={[
           { name: 'keyword', children: 'Keyword' },
           { name: 'kd', children: 'KD %' },
           { name: 'cpc', children: 'CPC' },
           { name: 'vol', children: 'Vol.' },
         ]}
-        // @ts-ignore
-        styles={style}
-        // @ts-ignore
-        activePanel={!!selectedRows.length}
+        uniqueRowKey='id'
+      />
+      <Pagination
+        mt={4}
+        totalPages={Math.ceil(data.length / limit)}
+        currentPage={currentPage + 1}
+        onCurrentPageChange={(page) => setCurrentPage(page - 1)}
       />
     </Box>
   );
 };
 
 const data = [
-  {
-    keyword: 'ebay buy',
-    kd: '77.8',
-    cpc: '$1.25',
-    vol: '32,500,000',
-  },
-  {
-    keyword: 'www.ebay.com',
-    kd: '11.2',
-    cpc: '$3.4',
-    vol: '65,457,920',
-  },
-  {
-    keyword: 'www.ebay.com',
-    kd: '10',
-    cpc: '$0.65',
-    vol: '47,354,640',
-  },
-  {
-    keyword: 'ebay buy',
-    kd: '-',
-    cpc: '$0',
-    vol: 'n/a',
-  },
-  {
-    keyword: 'ebay buy',
-    kd: '75.89',
-    cpc: '$0',
-    vol: '21,644,290',
-  },
-  {
-    keyword: 'ebay buy',
-    kd: '77.8',
-    cpc: '$1.25',
-    vol: '32,500,000',
-  },
-  {
-    keyword: 'www.ebay.com',
-    kd: '11.2',
-    cpc: '$3.4',
-    vol: '65,457,920',
-  },
-  {
-    keyword: 'www.ebay.com',
-    kd: '10',
-    cpc: '$0.65',
-    vol: '47,354,640',
-  },
-  {
-    keyword: 'ebay buy',
-    kd: '-',
-    cpc: '$0',
-    vol: 'n/a',
-  },
-  {
-    keyword: 'ebay buy',
-    kd: '75.89',
-    cpc: '$0',
-    vol: '21,644,290',
-  },
-  {
-    keyword: 'ebay buy',
-    kd: '77.8',
-    cpc: '$1.25',
-    vol: '32,500,000',
-  },
-  {
-    keyword: 'www.ebay.com',
-    kd: '11.2',
-    cpc: '$3.4',
-    vol: '65,457,920',
-  },
-  {
-    keyword: 'www.ebay.com',
-    kd: '10',
-    cpc: '$0.65',
-    vol: '47,354,640',
-  },
-  {
-    keyword: 'ebay buy',
-    kd: '-',
-    cpc: '$0',
-    vol: 'n/a',
-  },
-  {
-    keyword: 'ebay buy',
-    kd: '75.89',
-    cpc: '$0',
-    vol: '21,644,290',
-  },
-  {
-    keyword: 'ebay buy',
-    kd: '77.8',
-    cpc: '$1.25',
-    vol: '32,500,000',
-  },
-  {
-    keyword: 'www.ebay.com',
-    kd: '11.2',
-    cpc: '$3.4',
-    vol: '65,457,920',
-  },
-  {
-    keyword: 'www.ebay.com',
-    kd: '10',
-    cpc: '$0.65',
-    vol: '47,354,640',
-  },
-  {
-    keyword: 'ebay buy',
-    kd: '-',
-    cpc: '$0',
-    vol: 'n/a',
-  },
-  {
-    keyword: 'ebay buy',
-    kd: '75.89',
-    cpc: '$0',
-    vol: '21,644,290',
-  },
-  {
-    keyword: 'ebay buy',
-    kd: '77.8',
-    cpc: '$1.25',
-    vol: '32,500,000',
-  },
-  {
-    keyword: 'www.ebay.com',
-    kd: '11.2',
-    cpc: '$3.4',
-    vol: '65,457,920',
-  },
-  {
-    keyword: 'www.ebay.com',
-    kd: '10',
-    cpc: '$0.65',
-    vol: '47,354,640',
-  },
-  {
-    keyword: 'ebay buy',
-    kd: '-',
-    cpc: '$0',
-    vol: 'n/a',
-  },
-  {
-    keyword: 'ebay buy',
-    kd: '75.89',
-    cpc: '$0',
-    vol: '21,644,290',
-  },
+  { id: '1', keyword: 'ebay buy', kd: '31.2', cpc: '$1.15', vol: '22,000' },
+  { id: '2', keyword: 'amazon shoes', kd: '47', cpc: '$2.95', vol: '48,000' },
+  { id: '3', keyword: 'www.nike.com', kd: '66.4', cpc: '$3.80', vol: 'n/a' },
+  { id: '4', keyword: 'buy iphone 13', kd: '59', cpc: '$5.20', vol: '71,000' },
+  { id: '5', keyword: 'adidas sale', kd: '40.2', cpc: '$1.85', vol: '19,500' },
+  { id: '6', keyword: 'cheap flights expedia', kd: '52', cpc: '$4.10', vol: '35,800' },
+  { id: '7', keyword: 'booking.com hotels', kd: '73', cpc: '$6.45', vol: 'n/a' },
+  { id: '8', keyword: 'ubereats promo code', kd: '38', cpc: '$2.10', vol: '11,700' },
+  { id: '9', keyword: 'buy ps5 online', kd: '64', cpc: '$5.95', vol: '44,200' },
+  { id: '10', keyword: 'shopify login', kd: '25.8', cpc: '$0.65', vol: '13,600' },
+  { id: '11', keyword: 'h&m online store', kd: '36', cpc: '$1.70', vol: '10,300' },
+  { id: '12', keyword: 'buy macbook air', kd: '57.4', cpc: '$4.90', vol: '28,400' },
+  { id: '13', keyword: 'www.zara.com', kd: '45', cpc: '$3.20', vol: 'n/a' },
+  { id: '14', keyword: 'target clearance', kd: '33', cpc: '$1.25', vol: '12,900' },
+  { id: '15', keyword: 'asos men jackets', kd: '41', cpc: '$2.55', vol: '6,800' },
+  { id: '16', keyword: 'best buy coupons', kd: '48', cpc: '$3.70', vol: '17,100' },
+  { id: '17', keyword: 'walmart near me', kd: '60.1', cpc: '$0.95', vol: '50,000' },
+  { id: '18', keyword: 'netflix gift card', kd: '39', cpc: '$2.20', vol: '8,900' },
+  { id: '19', keyword: 'www.apple.com', kd: '71', cpc: '$6.90', vol: 'n/a' },
+  { id: '20', keyword: 'nike running shoes men', kd: '44', cpc: '$3.60', vol: '21,700' },
+  { id: '21', keyword: 'download spotify premium', kd: '58', cpc: '$4.75', vol: '26,800' },
+  { id: '22', keyword: 'buy dell laptop', kd: '53.1', cpc: '$5.40', vol: '19,600' },
+  { id: '23', keyword: 'gap kids sale', kd: '34', cpc: '$1.10', vol: '5,300' },
+  { id: '24', keyword: 'www.shein.com', kd: '69.8', cpc: '$3.95', vol: 'n/a' },
+  { id: '25', keyword: 'mcdonalds delivery app', kd: '29', cpc: '$2.05', vol: '14,200' },
 ];
 
 export default Demo;

--- a/stories/components/data-table/tests/data-table-checkbox.stories.tsx
+++ b/stories/components/data-table/tests/data-table-checkbox.stories.tsx
@@ -1,0 +1,16 @@
+import { DataTable } from '@semcore/data-table';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import CheckboxInTableDemo from './examples/checkbox-tests/checkbox-in-table.tsx';
+
+const meta: Meta<typeof DataTable> = {
+  title: 'Components/DataTable/Tests/Checkbox',
+  component: DataTable,
+};
+
+export default meta;
+type Story = StoryObj<typeof DataTable>;
+
+export const CheckboxInTable: Story = {
+  render: CheckboxInTableDemo,
+};

--- a/stories/components/data-table/tests/examples/checkbox-tests/checkbox-in-table.tsx
+++ b/stories/components/data-table/tests/examples/checkbox-tests/checkbox-in-table.tsx
@@ -1,0 +1,254 @@
+import { Box, Flex, Collapse, ScreenReaderOnly } from '@semcore/base-components';
+import Button from '@semcore/button';
+import { sstyled } from '@semcore/core';
+import { DataTable } from '@semcore/data-table';
+import { Text } from '@semcore/typography';
+import React from 'react';
+
+const style = sstyled.css`
+  SDataTable > [aria-rowindex='1'] > div {
+    transition: top 150ms ease-out;
+  }
+  SDataTable[activePanel] > [aria-rowindex='1'] > div {
+    top: 44px;
+    transition-delay: 80ms;
+  }
+`;
+
+const Demo = () => {
+  const [selectedRows, setSelectedRows] = React.useState<string[]>([]);
+  const [selectedRowsDisplay, setSelectedRowsDisplay] = React.useState(0);
+  const [ariaMessage, setAriaMessage] = React.useState('');
+  const tableRef = React.useRef<HTMLDivElement>(null);
+
+  const handleChangeSelectedRows = (value: string[]) => {
+    setSelectedRows(value);
+    if (!selectedRows.length) setAriaMessage('Action bar appeared before the table');
+    if (value.length) setSelectedRowsDisplay(value.length);
+  };
+
+  const handleDeselectAll = () => {
+    setSelectedRows([]);
+    tableRef.current?.focus();
+  };
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => setAriaMessage(''), 300);
+    return () => clearTimeout(timer);
+  }, [ariaMessage]);
+
+  return (
+    <Box
+      // need this for FF
+      tabIndex={-1}
+      wMax={800}
+      h='100%'
+      hMax={400}
+      style={{ overflow: 'auto', scrollPaddingTop: selectedRows.length ? '44px' : undefined }}
+    >
+      <ScreenReaderOnly role='status' aria-live='polite'>
+        {ariaMessage}
+      </ScreenReaderOnly>
+      <Collapse
+        visible={!!selectedRows.length}
+        duration={150}
+        style={{ position: 'sticky', top: 0, zIndex: 2 }}
+      >
+        <Flex
+          role='region'
+          aria-label='Table action bar'
+          alignItems='center'
+          gap={6}
+          py={2}
+          px={3}
+          style={{
+            backgroundColor: 'var(--intergalactic-bg-primary-neutral, #ffffff)',
+          }}
+        >
+          <Text size={200}>
+            Selected rows:
+            {' '}
+            <Text bold>{selectedRowsDisplay}</Text>
+          </Text>
+          <Button use='tertiary' onClick={handleDeselectAll}>
+            Deselect all
+          </Button>
+        </Flex>
+      </Collapse>
+      <DataTable
+        data={data}
+        aria-label='Table example with selectable rows'
+        defaultGridTemplateColumnWidth='auto'
+        selectedRows={selectedRows}
+        onSelectedRowsChange={handleChangeSelectedRows}
+        ref={tableRef}
+        headerProps={{ sticky: true }}
+        columns={[
+          { name: 'keyword', children: 'Keyword' },
+          { name: 'kd', children: 'KD %' },
+          { name: 'cpc', children: 'CPC' },
+          { name: 'vol', children: 'Vol.' },
+        ]}
+        // @ts-ignore
+        styles={style}
+        // @ts-ignore
+        activePanel={!!selectedRows.length}
+      />
+    </Box>
+  );
+};
+
+const data = [
+  {
+    keyword: 'ebay buy',
+    kd: '77.8',
+    cpc: '$1.25',
+    vol: '32,500,000',
+  },
+  {
+    keyword: 'www.ebay.com',
+    kd: '11.2',
+    cpc: '$3.4',
+    vol: '65,457,920',
+  },
+  {
+    keyword: 'www.ebay.com',
+    kd: '10',
+    cpc: '$0.65',
+    vol: '47,354,640',
+  },
+  {
+    keyword: 'ebay buy',
+    kd: '-',
+    cpc: '$0',
+    vol: 'n/a',
+  },
+  {
+    keyword: 'ebay buy',
+    kd: '75.89',
+    cpc: '$0',
+    vol: '21,644,290',
+  },
+  {
+    keyword: 'ebay buy',
+    kd: '77.8',
+    cpc: '$1.25',
+    vol: '32,500,000',
+  },
+  {
+    keyword: 'www.ebay.com',
+    kd: '11.2',
+    cpc: '$3.4',
+    vol: '65,457,920',
+  },
+  {
+    keyword: 'www.ebay.com',
+    kd: '10',
+    cpc: '$0.65',
+    vol: '47,354,640',
+  },
+  {
+    keyword: 'ebay buy',
+    kd: '-',
+    cpc: '$0',
+    vol: 'n/a',
+  },
+  {
+    keyword: 'ebay buy',
+    kd: '75.89',
+    cpc: '$0',
+    vol: '21,644,290',
+  },
+  {
+    keyword: 'ebay buy',
+    kd: '77.8',
+    cpc: '$1.25',
+    vol: '32,500,000',
+  },
+  {
+    keyword: 'www.ebay.com',
+    kd: '11.2',
+    cpc: '$3.4',
+    vol: '65,457,920',
+  },
+  {
+    keyword: 'www.ebay.com',
+    kd: '10',
+    cpc: '$0.65',
+    vol: '47,354,640',
+  },
+  {
+    keyword: 'ebay buy',
+    kd: '-',
+    cpc: '$0',
+    vol: 'n/a',
+  },
+  {
+    keyword: 'ebay buy',
+    kd: '75.89',
+    cpc: '$0',
+    vol: '21,644,290',
+  },
+  {
+    keyword: 'ebay buy',
+    kd: '77.8',
+    cpc: '$1.25',
+    vol: '32,500,000',
+  },
+  {
+    keyword: 'www.ebay.com',
+    kd: '11.2',
+    cpc: '$3.4',
+    vol: '65,457,920',
+  },
+  {
+    keyword: 'www.ebay.com',
+    kd: '10',
+    cpc: '$0.65',
+    vol: '47,354,640',
+  },
+  {
+    keyword: 'ebay buy',
+    kd: '-',
+    cpc: '$0',
+    vol: 'n/a',
+  },
+  {
+    keyword: 'ebay buy',
+    kd: '75.89',
+    cpc: '$0',
+    vol: '21,644,290',
+  },
+  {
+    keyword: 'ebay buy',
+    kd: '77.8',
+    cpc: '$1.25',
+    vol: '32,500,000',
+  },
+  {
+    keyword: 'www.ebay.com',
+    kd: '11.2',
+    cpc: '$3.4',
+    vol: '65,457,920',
+  },
+  {
+    keyword: 'www.ebay.com',
+    kd: '10',
+    cpc: '$0.65',
+    vol: '47,354,640',
+  },
+  {
+    keyword: 'ebay buy',
+    kd: '-',
+    cpc: '$0',
+    vol: 'n/a',
+  },
+  {
+    keyword: 'ebay buy',
+    kd: '75.89',
+    cpc: '$0',
+    vol: '21,644,290',
+  },
+];
+
+export default Demo;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

`Select all` checkbox does not reflect correct selection state when paging is used. The logic is updated to account for paginated data.

## How has this been tested?

I've added a browser test.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
