### PR TITLE
[UIK-3921][bulk-textarea] fixed styling in types o_O

### DIFF
--- a/semcore/bulk-textarea/CHANGELOG.md
+++ b/semcore/bulk-textarea/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.2.4] - 2025-07-10
+
+### Fixed
+
+- Missing type names for `InputFieldProps` on API page for Bulk Textarea due to ESLint fixes.
+
 ## [16.2.3] - 2025-07-04
 
 ### Changed

--- a/semcore/bulk-textarea/src/components/InputField/InputField.types.ts
+++ b/semcore/bulk-textarea/src/components/InputField/InputField.types.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @stylistic/quote-props */
+
 type PasteProps = {
   /**
    * @default '\n'
@@ -23,148 +25,148 @@ export type InputFieldProps<T extends string | string[]> = {
   /**
    * Unique id
    */
-  'id'?: string;
+  id?: string;
 
   /**
    * Placeholder for field
    */
-  'placeholder'?: string;
+  placeholder?: string;
   /**
    * String to render in textarea. OnChanging value, it will go throw paste pipeline
    */
-  'value': T;
+  value: T;
   /**
    * This component doesn't have default onChange callback, because we think that you need only the result after every changes/fixes
    */
-  'onBlur': (value: T, e: Event) => void;
+  onBlur: (value: T, e: Event) => void;
 
   /**
    * Size of component
    * @default m
    */
-  'size': 'm' | 'l';
+  size: 'm' | 'l';
   /**
    * State for show errors or valid(green) borders
    * @default normal
    */
-  'state': 'normal' | 'valid' | 'invalid';
+  state: 'normal' | 'valid' | 'invalid';
 
   /**
    * Flag for disabling field
    * @default false
    */
-  'disabled'?: boolean;
+  disabled?: boolean;
 
   /**
    * Flag for readonly field
    * @default false
    */
-  'readonly'?: boolean;
+  readonly?: boolean;
 
   /**
    * Min rows
    * @default 2
    */
-  'minRows': number;
+  minRows: number;
   /**
    * Max rows
    * @default 10
    */
-  'maxRows': number;
+  maxRows: number;
 
   /**
    * List of available points to validate value
    * @default blur
    */
-  'validateOn': ('blur' | 'blurLine' | 'paste')[];
+  validateOn: ('blur' | 'blurLine' | 'paste')[];
 
   /**
    * Function to validate line
    */
-  'lineValidation'?: (line: string, lines: string[]) => { isValid: boolean; errorMessage: string };
+  lineValidation?: (line: string, lines: string[]) => { isValid: boolean; errorMessage: string };
 
   /**
    * Message for display error about whole field, not only one line.
    * If set empty string, field will not have invalid state.
    */
-  'commonErrorMessage': string;
+  commonErrorMessage: string;
 
   /**
    * Delimiters (event.key) for lines
    * @default Enter
    */
-  'linesDelimiters'?: string[];
+  linesDelimiters?: string[];
 
   /**
    * Count of max lines in badge
    * @default 100
    */
-  'maxLines': number;
+  maxLines: number;
 
   /**
    * Paste props
    */
-  'pasteProps': PasteProps;
+  pasteProps: PasteProps;
 
   /**
    * Function for process line after it was blurred
    */
-  'lineProcessing'?: (line: string, lines: string[]) => string;
+  lineProcessing?: (line: string, lines: string[]) => string;
 
   /**
    * Internal
    */
-  'prevError': ErrorItem;
+  prevError: ErrorItem;
 
   /**
    * Internal
    */
-  'currentLineIndex': number;
+  currentLineIndex: number;
 
   /**
    * Internal
    */
-  'linesCount': number;
+  linesCount: number;
   /**
    * Internal
    */
-  'onChangeLineIndex': (newIndex: number) => void;
+  onChangeLineIndex: (newIndex: number) => void;
   /**
    * Internal
    */
-  'onChangeLinesCount': (rowsCount: number) => void;
+  onChangeLinesCount: (rowsCount: number) => void;
 
   /**
    * Internal
    */
-  'showErrors': boolean;
+  showErrors: boolean;
   /**
    * Internal
    * List of errors in rows
    */
-  'errors': ErrorItem[];
+  errors: ErrorItem[];
   /**
    * Internal
    * Select row with error
    */
-  'errorIndex': number;
+  errorIndex: number;
   /**
    * Internal
    * Flag for select all row
    */
-  'highlightErrorIndex': boolean;
+  highlightErrorIndex: boolean;
   /**
    * Internal
    */
-  'onErrorsChange': (errors: ErrorItem[]) => void;
+  onErrorsChange: (errors: ErrorItem[]) => void;
   /**
    * Internal
    */
-  'onShowErrorsChange': (showErrors: boolean) => void;
+  onShowErrorsChange: (showErrors: boolean) => void;
   /**
    * Internal
    */
-  'onErrorIndexChange': (errorIndex: number) => void;
+  onErrorIndexChange: (errorIndex: number) => void;
 
   /**
    * Internal


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Type names for `InputFieldProps` on the API page are removed during build because ESLint decided to add `'` since the internal prop is named in the quotes.

## How has this been tested?

It's been tested manually.

## Screenshots (if appropriate):
<img width="810" height="1118" alt="Screenshot 2025-07-10 at 12 58 11" src="https://github.com/user-attachments/assets/5c6a3e85-d6c3-427a-a66d-b42d49e2c538" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
