### PR TITLE
[UIK-3941] Remove /ui/ from import paths in docs

### DIFF
--- a/stories/components/data-table/docs/examples/skeleton-in-table.tsx
+++ b/stories/components/data-table/docs/examples/skeleton-in-table.tsx
@@ -1,20 +1,8 @@
+import { ScreenReaderOnly } from '@semcore/base-components';
+import Button from '@semcore/button';
 import { DataTable } from '@semcore/data-table';
 import Skeleton from '@semcore/skeleton';
-import { ScreenReaderOnly } from '@semcore/ui/base-components';
-import Button from '@semcore/ui/button';
 import React from 'react';
-
-function getSkeleton() {
-  return ['keyword', 'kd', 'cpc', 'vol'].map((c) => ({
-    cssVar: `--${c}_width`,
-    name: c,
-    data: (
-      <Skeleton height={17}>
-        <Skeleton.Text y='5' width='60%' />
-      </Skeleton>
-    ),
-  }));
-}
 
 const Demo = () => {
   const [loading, setLoading] = React.useState(true);

--- a/stories/components/data-table/docs/examples/spin-container-in-table.tsx
+++ b/stories/components/data-table/docs/examples/spin-container-in-table.tsx
@@ -1,6 +1,6 @@
+import { ScreenReaderOnly } from '@semcore/base-components';
+import Button from '@semcore/button';
 import { DataTable } from '@semcore/data-table';
-import { ScreenReaderOnly } from '@semcore/ui/base-components';
-import Button from '@semcore/ui/button';
 import React from 'react';
 
 const Demo = (): any => {

--- a/stories/components/input-number/docs/examples/appearance_customization.tsx
+++ b/stories/components/input-number/docs/examples/appearance_customization.tsx
@@ -1,7 +1,7 @@
 import { Flex } from '@semcore/base-components';
-import Button from '@semcore/ui/button';
-import InputNumber from '@semcore/ui/input-number';
-import { Text } from '@semcore/ui/typography';
+import Button from '@semcore/button';
+import InputNumber from '@semcore/input-number';
+import { Text } from '@semcore/typography';
 import React from 'react';
 
 const Demo = () => {

--- a/stories/components/tag/tests/examples/styles-themes-sizes-disabled.tsx
+++ b/stories/components/tag/tests/examples/styles-themes-sizes-disabled.tsx
@@ -1,5 +1,5 @@
 import { Flex, Box } from '@semcore/flex-box';
-import Tag, { TagContainer } from '@semcore/tag';
+import Tag from '@semcore/tag';
 import { Text } from '@semcore/typography';
 import React from 'react';
 

--- a/stories/components/tag/tests/examples/styles-themes-sizes-interactive.tsx
+++ b/stories/components/tag/tests/examples/styles-themes-sizes-interactive.tsx
@@ -1,5 +1,5 @@
 import { Flex, Box } from '@semcore/flex-box';
-import Tag, { TagContainer } from '@semcore/tag';
+import Tag from '@semcore/tag';
 import { Text } from '@semcore/typography';
 import React from 'react';
 

--- a/stories/components/tooltip/tests/examples/basic_usage.tsx
+++ b/stories/components/tooltip/tests/examples/basic_usage.tsx
@@ -1,10 +1,9 @@
 import Button, { ButtonLink } from '@semcore/button';
 import { Flex } from '@semcore/flex-box';
-import CheckAltM from '@semcore/icon/CheckAlt/m';
 import FileExportM from '@semcore/icon/FileExport/m';
 import InfoM from '@semcore/icon/Info/m';
 import Link from '@semcore/link';
-import Tooltip, { Hint, DescriptionTooltip } from '@semcore/tooltip';
+import Tooltip, { DescriptionTooltip } from '@semcore/tooltip';
 import { Text } from '@semcore/typography';
 import React from 'react';
 

--- a/stories/components/typography/tests/examples/text-with-diff-combimations.tsx
+++ b/stories/components/typography/tests/examples/text-with-diff-combimations.tsx
@@ -1,4 +1,3 @@
-import { Flex, Box } from '@semcore/flex-box';
 import { Text } from '@semcore/typography';
 import React from 'react';
 

--- a/stories/patterns/filters/advanced-filters/docs/examples/filters-with-filter-conditions.tsx
+++ b/stories/patterns/filters/advanced-filters/docs/examples/filters-with-filter-conditions.tsx
@@ -8,7 +8,7 @@ import MathPlusM from '@semcore/icon/MathPlus/m';
 import TrashM from '@semcore/icon/Trash/m';
 import Input from '@semcore/input';
 import Select from '@semcore/select';
-import { Hint } from '@semcore/ui/tooltip';
+import { Hint } from '@semcore/tooltip';
 import React, { useEffect, useRef, useState } from 'react';
 
 const makeOptions = (options: string[]) => options.map((value) => ({ value, children: value }));

--- a/stories/patterns/filters/filter-cp-cd-cpc/docs/examples/basic-example.tsx
+++ b/stories/patterns/filters/filter-cp-cd-cpc/docs/examples/basic-example.tsx
@@ -1,9 +1,9 @@
-import { Flex } from '@semcore/ui/base-components';
-import { FilterTrigger } from '@semcore/ui/base-trigger';
-import Button from '@semcore/ui/button';
-import Dropdown from '@semcore/ui/dropdown';
-import InputNumber from '@semcore/ui/input-number';
-import { Text } from '@semcore/ui/typography';
+import { Flex } from '@semcore/base-components';
+import { FilterTrigger } from '@semcore/base-trigger';
+import Button from '@semcore/button';
+import Dropdown from '@semcore/dropdown';
+import InputNumber from '@semcore/input-number';
+import { Text } from '@semcore/typography';
 import React, { useState, useRef } from 'react';
 
 interface ValueState {

--- a/stories/patterns/filters/filter-include-exclude/docs/examples/basic-example.tsx
+++ b/stories/patterns/filters/filter-include-exclude/docs/examples/basic-example.tsx
@@ -1,4 +1,4 @@
-import { ScreenReaderOnly } from '@semcore/ui/base-components';
+import { ScreenReaderOnly } from '@semcore/base-components';
 import { Flex } from 'intergalactic/base-components';
 import { FilterTrigger } from 'intergalactic/base-trigger';
 import Button from 'intergalactic/button';

--- a/stories/patterns/ux-patterns/auto-suggest/docs/examples/autosuggest_example.tsx
+++ b/stories/patterns/ux-patterns/auto-suggest/docs/examples/autosuggest_example.tsx
@@ -1,7 +1,7 @@
-import { Box } from 'intergalactic/base-components';
-import Input from 'intergalactic/input';
-import Select from 'intergalactic/select';
-import { Text } from 'intergalactic/typography';
+import { Box } from '@semcore/base-components';
+import Input from '@semcore/input';
+import Select from '@semcore/select';
+import { Text } from '@semcore/typography';
 import React from 'react';
 
 const Highlight = ({ highlight, children }: { highlight: string; children: string }) => {

--- a/website/docs/components/accordion/accordion-api.md
+++ b/website/docs/components/accordion/accordion-api.md
@@ -6,7 +6,7 @@ tabs: Design('accordion'), A11y('accordion-a11y'), API('accordion-api'), Example
 ## Accordion
 
 ```jsx
-import Accordion from '@semcore/ui/accordion';
+import Accordion from '@semcore/accordion';
 
 <Accordion />;
 ```
@@ -16,7 +16,7 @@ import Accordion from '@semcore/ui/accordion';
 ## Accordion.Item
 
 ```jsx
-import { Accordion } from '@semcore/ui/accordion';
+import { Accordion } from '@semcore/accordion';
 
 <Accordion.Item />;
 ```
@@ -26,7 +26,7 @@ import { Accordion } from '@semcore/ui/accordion';
 ## Accordion.Item.Toggle
 
 ```jsx
-import { Accordion } from '@semcore/ui/accordion';
+import { Accordion } from '@semcore/accordion';
 
 <Accordion.Item.Toggle />;
 ```
@@ -36,7 +36,7 @@ Has all properties as [BoxProps](/layout/box-system/box-system-api) prop does.
 ## Accordion.Item.Collapse
 
 ```jsx
-import { Accordion } from '@semcore/ui/accordion';
+import { Accordion } from '@semcore/accordion';
 
 <Accordion.Item.Collapse />;
 ```
@@ -48,7 +48,7 @@ Has all properties as [BoxProps](/layout/box-system/box-system-api) prop does.
 ## Accordion.Item.Chevron
 
 ```jsx
-import { Accordion } from '@semcore/ui/accordion';
+import { Accordion } from '@semcore/accordion';
 
 <Accordion.Item.Chevron />;
 ```

--- a/website/docs/components/badge/badge-api.md
+++ b/website/docs/components/badge/badge-api.md
@@ -6,7 +6,7 @@ tabs: Design('badge'), A11y('badge-a11y'), API('badge-api'), Example('badge-code
 ## Badge
 
 ```jsx
-import Badge from '@semcore/ui/badge';
+import Badge from '@semcore/badge';
 <Badge />;
 ```
 

--- a/website/docs/components/base-trigger/base-trigger-api.md
+++ b/website/docs/components/base-trigger/base-trigger-api.md
@@ -9,7 +9,7 @@ tabs: Design('base-trigger'), A11y('base-trigger-a11y'), API('base-trigger-api')
 Basic trigger-button for all dropdowns.
 
 ```js
-import { BaseTrigger } from '@semcore/ui/base-trigger';
+import { BaseTrigger } from '@semcore/base-trigger';
 ```
 
 <TypesView type="BaseTriggerProps" :types={...types} />
@@ -19,7 +19,7 @@ import { BaseTrigger } from '@semcore/ui/base-trigger';
 Button-trigger with the `ChevronDownM` icon.
 
 ```js
-import { ButtonTrigger } from '@semcore/ui/base-trigger';
+import { ButtonTrigger } from '@semcore/base-trigger';
 ```
 
 <TypesView type="ButtonTriggerProps" :types={...types} />
@@ -29,7 +29,7 @@ import { ButtonTrigger } from '@semcore/ui/base-trigger';
 This trigger looks like a link with the `ChevronDownM` icon.
 
 ```js
-import { LinkTrigger } from '@semcore/ui/base-trigger';
+import { LinkTrigger } from '@semcore/base-trigger';
 ```
 
 <TypesView type="LinkTriggerProps" :types={...types} />
@@ -39,7 +39,7 @@ import { LinkTrigger } from '@semcore/ui/base-trigger';
 Trigger for filters.
 
 ```js
-import { FilterTrigger } from '@semcore/ui/base-trigger';
+import { FilterTrigger } from '@semcore/base-trigger';
 ```
 
 <TypesView type="FilterTriggerProps" :types={...types} />

--- a/website/docs/components/breadcrumbs/breadcrumbs-api.md
+++ b/website/docs/components/breadcrumbs/breadcrumbs-api.md
@@ -8,7 +8,7 @@ tabs: Design('breadcrumbs'), A11y('breadcrumbs-a11y'), API('breadcrumbs-api'), E
 Wrapper with the `nav` tag.
 
 ```jsx
-import Breadcrumbs from '@semcore/ui/breadcrumbs';
+import Breadcrumbs from '@semcore/breadcrumbs';
 <Breadcrumbs />;
 ```
 
@@ -19,7 +19,7 @@ import Breadcrumbs from '@semcore/ui/breadcrumbs';
 A page in a hierarchical navigation structure, with the `a` tag by default, if inactive. **The active item is usually the last one in the link hierarchy**.
 
 ```jsx
-import Breadcrumbs from '@semcore/ui/breadcrumbs';
+import Breadcrumbs from '@semcore/breadcrumbs';
 <Breadcrumbs.Item />;
 ```
 

--- a/website/docs/components/button/button-api.md
+++ b/website/docs/components/button/button-api.md
@@ -8,7 +8,7 @@ tabs: Design('button'), A11y('button-a11y'), API('button-api'), Example('button-
 Modified button component (`type=button` by default), it can do `loading` and add Addons to itself 💪
 
 ```jsx
-import Button from '@semcore/ui/button';
+import Button from '@semcore/button';
 <Button />;
 ```
 
@@ -19,7 +19,7 @@ import Button from '@semcore/ui/button';
 The addon is inside the button (most often it is an icon), it sets the correct margins depending on the size. It takes all properties of the `Box`.
 
 ```jsx
-import Button from '@semcore/ui/button';
+import Button from '@semcore/button';
 <Button.Addon />;
 ```
 
@@ -28,7 +28,7 @@ import Button from '@semcore/ui/button';
 Plain text, it sets the correct margins depending on the button size. If the button uses just text without addons, it will automatically turn into the `Button.Text`. It takes all properties of the `Box`.
 
 ```jsx
-import Button from '@semcore/ui/button';
+import Button from '@semcore/button';
 <Button.Text />;
 ```
 
@@ -37,7 +37,7 @@ import Button from '@semcore/ui/button';
 Modified button component (`type=button` by default) with display as link.
 
 ```jsx
-import { ButtonLink } from '@semcore/ui/button';
+import { ButtonLink } from '@semcore/button';
 <Button />;
 ```
 

--- a/website/docs/components/card/card-api.md
+++ b/website/docs/components/card/card-api.md
@@ -8,7 +8,7 @@ tabs: Design('card'), A11y('card-a11y'), API('card-api'), Example('card-code'), 
 It's just a [Box](../../layout/box-system/box-system-api#box) with predefined styles.
 
 ```jsx
-import Card from '@semcore/ui/card';
+import Card from '@semcore/card';
 <Card />;
 ```
 
@@ -17,7 +17,7 @@ import Card from '@semcore/ui/card';
 It's just a [Box](../../layout/box-system/box-system-api#box) with predefined paddings. Contains `Card.Title` and `Card.Description`.
 
 ```jsx
-import Card from '@semcore/ui/card';
+import Card from '@semcore/card';
 <Card.Header />;
 ```
 
@@ -26,7 +26,7 @@ import Card from '@semcore/ui/card';
 It's just a [Box](../../layout/box-system/box-system-api#box) with predefined paddings.
 
 ```jsx
-import Card from '@semcore/ui/card';
+import Card from '@semcore/card';
 <Card.Body />;
 ```
 
@@ -35,7 +35,7 @@ import Card from '@semcore/ui/card';
 The card title is able to display the tip.
 
 ```jsx
-import Card from '@semcore/ui/card';
+import Card from '@semcore/card';
 <Card.Title />;
 ```
 
@@ -46,7 +46,7 @@ import Card from '@semcore/ui/card';
 Has all properties of [Text](/style/typography/typography-api#text).
 
 ```jsx
-import Card from '@semcore/ui/card';
+import Card from '@semcore/card';
 <Card.Description />;
 ```
 

--- a/website/docs/components/carousel/carousel-api.md
+++ b/website/docs/components/carousel/carousel-api.md
@@ -6,7 +6,7 @@ tabs: Design('carousel'), A11y('carousel-a11y'), API('carousel-api'), Example('c
 ## Carousel
 
 ```jsx
-import Carousel from '@semcore/ui/carousel';
+import Carousel from '@semcore/carousel';
 <Carousel />;
 ```
 
@@ -17,7 +17,7 @@ import Carousel from '@semcore/ui/carousel';
 `Carousel.Container` is a wrap over `Carousel.Item`. `Carousel.Item` doesn't have own API, extends to [Box](/layout/box-system/box-system-api#box).
 
 ```jsx
-import Carousel from '@semcore/ui/carousel';
+import Carousel from '@semcore/carousel';
 <Carousel.Container />;
 ```
 
@@ -26,7 +26,7 @@ import Carousel from '@semcore/ui/carousel';
 `Carousel.Item` doesn't have own API, extends to [Box](/layout/box-system/box-system-api#box).
 
 ```jsx
-import Carousel from '@semcore/ui/carousel';
+import Carousel from '@semcore/carousel';
 <Carousel.Item />;
 ```
 
@@ -35,7 +35,7 @@ import Carousel from '@semcore/ui/carousel';
 Component view for default dots. It doesn't have own API, extends to [Box](/layout/box-system/box-system-api#box).
 
 ```jsx
-import Carousel from '@semcore/ui/carousel';
+import Carousel from '@semcore/carousel';
 <Carousel.Indicators />;
 ```
 
@@ -44,7 +44,7 @@ import Carousel from '@semcore/ui/carousel';
 Component view for default Chevron icons. It doesn't have own API, extends to [Box](/layout/box-system/box-system-api#box).
 
 ```jsx
-import Carousel from '@semcore/ui/carousel';
+import Carousel from '@semcore/carousel';
 <Carousel.Prev />
 <Carousel.Next />
 ```

--- a/website/docs/components/checkbox/checkbox-api.md
+++ b/website/docs/components/checkbox/checkbox-api.md
@@ -8,7 +8,7 @@ tabs: Design('checkbox'), A11y('checkbox-a11y'), API('checkbox-api'), Example('c
 Wrapper over the checkbox with the `label` tag.
 
 ```jsx
-import Checkbox from '@semcore/ui/checkbox';
+import Checkbox from '@semcore/checkbox';
 <Checkbox />;
 ```
 
@@ -19,7 +19,7 @@ import Checkbox from '@semcore/ui/checkbox';
 Represents `input[type=checkbox]` and `span` with an icon.
 
 ```jsx
-import Checkbox from '@semcore/ui/checkbox';
+import Checkbox from '@semcore/checkbox';
 <Checkbox.Value />;
 ```
 
@@ -28,7 +28,7 @@ import Checkbox from '@semcore/ui/checkbox';
 Represents `input[type=checkbox]` 
 
 ```jsx
-import Checkbox from '@semcore/ui/checkbox';
+import Checkbox from '@semcore/checkbox';
 <Checkbox.Value.Control />;
 ```
 
@@ -37,7 +37,7 @@ import Checkbox from '@semcore/ui/checkbox';
 Represents `span` in `Checkbox.Value`.
 
 ```jsx
-import Checkbox from '@semcore/ui/checkbox';
+import Checkbox from '@semcore/checkbox';
 <Checkbox.Value.CheckMark />;
 ```
 
@@ -48,7 +48,7 @@ import Checkbox from '@semcore/ui/checkbox';
 It is the customized `Text` from `intergalactic/typography`, depending on the size.
 
 ```jsx
-import Checkbox from '@semcore/ui/checkbox';
+import Checkbox from '@semcore/checkbox';
 <Checkbox.Text />;
 ```
 

--- a/website/docs/components/color-picker/color-picker-api.md
+++ b/website/docs/components/color-picker/color-picker-api.md
@@ -9,7 +9,7 @@ tabs: Design('color-picker'), A11y('color-picker-a11y'), API('color-picker-api')
 Widget for selecting the color.
 
 ```jsx
-import ColorPicker from '@semcore/ui/color-picker';
+import ColorPicker from '@semcore/color-picker';
 <ColorPicker />;
 ```
 
@@ -20,7 +20,7 @@ import ColorPicker from '@semcore/ui/color-picker';
 The wrap over the `<Dropdown.Trigger/>` component.
 
 ```jsx
-import ColorPicker from '@semcore/ui/color-picker';
+import ColorPicker from '@semcore/color-picker';
 <ColorPicker.Trigger />;
 ```
 
@@ -29,7 +29,7 @@ import ColorPicker from '@semcore/ui/color-picker';
 The wrap over the `<Dropdown.Popper/>` component.
 
 ```jsx
-import ColorPicker from '@semcore/ui/color-picker';
+import ColorPicker from '@semcore/color-picker';
 <ColorPicker.Popper />;
 ```
 
@@ -38,7 +38,7 @@ import ColorPicker from '@semcore/ui/color-picker';
 List of colors in `ColorPicker`.
 
 ```jsx
-import ColorPicker from '@semcore/ui/color-picker';
+import ColorPicker from '@semcore/color-picker';
 <ColorPicker.Colors />;
 ```
 
@@ -53,7 +53,7 @@ import ColorPicker from '@semcore/ui/color-picker';
 One unit of `<ColorPicker.Colors />`. ColorPicker.Item is a swatch preview that allows a user to see what color is currently selected.
 
 ```jsx
-import ColorPicker from '@semcore/ui/color-picker';
+import ColorPicker from '@semcore/color-picker';
 <ColorPicker.Item />;
 ```
 
@@ -64,7 +64,7 @@ import ColorPicker from '@semcore/ui/color-picker';
 Part of ColorPicker that provides the ability to add and remove custom colors to the palette.
 
 ```jsx
-import { PaletteManager } from '@semcore/ui/color-picker';
+import { PaletteManager } from '@semcore/color-picker';
 <PaletteManager />;
 ```
 
@@ -75,7 +75,7 @@ import { PaletteManager } from '@semcore/ui/color-picker';
 List of colors in `PaletteManager`.
 
 ```jsx
-import { PaletteManager } from '@semcore/ui/color-picker';
+import { PaletteManager } from '@semcore/color-picker';
 <PaletteManager.Colors />;
 ```
 
@@ -90,7 +90,7 @@ import { PaletteManager } from '@semcore/ui/color-picker';
 One unit of `<PaletteManager.Colors />`. PaletteManager.Item is a swatch preview that allows a user to see what color is currently selected.
 
 ```jsx
-import { PaletteManager } from '@semcore/ui/color-picker';
+import { PaletteManager } from '@semcore/color-picker';
 <PaletteManager.Item />;
 ```
 
@@ -101,7 +101,7 @@ import { PaletteManager } from '@semcore/ui/color-picker';
 Input for adding colors in hexadecimal format.
 
 ```jsx
-import { PaletteManager } from '@semcore/ui/color-picker';
+import { PaletteManager } from '@semcore/color-picker';
 <PaletteManager.InputColor />;
 ```
 

--- a/website/docs/components/counter/counter-api.md
+++ b/website/docs/components/counter/counter-api.md
@@ -6,7 +6,7 @@ tabs: Design('counter'), A11y('counter-a11y'), API('counter-api'), Example('coun
 ## Counter
 
 ```jsx
-import Counter from '@semcore/ui/counter';
+import Counter from '@semcore/counter';
 <Counter />;
 ```
 
@@ -17,7 +17,7 @@ import Counter from '@semcore/ui/counter';
 The component which will render some value with animation from initValue (0 by default).
 
 ```jsx
-import { AnimatedNumber } from '@semcore/ui/counter';
+import { AnimatedNumber } from '@semcore/counter';
 <AnimatedNumber />;
 ```
 

--- a/website/docs/components/date-picker/date-picker-api.md
+++ b/website/docs/components/date-picker/date-picker-api.md
@@ -9,7 +9,7 @@ tabs: Design('date-picker'), A11y('date-picker-a11y'), API('date-picker-api'), E
 Widget for selecting the date/month.
 
 ```jsx
-import { DatePicker, MonthPicker } from '@semcore/ui/date-picker';
+import { DatePicker, MonthPicker } from '@semcore/date-picker';
 <DatePicker />;
 <MonthPicker />;
 ```
@@ -21,7 +21,7 @@ import { DatePicker, MonthPicker } from '@semcore/ui/date-picker';
 Widget for selecting the range of dates/months.
 
 ```jsx
-import { DateRangePicker, MonthRangePicker } from '@semcore/ui/date-picker';
+import { DateRangePicker, MonthRangePicker } from '@semcore/date-picker';
 <DateRangePicker />;
 <MonthRangePicker />;
 ```
@@ -33,7 +33,7 @@ import { DateRangePicker, MonthRangePicker } from '@semcore/ui/date-picker';
 Trigger input, exists by default. `DateRangePicker` has the same interface.
 
 ```jsx
-import { DatePicker } from '@semcore/ui/date-picker';
+import { DatePicker } from '@semcore/date-picker';
 <DatePicker.Trigger />;
 ```
 
@@ -44,7 +44,7 @@ import { DatePicker } from '@semcore/ui/date-picker';
 Component for rendering the configurable periods.
 
 ```jsx
-import { DateRangePicker } from '@semcore/ui/date-picker';
+import { DateRangePicker } from '@semcore/date-picker';
 <DateRangePicker.Period />;
 ```
 
@@ -55,7 +55,7 @@ import { DateRangePicker } from '@semcore/ui/date-picker';
 Calendar component 📅
 
 ```jsx
-import { DatePicker, MonthPicker } from '@semcore/ui/date-picker';
+import { DatePicker, MonthPicker } from '@semcore/date-picker';
 <DatePicker.Calendar />;
 <MonthPicker.Calendar />;
 ```
@@ -67,7 +67,7 @@ import { DatePicker, MonthPicker } from '@semcore/ui/date-picker';
 The unit inside the calendar.
 
 ```jsx
-import { DatePicker, MonthPicker } from '@semcore/ui/date-picker';
+import { DatePicker, MonthPicker } from '@semcore/date-picker';
 <DatePicker.Calendar.Unit />;
 <MonthPicker.Calendar.Unit />;
 ```

--- a/website/docs/components/divider/divider-api.md
+++ b/website/docs/components/divider/divider-api.md
@@ -7,7 +7,7 @@ tabs: Design('divider'), A11y('divider-a11y'), API('divider-api'), Example('divi
 ## Divider
 
 ```jsx
-import Divider from '@semcore/ui/divider';
+import Divider from '@semcore/divider';
 <Divider />;
 ```
 

--- a/website/docs/components/dot/dot-api.md
+++ b/website/docs/components/dot/dot-api.md
@@ -7,7 +7,7 @@ tabs: Design('dot'), A11y('dot-a11y'), API('dot-api'), Example('dot-code'), Chan
 ## Dot
 
 ```jsx
-import Dot from '@semcore/ui/dot';
+import Dot from '@semcore/dot';
 <Dot aria-label="..." />;
 ```
 

--- a/website/docs/components/drag-and-drop/drag-and-drop-api.md
+++ b/website/docs/components/drag-and-drop/drag-and-drop-api.md
@@ -9,7 +9,7 @@ tabs: Design('drag-and-drop'), A11y('drag-and-drop-a11y'), API('drag-and-drop-ap
 Drag control component.
 
 ```jsx
-import DnD from '@semcore/ui/drag-and-drop';
+import DnD from '@semcore/drag-and-drop';
 <DnD />;
 ```
 
@@ -20,7 +20,7 @@ import DnD from '@semcore/ui/drag-and-drop';
 The element, which will be dragged.
 
 ```jsx
-import DnD from '@semcore/ui/drag-and-drop';
+import DnD from '@semcore/drag-and-drop';
 <DnD>
   <DnD.Draggable />
 </DnD>
@@ -33,7 +33,7 @@ import DnD from '@semcore/ui/drag-and-drop';
 The area, to which the dragged element will be placed.
 
 ```jsx
-import DnD from '@semcore/ui/drag-and-drop';
+import DnD from '@semcore/drag-and-drop';
 <DnD>
   <DnD.DropZone />
 </DnD>

--- a/website/docs/components/dropdown-menu/dropdown-menu-api.md
+++ b/website/docs/components/dropdown-menu/dropdown-menu-api.md
@@ -13,7 +13,7 @@ tabs: Design('dropdown-menu'), A11y('dropdown-menu-a11y'), API('dropdown-menu-ap
 DropdownMenu is a wrap over `<Dropdown/>`, which is a wrap over `<Popper/>`.
 
 ```jsx
-import DropdownMenu from "@semcore/ui/dropdown";
+import DropdownMenu from "@semcore/dropdown";
 <DropdownMenu />;
 ```
 
@@ -24,7 +24,7 @@ import DropdownMenu from "@semcore/ui/dropdown";
 DropdownMenu.Trigger is a wrap over `<Dropdown.Trigger/>` component, which is a wrap over `<Popper.Trigger/>`.
 
 ```jsx
-import DropdownMenu from "@semcore/ui/dropdown-menu";
+import DropdownMenu from "@semcore/dropdown-menu";
 <DropdownMenu.Trigger />;
 ```
 
@@ -33,7 +33,7 @@ import DropdownMenu from "@semcore/ui/dropdown-menu";
 DropdownMenu.Popper is a wrap over `<Dropdown.Popper/>` component, which is a wrap over `<Popper.Popper/>`.
 
 ```jsx
-import DropdownMenu from "@semcore/ui/dropdown-menu";
+import DropdownMenu from "@semcore/dropdown-menu";
 <DropdownMenu.Popper />;
 ```
 
@@ -42,7 +42,7 @@ import DropdownMenu from "@semcore/ui/dropdown-menu";
 DropdownMenu.List is a container component for the list items with the `<ScrollArea/>` inside it.
 
 ```jsx
-import DropdownMenu from "@semcore/ui/dropdown-menu";
+import DropdownMenu from "@semcore/dropdown-menu";
 <DropdownMenu.List />;
 ```
 
@@ -53,7 +53,7 @@ import DropdownMenu from "@semcore/ui/dropdown-menu";
 DropdownMenu.Menu is a wrap over the `<Dropdown.Popper/>` + `<DropdownMenu.List/>` component. In fact, it is syntactic sugar when no direct access to the `Popper` node is needed.
 
 ```jsx
-import DropdownMenu from "@semcore/ui/dropdown-menu";
+import DropdownMenu from "@semcore/dropdown-menu";
 <DropdownMenu.Menu />;
 ```
 
@@ -62,7 +62,7 @@ import DropdownMenu from "@semcore/ui/dropdown-menu";
 Interactive menu items that are available for selection and switching from the keyboard.
 
 ```jsx
-import DropdownMenu from "@semcore/ui/dropdown-menu";
+import DropdownMenu from "@semcore/dropdown-menu";
 <DropdownMenu.Item />;
 ```
 
@@ -73,7 +73,7 @@ import DropdownMenu from "@semcore/ui/dropdown-menu";
 Content of menu item. Use it if you need Hints, Actions of nested menus.
 
 ```jsx
-import DropdownMenu from "@semcore/ui/dropdown-menu";
+import DropdownMenu from "@semcore/dropdown-menu";
 <DropdownMenu.Item.Content />;
 ```
 
@@ -84,7 +84,7 @@ import DropdownMenu from "@semcore/ui/dropdown-menu";
 Group of interactive menu items.
 
 ```jsx
-import Dropdown from "@semcore/ui/dropdown";
+import Dropdown from "@semcore/dropdown";
 <Dropdown.Group />;
 ```
 
@@ -95,7 +95,7 @@ import Dropdown from "@semcore/ui/dropdown";
 This noninteractive menu item is used to display tips in the list. Using as an `aria-describedby` for `DropdownMenu.Item`.
 
 ```jsx
-import DropdownMenu from "@semcore/ui/dropdown-menu";
+import DropdownMenu from "@semcore/dropdown-menu";
 <DropdownMenu.Item.Hint />;
 ```
 
@@ -120,7 +120,7 @@ The `DropdownMenu.ItemTitle` is deprecated, use `DropdownMenu.Group` instead.
 This noninteractive menu item is used to display the titles in the list. It is a wrap over the `Flex` component.
 
 ```jsx
-import DropdownMenu from "@semcore/ui/dropdown-menu";
+import DropdownMenu from "@semcore/dropdown-menu";
 <DropdownMenu.ItemTitle />;
 ```
 
@@ -135,7 +135,7 @@ The `DropdownMenu.ItemHint` is deprecated, use `DropdownMenu.Item.Hint` or `Drop
 This noninteractive menu item is used to display tips in the list. It is a wrap over the `Flex` component.
 
 ```jsx
-import DropdownMenu from "@semcore/ui/dropdown-menu";
+import DropdownMenu from "@semcore/dropdown-menu";
 <DropdownMenu.ItemHint />;
 ```
 

--- a/website/docs/components/dropdown/dropdown-api.md
+++ b/website/docs/components/dropdown/dropdown-api.md
@@ -13,7 +13,7 @@ The `Dropdown` is a wrap over the `Popper` with the addition of styles, presets 
 The wrap over the `<Popper/>` component.
 
 ```jsx
-import Dropdown from '@semcore/ui/dropdown';
+import Dropdown from '@semcore/dropdown';
 <Dropdown />;
 ```
 
@@ -24,7 +24,7 @@ import Dropdown from '@semcore/ui/dropdown';
 The wrap over the `<Popper.Trigger/>` component.
 
 ```jsx
-import Dropdown from '@semcore/ui/dropdown';
+import Dropdown from '@semcore/dropdown';
 <Dropdown.Trigger />;
 ```
 
@@ -35,7 +35,7 @@ import Dropdown from '@semcore/ui/dropdown';
 The wrap over the `<Popper.Popper/>` component.
 
 ```jsx
-import Dropdown from '@semcore/ui/dropdown';
+import Dropdown from '@semcore/dropdown';
 <Dropdown.Popper />;
 ```
 

--- a/website/docs/components/ellipsis/ellipsis-api.md
+++ b/website/docs/components/ellipsis/ellipsis-api.md
@@ -7,7 +7,7 @@ tabs: Design('ellipsis'), A11y('ellipsis-a11y'), API('ellipsis-api'), Example('e
 ## Ellipsis
 
 ```jsx
-import Ellipsis from '@semcore/ui/ellipsis';
+import Ellipsis from '@semcore/ellipsis';
 <Ellipsis />;
 ```
 

--- a/website/docs/components/feature-popover/feature-popover-api.md
+++ b/website/docs/components/feature-popover/feature-popover-api.md
@@ -9,7 +9,7 @@ tabs: Design('feature-popover'), A11y('feature-popover-a11y'), API('feature-popo
 This is a wrap component, which is completely inherited from `<Popper/>`.
 
 ```jsx
-import FeaturePopover from '@semcore/ui/feature-popover';
+import FeaturePopover from '@semcore/feature-popover';
 <FeaturePopover />;
 ```
 
@@ -20,7 +20,7 @@ import FeaturePopover from '@semcore/ui/feature-popover';
 This is the element, to which `<FeaturePopover.Popper/>` will be attached. It's fully inherited from `<Popper.Trigger/>`.
 
 ```jsx
-import FeaturePopover from '@semcore/ui/feature-popover';
+import FeaturePopover from '@semcore/feature-popover';
 <FeaturePopover.Trigger />;
 ```
 
@@ -31,7 +31,7 @@ import FeaturePopover from '@semcore/ui/feature-popover';
 This is the element, to which `<FeaturePopover.Trigger/>` will be attached. It's fully inherited from `<Popper.Popper/>`.
 
 ```jsx
-import FeaturePopover from '@semcore/ui/feature-popover';
+import FeaturePopover from '@semcore/feature-popover';
 <FeaturePopover.Popper />;
 ```
 
@@ -42,7 +42,7 @@ import FeaturePopover from '@semcore/ui/feature-popover';
 This blinking circle is inherited from `<Box>`.
 
 ```jsx
-import FeaturePopover from '@semcore/ui/feature-popover';
+import FeaturePopover from '@semcore/feature-popover';
 <FeaturePopover.Spot />;
 ```
 

--- a/website/docs/components/feedback-form/feedback-form-api.md
+++ b/website/docs/components/feedback-form/feedback-form-api.md
@@ -8,7 +8,7 @@ tabs: Design('feedback-form'), A11y('feedback-form-a11y'), API('feedback-form-ap
 Ready-made component, using which you may assemble the form for feedback filling. Assembled using our components, and the [react-final-form](https://final-form.org/react) is responsible for the form validation. The component [Form](https://final-form.org/docs/react-final-form/api/Form) of the library `react-final-form`, inside which there is the `SpinContainer`, takes all the properties.
 
 ```jsx
-import FeedbackForm from '@semcore/ui/feedback-form';
+import FeedbackForm from '@semcore/feedback-form';
 <FeedbackForm />;
 ```
 
@@ -19,7 +19,7 @@ import FeedbackForm from '@semcore/ui/feedback-form';
 The pre-configured [Field](https://final-form.org/docs/react-final-form/api/Field) component from the [react-final-form](https://final-form.org/react) library. Inside it there is the `Tooltip`, and you may set the trigger using the property `tag` or `render function`.
 
 ```jsx
-import FeedbackForm from '@semcore/ui/feedback-form';
+import FeedbackForm from '@semcore/feedback-form';
 <FeedbackForm.Item />;
 ```
 
@@ -28,7 +28,7 @@ import FeedbackForm from '@semcore/ui/feedback-form';
 The pre-configured `Box` component.
 
 ```jsx
-import FeedbackForm from '@semcore/ui/feedback-form';
+import FeedbackForm from '@semcore/feedback-form';
 <FeedbackForm.Success />;
 ```
 
@@ -37,7 +37,7 @@ import FeedbackForm from '@semcore/ui/feedback-form';
 The pre-configured `Button` component.
 
 ```jsx
-import FeedbackForm from '@semcore/ui/feedback-form';
+import FeedbackForm from '@semcore/feedback-form';
 <FeedbackForm.Submit />;
 <FeedbackForm.Cancel />;
 ```
@@ -47,7 +47,7 @@ import FeedbackForm from '@semcore/ui/feedback-form';
 The pre-configured `Notice` component.
 
 ```jsx
-import FeedbackForm from '@semcore/ui/feedback-form';
+import FeedbackForm from '@semcore/feedback-form';
 <FeedbackForm.Notice />;
 ```
 
@@ -58,7 +58,7 @@ import FeedbackForm from '@semcore/ui/feedback-form';
 The pre-configured `FeedbackForm` component for [FeedbackRating](/patterns/feedback-rating/feedback-rating).
 
 ```jsx
-import FeedbackRating from '@semcore/ui/feedback-form';
+import FeedbackRating from '@semcore/feedback-form';
 <FeedbackForm.FeedbackRatingProps />;
 ```
 

--- a/website/docs/components/filter-trigger/filter-trigger-api.md
+++ b/website/docs/components/filter-trigger/filter-trigger-api.md
@@ -9,7 +9,7 @@ tabs: Design('filter-trigger'), A11y('filter-trigger-a11y'), API('filter-trigger
 Trigger for filters.
 
 ```js
-import { FilterTrigger } from '@semcore/ui/base-trigger';
+import { FilterTrigger } from '@semcore/base-trigger';
 ```
 
 <TypesView type="FilterTriggerProps" :types={...types} />

--- a/website/docs/components/flags/flags-api.md
+++ b/website/docs/components/flags/flags-api.md
@@ -6,7 +6,7 @@ tabs: Design('flags'), A11y('flags-a11y'), API('flags-api'), Changelog('flags-ch
 ## Flags
 
 ```js
-import Flags from '@semcore/ui/flags';
+import Flags from '@semcore/flags';
 ```
 
 <TypesView type="FlagsProps" :types={...types} />

--- a/website/docs/components/fullscreen-modal/fullscreen-modal-api.md
+++ b/website/docs/components/fullscreen-modal/fullscreen-modal-api.md
@@ -7,7 +7,7 @@ tabs: Design('fullscreen-modal'), A11y('fullscreen-modal-a11y'), API('fullscreen
 ## FullscreenModal
 
 ```js
-import FullscreenModal from '@semcore/ui/fullscreen-modal';
+import FullscreenModal from '@semcore/fullscreen-modal';
 ```
 
 <TypesView type="FullscreenModalProps" :types={...types} />

--- a/website/docs/components/inline-edit/inline-edit-api.md
+++ b/website/docs/components/inline-edit/inline-edit-api.md
@@ -8,7 +8,7 @@ tabs: Design('inline-edit'), A11y('inline-edit-a11y'), API('inline-edit-api'), E
 Wrap over the inline edit elements.
 
 ```jsx
-import InlineEdit from '@semcore/ui/inline-edit';
+import InlineEdit from '@semcore/inline-edit';
 <InlineEdit />;
 ```
 
@@ -19,7 +19,7 @@ import InlineEdit from '@semcore/ui/inline-edit';
 All children of `InlineEdit.View` is displayed when `editable` property of `InlineEdit` is set to `false`. When `editable` property is set to `true`, children elements still persist in DOM, but hidden via CSS opacity.
 
 ```jsx
-import InlineEdit from '@semcore/ui/inline-edit';
+import InlineEdit from '@semcore/inline-edit';
 <InlineEdit.View />;
 ```
 
@@ -28,7 +28,7 @@ import InlineEdit from '@semcore/ui/inline-edit';
 All children of `InlineEdit.Edit` is displayed when `editable` property of `InlineEdit` is set to `true`.
 
 ```jsx
-import InlineEdit from '@semcore/ui/inline-edit';
+import InlineEdit from '@semcore/inline-edit';
 <InlineEdit.Edit />;
 ```
 

--- a/website/docs/components/inline-input/inline-input-api.md
+++ b/website/docs/components/inline-input/inline-input-api.md
@@ -8,7 +8,7 @@ tabs: Design('inline-input'), A11y('inline-input-a11y'), API('inline-input-api')
 Wrap over the inline-input elements.
 
 ```jsx
-import InlineInput from '@semcore/ui/inline-input';
+import InlineInput from '@semcore/inline-input';
 <InlineInput />;
 ```
 
@@ -19,7 +19,7 @@ import InlineInput from '@semcore/ui/inline-input';
 This component represents the native `tag` `input` and accepts all its properties, such as `value` and `onChange`.
 
 ```jsx
-import InlineInput from '@semcore/ui/inline-input';
+import InlineInput from '@semcore/inline-input';
 <InlineInput.Value />;
 ```
 
@@ -32,7 +32,7 @@ The addon inside the container (most often it is an icon or short text) places t
 When you click on Addon, the focus shifts to the input. You can cancel this by returning the `return false` in the `onClick` handler.
 
 ```jsx
-import InlineInput from '@semcore/ui/inline-input';
+import InlineInput from '@semcore/inline-input';
 <InlineInput.Addon />;
 ```
 
@@ -43,7 +43,7 @@ The addon with hint tooltip and icon. By default is displayed with middle-size C
 When `loading` property is provided to `InlineInput`, `InlineInput.ConfirmControl` icon replaced with spinner.
 
 ```jsx
-import InlineInput from '@semcore/ui/inline-input';
+import InlineInput from '@semcore/inline-input';
 <InlineInput.ConfirmControl />;
 ```
 
@@ -54,7 +54,7 @@ import InlineInput from '@semcore/ui/inline-input';
 The addon with hint tooltip and icon. By default is displayed with middle-size Close icon. Addon click triggers `InlineInput` `onCancel` callback.
 
 ```jsx
-import InlineInput from '@semcore/ui/inline-input';
+import InlineInput from '@semcore/inline-input';
 <InlineInput.CancelControl />;
 ```
 

--- a/website/docs/components/input-mask/input-mask-api.md
+++ b/website/docs/components/input-mask/input-mask-api.md
@@ -11,7 +11,7 @@ tabs: Design('input-mask'), A11y('input-mask-a11y'), API('input-mask-api'), Exam
 ## InputMask
 
 ```js
-import InputMask from '@semcore/ui/input-mask';
+import InputMask from '@semcore/input-mask';
 ```
 
 The API is the same as [Input](/components/input/input-api).
@@ -19,7 +19,7 @@ The API is the same as [Input](/components/input/input-api).
 ## InputMask.Value
 
 ```js
-import InputMask from '@semcore/ui/input-mask';
+import InputMask from '@semcore/input-mask';
 <InputMask.Value />;
 ```
 
@@ -28,7 +28,7 @@ import InputMask from '@semcore/ui/input-mask';
 ## InputMask.Addon
 
 ```js
-import InputMask from '@semcore/ui/input-mask';
+import InputMask from '@semcore/input-mask';
 <InputMask.Addon />;
 ```
 

--- a/website/docs/components/input-number/input-number-api.md
+++ b/website/docs/components/input-number/input-number-api.md
@@ -7,7 +7,7 @@ tabs: Design('input-number'), A11y('input-number-a11y'), API('input-number-api')
 ## InputNumber
 
 ```js
-import InputNumber from '@semcore/ui/input-number';
+import InputNumber from '@semcore/input-number';
 ```
 
 <TypesView type="InputNumberProps" :types={...types} />
@@ -15,7 +15,7 @@ import InputNumber from '@semcore/ui/input-number';
 ## InputNumber.Value
 
 ```jsx
-import InputNumber from '@semcore/ui/input-number';
+import InputNumber from '@semcore/input-number';
 <InputNumber.Value />;
 ```
 
@@ -24,7 +24,7 @@ import InputNumber from '@semcore/ui/input-number';
 ## InputNumber.Controls
 
 ```jsx
-import InputNumber from '@semcore/ui/input-number';
+import InputNumber from '@semcore/input-number';
 <InputNumber.Controls />;
 ```
 
@@ -33,7 +33,7 @@ import InputNumber from '@semcore/ui/input-number';
 ## InputNumber.Addon
 
 ```jsx
-import InputNumber from '@semcore/ui/input-number';
+import InputNumber from '@semcore/input-number';
 <InputNumber.Addon />;
 ```
 

--- a/website/docs/components/input-tags/input-tags-api.md
+++ b/website/docs/components/input-tags/input-tags-api.md
@@ -7,7 +7,7 @@ tabs: Design('input-tags'), A11y('input-tags-a11y'), API('input-tags-api'), Exam
 ## InputTags
 
 ```jsx
-import InputTags from '@semcore/ui/input-tags';
+import InputTags from '@semcore/input-tags';
 ```
 
 <TypesView type="InputTagsProps" :types={...types} />
@@ -15,7 +15,7 @@ import InputTags from '@semcore/ui/input-tags';
 ## InputTags.Value
 
 ```jsx
-import InputTags from '@semcore/ui/input-tags';
+import InputTags from '@semcore/input-tags';
 <InputTags.Value />;
 ```
 
@@ -26,7 +26,7 @@ import InputTags from '@semcore/ui/input-tags';
 Styled component [Tag](/components/tag/tag).
 
 ```jsx
-import InputTags from '@semcore/ui/input-tags';
+import InputTags from '@semcore/input-tags';
 <InputTags.Tag />;
 ```
 
@@ -35,7 +35,7 @@ import InputTags from '@semcore/ui/input-tags';
 ## InputTags.Tag.Addon
 
 ```jsx
-import InputTags from '@semcore/ui/input-tags';
+import InputTags from '@semcore/input-tags';
 <InputTags.Tag.Addon />;
 ```
 
@@ -44,7 +44,7 @@ Inherited from the [Tag.Addon](../tag/tag-api#tag-addon) component.
 ## InputTags.Tag.Text
 
 ```jsx
-import InputTags from '@semcore/ui/input-tags';
+import InputTags from '@semcore/input-tags';
 <InputTags.Tag.Text />;
 ```
 
@@ -53,7 +53,7 @@ Inherited from the [Tag.Text](../tag/tag-api#tag-text) component.
 ## InputTags.Tag.Close
 
 ```jsx
-import InputTags from '@semcore/ui/input-tags';
+import InputTags from '@semcore/input-tags';
 <InputTags.Tag.Close />;
 ```
 
@@ -62,7 +62,7 @@ Inherited from the [TagContainer.Close](../tag/tag-api#tagcontainer-close) compo
 ## InputTags.Tag.Circle
 
 ```jsx
-import InputTags from '@semcore/ui/input-tags';
+import InputTags from '@semcore/input-tags';
 <InputTags.Tag.Circle />;
 ```
 

--- a/website/docs/components/input/input-api.md
+++ b/website/docs/components/input/input-api.md
@@ -9,7 +9,7 @@ tabs: Design('input'), A11y('input-a11y'), API('input-api'), Example('input-code
 Wrap over the input elements.
 
 ```jsx
-import Input from '@semcore/ui/input';
+import Input from '@semcore/input';
 <Input />;
 ```
 
@@ -20,7 +20,7 @@ import Input from '@semcore/ui/input';
 This component represents the native `tag` `input` and accepts all its properties, such as `value` and `onChange`.
 
 ```jsx
-import Input from '@semcore/ui/input';
+import Input from '@semcore/input';
 <Input.Value />;
 ```
 
@@ -33,7 +33,7 @@ The addon inside the input (most often it is an icon) places the correct indent 
 When you click on Addon, the focus shifts to the input. You can cancel this by returning the `return false` in the `onMouseDown` handler.
 
 ```jsx
-import Input from '@semcore/ui/input';
+import Input from '@semcore/input';
 <Input.Addon />;
 ```
 

--- a/website/docs/components/link/link-api.md
+++ b/website/docs/components/link/link-api.md
@@ -8,7 +8,7 @@ tabs: Design('link'), A11y('link-a11y'), API('link-api'), Example('link-code'), 
 A modified link component that can be `disabled` and have `Addon` elements. By default, the link is `inline-block` and `no-wrap` – that is, in most cases it's used as a stand-alone component.
 
 ```jsx
-import Link from '@semcore/ui/link';
+import Link from '@semcore/link';
 <Link />;
 ```
 
@@ -19,7 +19,7 @@ import Link from '@semcore/ui/link';
 The addon inside the link (most often an icon) places the correct padding units depending on the size. Takes all properties of the `Box`.
 
 ```jsx
-import Link from '@semcore/ui/link';
+import Link from '@semcore/link';
 <Link.Addon />;
 ```
 
@@ -28,7 +28,7 @@ import Link from '@semcore/ui/link';
 Plain text, it sets correct paddings depending on the size. If only text with no addons is used in the link, it will be wrapped in `Link.Text` automatically. Takes all properties of the `Box`.
 
 ```jsx
-import Link from '@semcore/ui/link';
+import Link from '@semcore/link';
 <Link.Text />;
 ```
 

--- a/website/docs/components/modal/modal-api.md
+++ b/website/docs/components/modal/modal-api.md
@@ -7,7 +7,7 @@ tabs: Design('modal'), A11y('modal-a11y'), API('modal-api'), Example('modal-code
 ## Modal
 
 ```jsx
-import Modal from '@semcore/ui/modal';
+import Modal from '@semcore/modal';
 <Modal />;
 ```
 
@@ -18,7 +18,7 @@ import Modal from '@semcore/ui/modal';
 Component which represents the background. Has all properties as [BoxProps](/layout/box-system/box-system-api) prop does.
 
 ```jsx
-import Modal from '@semcore/ui/modal';
+import Modal from '@semcore/modal';
 <Modal.Overlay />;
 ```
 
@@ -27,7 +27,7 @@ import Modal from '@semcore/ui/modal';
 Component which represents the modal window itself. Has all properties as [BoxProps](/layout/box-system/box-system-api) prop does.
 
 ```jsx
-import Modal from '@semcore/ui/modal';
+import Modal from '@semcore/modal';
 <Modal.Window />;
 ```
 
@@ -36,7 +36,7 @@ import Modal from '@semcore/ui/modal';
 Component which represents the closing icon. The component is the `CloseS` icon with the configured styles. Has all properties as [BoxProps](/layout/box-system/box-system-api) prop and [IconProps](/style/icon/icon-api) prop does.
 
 ```jsx
-import Modal from '@semcore/ui/modal';
+import Modal from '@semcore/modal';
 <Modal.Close />;
 ```
 
@@ -45,7 +45,7 @@ import Modal from '@semcore/ui/modal';
 Component which represents the title. It adds `aria-labelledby` attribute to modal window. Has all properties as [TextProps](/style/typography/typography-api) prop does.
 
 ```jsx
-import Modal from '@semcore/ui/modal';
+import Modal from '@semcore/modal';
 <Modal.Title />;
 ```
 

--- a/website/docs/components/notice-bubble/notice-bubble-api.md
+++ b/website/docs/components/notice-bubble/notice-bubble-api.md
@@ -6,7 +6,7 @@ tabs: Design('notice-bubble'), A11y('notice-bubble-a11y'), API('notice-bubble-ap
 ## NoticeBubbleManager
 
 ```js
-import { noticeBubbleDefaultManager } from '@semcore/ui/notice-bubble';
+import { noticeBubbleDefaultManager } from '@semcore/notice-bubble';
 ```
 
 Manager is a storage of all notice instances, it is able to add, delete and update notices by calling the appropriate methods.
@@ -16,7 +16,7 @@ Manager is a storage of all notice instances, it is able to add, delete and upda
 ## NoticeBubbleContainer
 
 ```js
-import { NoticeBubbleContainer } from '@semcore/ui/notice-bubble';
+import { NoticeBubbleContainer } from '@semcore/notice-bubble';
 ```
 
 Container is a `div` created in the `body` using `React.Portal`. It is inserted once in any part of the application and subscribes to Manager updates (`NoticeBubbleManager`). Later, notices will be rendered to it.

--- a/website/docs/components/notice-global/notice-global-api.md
+++ b/website/docs/components/notice-global/notice-global-api.md
@@ -6,7 +6,7 @@ tabs: Design('notice-global'), A11y('notice-global-a11y'), API('notice-global-ap
 ## Notice
 
 ```jsx
-import NoticeGlobal from '@semcore/ui/notice-global';
+import NoticeGlobal from '@semcore/notice-global';
 <NoticeGlobal />;
 ```
 
@@ -17,7 +17,7 @@ import NoticeGlobal from '@semcore/ui/notice-global';
 The component is inherited from `Box` and is used to insert content in the notification.
 
 ```jsx
-import NoticeGlobal from '@semcore/ui/notice';
+import NoticeGlobal from '@semcore/notice';
 <NoticeGlobal.Content />;
 ```
 
@@ -26,7 +26,7 @@ import NoticeGlobal from '@semcore/ui/notice';
 The component is inherited from `Button` and is used to insert the **Close** button.
 
 ```jsx
-import NoticeGlobal from '@semcore/ui/notice';
+import NoticeGlobal from '@semcore/notice';
 <NoticeGlobal.CloseIcon />;
 ```
 

--- a/website/docs/components/notice/notice-api.md
+++ b/website/docs/components/notice/notice-api.md
@@ -6,7 +6,7 @@ tabs: Design('notice'), A11y('notice-a11y'), API('notice-api'), Example('notice-
 ## Notice
 
 ```jsx
-import Notice from '@semcore/ui/notice';
+import Notice from '@semcore/notice';
 <Notice />;
 ```
 
@@ -17,7 +17,7 @@ import Notice from '@semcore/ui/notice';
 The component is inherited from `Box` and is used to insert a label in the left part of the notice (usually, an icon).
 
 ```jsx
-import Notice from '@semcore/ui/notice';
+import Notice from '@semcore/notice';
 <Notice.label />;
 ```
 
@@ -26,7 +26,7 @@ import Notice from '@semcore/ui/notice';
 The component is inherited from `Box` and is used to insert control components in the lower part of the notice. Usually, it's a button or a group of buttons.
 
 ```jsx
-import Notice from '@semcore/ui/notice';
+import Notice from '@semcore/notice';
 <Notice.Actions />;
 ```
 
@@ -35,7 +35,7 @@ import Notice from '@semcore/ui/notice';
 The component is inherited from `Box` and is used to insert content in the notice.
 
 ```jsx
-import Notice from '@semcore/ui/notice';
+import Notice from '@semcore/notice';
 <Notice.Content />;
 ```
 
@@ -44,7 +44,7 @@ import Notice from '@semcore/ui/notice';
 The component is inherited from `Button` and is used to insert the **Close** button.
 
 ```jsx
-import Notice from '@semcore/ui/notice';
+import Notice from '@semcore/notice';
 <Notice.Close />;
 ```
 
@@ -53,7 +53,7 @@ import Notice from '@semcore/ui/notice';
 The text content of the notice. Inherited from `Text`.
 
 ```jsx
-import Notice from '@semcore/ui/notice';
+import Notice from '@semcore/notice';
 <Notice.Text />;
 ```
 
@@ -62,7 +62,7 @@ import Notice from '@semcore/ui/notice';
 The title of the notice. Inherited from `Text`.
 
 ```jsx
-import Notice from '@semcore/ui/notice';
+import Notice from '@semcore/notice';
 <Notice.Title />;
 ```
 
@@ -71,7 +71,7 @@ import Notice from '@semcore/ui/notice';
 A more convenient component version with posibility to define features through props. For more details, [refer to the example](./notice-code#noticesmart).
 
 ```jsx
-import { NoticeSmart } from '@semcore/ui/notice';
+import { NoticeSmart } from '@semcore/notice';
 <NoticeSmart />;
 ```
 

--- a/website/docs/components/pagination/pagination-api.md
+++ b/website/docs/components/pagination/pagination-api.md
@@ -6,7 +6,7 @@ tabs: Design('pagination'), A11y('pagination-a11y'), API('pagination-api'), Exam
 ## Pagination
 
 ```jsx
-import Pagination from '@semcore/ui/pagination';
+import Pagination from '@semcore/pagination';
 <Pagination />;
 ```
 
@@ -17,7 +17,7 @@ import Pagination from '@semcore/ui/pagination';
 Takes all the properties of the button.
 
 ```jsx
-import Pagination from '@semcore/ui/pagination';
+import Pagination from '@semcore/pagination';
 <Pagination.FirstPage />;
 ```
 
@@ -26,14 +26,14 @@ import Pagination from '@semcore/ui/pagination';
 Takes all the properties of the button.
 
 ```jsx
-import Pagination from '@semcore/ui/pagination';
+import Pagination from '@semcore/pagination';
 <Pagination.NextPage />;
 ```
 
 ## Pagination.PageInput
 
 ```jsx
-import Pagination from '@semcore/ui/pagination';
+import Pagination from '@semcore/pagination';
 <Pagination.PageInput />;
 ```
 
@@ -42,7 +42,7 @@ import Pagination from '@semcore/ui/pagination';
 ## Pagination.PageInput.Value
 
 ```jsx
-import Pagination from '@semcore/ui/pagination';
+import Pagination from '@semcore/pagination';
 <Pagination.PageInput.Value />;
 ```
 
@@ -53,14 +53,14 @@ import Pagination from '@semcore/ui/pagination';
 Takes all the properties of the button.
 
 ```jsx
-import Pagination from '@semcore/ui/pagination';
+import Pagination from '@semcore/pagination';
 <Pagination.PrevPage />;
 ```
 
 ## Pagination.TotalPages
 
 ```jsx
-import Pagination from '@semcore/ui/pagination';
+import Pagination from '@semcore/pagination';
 <Pagination.TotalPages />;
 ```
 

--- a/website/docs/components/pills/pills-api.md
+++ b/website/docs/components/pills/pills-api.md
@@ -7,7 +7,7 @@ tabs: Design('pills'), A11y('pills-a11y'), API('pills-api'), Example('pills-code
 ## Pills
 
 ```jsx
-import Pills from '@semcore/ui/pills';
+import Pills from '@semcore/pills';
 ```
 
 <TypesView type="PillsProps" :types={...types} />
@@ -15,7 +15,7 @@ import Pills from '@semcore/ui/pills';
 ## Pill.Item
 
 ```jsx
-import Pills from '@semcore/ui/pills';
+import Pills from '@semcore/pills';
 <Pills.Item />;
 ```
 
@@ -26,7 +26,7 @@ import Pills from '@semcore/ui/pills';
 The addon inside the pill (most often it is an icon) places the correct indent units depending on the size. Takes all properties of the `Box`.
 
 ```jsx
-import Pills from '@semcore/ui/pills';
+import Pills from '@semcore/pills';
 <Pills.Item.Addon />;
 ```
 
@@ -35,7 +35,7 @@ import Pills from '@semcore/ui/pills';
 Plain text, it sets correct indents depending on the size. If only text with no addons is used in the pill, it will be wrapped in `Pills.Item.Text` automatically. Takes all properties of the `Box`.
 
 ```jsx
-import Pills from '@semcore/ui/pills';
+import Pills from '@semcore/pills';
 <Pills.Item.Text />;
 ```
 

--- a/website/docs/components/product-head/product-head-api.md
+++ b/website/docs/components/product-head/product-head-api.md
@@ -9,7 +9,7 @@ tabs: Design('product-head'), A11y('product-head-a11y'), API('product-head-api')
 The wrapping with paddings. Not responsive (so far), but can be dragged.
 
 ```jsx
-import ProductHead from '@semcore/ui/product-head';
+import ProductHead from '@semcore/product-head';
 <ProductHead />;
 ```
 
@@ -18,7 +18,7 @@ import ProductHead from '@semcore/ui/product-head';
 The header is divided into lines with components. They are divided from each other with equal paddings – `my={2}`.
 
 ```jsx
-import ProductHead from '@semcore/ui/product-head';
+import ProductHead from '@semcore/product-head';
 <ProductHead.Row />;
 ```
 
@@ -27,7 +27,7 @@ import ProductHead from '@semcore/ui/product-head';
 The component for setting the paddings between the links.
 
 ```jsx
-import ProductHead from '@semcore/ui/product-head';
+import ProductHead from '@semcore/product-head';
 <ProductHead.Links />;
 ```
 
@@ -36,7 +36,7 @@ import ProductHead from '@semcore/ui/product-head';
 The component for setting the paddings between the buttons.
 
 ```jsx
-import ProductHead from '@semcore/ui/product-head';
+import ProductHead from '@semcore/product-head';
 <ProductHead.Buttons />;
 ```
 
@@ -45,7 +45,7 @@ import ProductHead from '@semcore/ui/product-head';
 The header’ heading component
 
 ```jsx
-import { Title } from '@semcore/ui/product-head';
+import { Title } from '@semcore/product-head';
 <Title />;
 ```
 
@@ -56,7 +56,7 @@ import { Title } from '@semcore/ui/product-head';
 The component for output of the information on the project and the global filters of the report. The information is divided with a vertical line.
 
 ```jsx
-import { Info } from '@semcore/ui/product-head';
+import { Info } from '@semcore/product-head';
 <Info />;
 ```
 
@@ -65,7 +65,7 @@ import { Info } from '@semcore/ui/product-head';
 One unit with the information on the project or global filter.
 
 ```jsx
-import { Info } from '@semcore/ui/product-head';
+import { Info } from '@semcore/product-head';
 <Info.Item />;
 ```
 

--- a/website/docs/components/progress-bar/progress-bar-api.md
+++ b/website/docs/components/progress-bar/progress-bar-api.md
@@ -9,7 +9,7 @@ tabs: Design('progress-bar'), A11y('progress-bar-a11y'), API('progress-bar-api')
 The component responsible for the background under the progress bar value.
 
 ```jsx
-import ProgressBar from '@semcore/ui/progress-bar';
+import ProgressBar from '@semcore/progress-bar';
 <ProgressBar />;
 ```
 
@@ -20,7 +20,7 @@ import ProgressBar from '@semcore/ui/progress-bar';
 The component responsible for the progress bar value.
 
 ```jsx
-import ProgressBar from '@semcore/ui/progress-bar';
+import ProgressBar from '@semcore/progress-bar';
 <ProgressBar.Value />;
 ```
 

--- a/website/docs/components/radio/radio-api.md
+++ b/website/docs/components/radio/radio-api.md
@@ -9,7 +9,7 @@ tabs: Design('radio'), A11y('radio-a11y'), API('radio-api'), Example('radio-code
 A component used to simplify working with multiple radio buttons.
 
 ```jsx
-import { RadioGroup } from '@semcore/ui/radio';
+import { RadioGroup } from '@semcore/radio';
 <RadioGroup />;
 ```
 
@@ -20,7 +20,7 @@ import { RadioGroup } from '@semcore/ui/radio';
 This is an independent radio component.
 
 ```jsx
-import Radio from '@semcore/ui/radio';
+import Radio from '@semcore/radio';
 <Radio />;
 ```
 
@@ -29,7 +29,7 @@ import Radio from '@semcore/ui/radio';
 ## Radio.Value
 
 ```jsx
-import Radio from '@semcore/ui/radio';
+import Radio from '@semcore/radio';
 <Radio.Value />;
 ```
 
@@ -38,7 +38,7 @@ import Radio from '@semcore/ui/radio';
 ## Radio.Text
 
 ```jsx
-import Radio from '@semcore/ui/radio';
+import Radio from '@semcore/radio';
 <Radio.Text />;
 ```
 

--- a/website/docs/components/select/select-api.md
+++ b/website/docs/components/select/select-api.md
@@ -11,7 +11,7 @@ tabs: Design('select'), A11y('select-a11y'), API('select-api'), Example('select-
 ## Select
 
 ```jsx
-import Select from '@semcore/ui/select';
+import Select from '@semcore/select';
 <Select />;
 ```
 
@@ -22,7 +22,7 @@ import Select from '@semcore/ui/select';
 A wrapper over [DropdownMenu.Trigger](../dropdown-menu/dropdown-menu-api#dropdownmenu-trigger) with [ButtonTrigger](/components/base-trigger/base-trigger-api#buttontrigger) as the default tag.
 
 ```jsx
-import Select from '@semcore/ui/select';
+import Select from '@semcore/select';
 <Select.Trigger />;
 ```
 
@@ -31,7 +31,7 @@ import Select from '@semcore/ui/select';
 A wrapper over `Select.Popper` and `Select.List`, with all props passed to `Select.List`.
 
 ```jsx
-import Select from '@semcore/ui/select';
+import Select from '@semcore/select';
 <Select.Menu />;
 ```
 
@@ -40,7 +40,7 @@ import Select from '@semcore/ui/select';
 A wrapper over [DropdownMenu.Popper](../dropdown-menu/dropdown-menu-api#dropdownmenu-popper).
 
 ```jsx
-import Select from '@semcore/ui/select';
+import Select from '@semcore/select';
 <Select.Popper />;
 ```
 
@@ -49,7 +49,7 @@ import Select from '@semcore/ui/select';
 A wrapper over [DropdownMenu.List](../dropdown-menu/dropdown-menu-api#dropdownmenu-list).
 
 ```jsx
-import Select from '@semcore/ui/select';
+import Select from '@semcore/select';
 <Select.List />;
 ```
 
@@ -58,7 +58,7 @@ import Select from '@semcore/ui/select';
 A wrapper over [Input](../input/input-api) with a `Search` icon and a **Clear** button as default addons.
 
 ```jsx
-import { InputSearch } from '@semcore/ui/select';
+import { InputSearch } from '@semcore/select';
 <InputSearch />;
 ```
 
@@ -67,7 +67,7 @@ import { InputSearch } from '@semcore/ui/select';
 A wrapper over [Dropdown.Group](../dropdown-menu/dropdown-menu-api#dropdown-group).
 
 ```jsx
-import Select from '@semcore/ui/select';
+import Select from '@semcore/select';
 <Select.Group />;
 ```
 
@@ -76,7 +76,7 @@ import Select from '@semcore/ui/select';
 A wrapper over [DropdownMenu.Item](../dropdown-menu/dropdown-menu-api#dropdownmenu-item) with additional props.
 
 ```jsx
-import Select from '@semcore/ui/select';
+import Select from '@semcore/select';
 <Select.Option />;
 ```
 
@@ -87,7 +87,7 @@ import Select from '@semcore/ui/select';
 Styled [Flex](/layout/box-system/box-system-api#flex).
 
 ```jsx
-import Select from '@semcore/ui/select';
+import Select from '@semcore/select';
 <Select.Option.Hint />;
 ```
 
@@ -96,7 +96,7 @@ import Select from '@semcore/ui/select';
 A styled [Box](/layout/box-system/box-system-api#box) that looks like a checkbox.
 
 ```jsx
-import Select from '@semcore/ui/select';
+import Select from '@semcore/select';
 <Select.Option.Checkbox />;
 ```
 
@@ -111,7 +111,7 @@ The `Select.OptionHint` is deprecated, use `Select.Option.Hint` or `Select.Group
 :::
 
 ```jsx
-import Select from '@semcore/ui/select';
+import Select from '@semcore/select';
 <Select.OptionHint />;
 ```
 
@@ -122,7 +122,7 @@ The `Select.OptionTitle` is deprecated, use `Select.Group` with `title` prop ins
 :::
 
 ```jsx
-import Select from '@semcore/ui/select';
+import Select from '@semcore/select';
 <Select.OptionTitle />;
 ```
 

--- a/website/docs/components/side-panel/side-panel-api.md
+++ b/website/docs/components/side-panel/side-panel-api.md
@@ -7,7 +7,7 @@ tabs: Design('side-panel'), A11y('side-panel-a11y'), API('side-panel-api'), Exam
 ## SidePanel
 
 ```jsx
-import SidePanel from '@semcore/ui/side-panel';
+import SidePanel from '@semcore/side-panel';
 <SidePanel />;
 ```
 
@@ -16,7 +16,7 @@ import SidePanel from '@semcore/ui/side-panel';
 ## SidePanel.Overlay
 
 ```jsx
-import SidePanel from '@semcore/ui/side-panel';
+import SidePanel from '@semcore/side-panel';
 <SidePanel.Overlay />;
 ```
 
@@ -25,7 +25,7 @@ This is a wrap over the [Box](/layout/box-system/box-system-api#box) component.
 ## SidePanel.Panel
 
 ```jsx
-import SidePanel from '@semcore/ui/side-panel';
+import SidePanel from '@semcore/side-panel';
 <SidePanel.Panel />;
 ```
 
@@ -36,7 +36,7 @@ This is a wrap over [Box](/layout/box-system/box-system-api#box) and `FocusLock`
 ## SidePanel.Close
 
 ```jsx
-import SidePanel from '@semcore/ui/side-panel';
+import SidePanel from '@semcore/side-panel';
 <SidePanel.Close />;
 ```
 

--- a/website/docs/components/skeleton/skeleton-api.md
+++ b/website/docs/components/skeleton/skeleton-api.md
@@ -7,7 +7,7 @@ tabs: Design('skeleton'), A11y('skeleton-a11y'), API('skeleton-api'), Example('s
 ## Skeleton
 
 ```jsx
-import Skeleton from '@semcore/ui/skeleton';
+import Skeleton from '@semcore/skeleton';
 <Skeleton />;
 ```
 
@@ -16,7 +16,7 @@ import Skeleton from '@semcore/ui/skeleton';
 ## Skeleton.Text
 
 ```jsx
-import Skeleton from '@semcore/ui/skeleton';
+import Skeleton from '@semcore/skeleton';
 <Skeleton.Text />;
 ```
 
@@ -25,7 +25,7 @@ import Skeleton from '@semcore/ui/skeleton';
 ## LineChartSkeleton
 
 ```jsx
-import { LineChartSkeleton } from '@semcore/ui/skeleton';
+import { LineChartSkeleton } from '@semcore/skeleton';
 ```
 
 <TypesView type="LineChartSkeletonProps" :types={...types} />
@@ -33,7 +33,7 @@ import { LineChartSkeleton } from '@semcore/ui/skeleton';
 ## AreaChartSkeleton
 
 ```jsx
-import { AreaChartSkeleton } from '@semcore/ui/skeleton';
+import { AreaChartSkeleton } from '@semcore/skeleton';
 ```
 
 <TypesView type="AreaChartSkeletonProps" :types={...types} />
@@ -41,7 +41,7 @@ import { AreaChartSkeleton } from '@semcore/ui/skeleton';
 ## BarChartSkeleton
 
 ```jsx
-import { BarChartSkeleton } from '@semcore/ui/skeleton';
+import { BarChartSkeleton } from '@semcore/skeleton';
 ```
 
 <TypesView type="BarChartSkeletonProps" :types={...types} />
@@ -49,7 +49,7 @@ import { BarChartSkeleton } from '@semcore/ui/skeleton';
 ## HistogramChartSkeleton
 
 ```jsx
-import { HistogramChartSkeleton } from '@semcore/ui/skeleton';
+import { HistogramChartSkeleton } from '@semcore/skeleton';
 ```
 
 <TypesView type="HistogramChartSkeletonProps" :types={...types} />
@@ -57,7 +57,7 @@ import { HistogramChartSkeleton } from '@semcore/ui/skeleton';
 ## DonutChartSkeleton
 
 ```jsx
-import { DonutChartSkeleton } from '@semcore/ui/skeleton';
+import { DonutChartSkeleton } from '@semcore/skeleton';
 ```
 
 <TypesView type="DonutChartSkeletonProps" :types={...types} />
@@ -65,25 +65,25 @@ import { DonutChartSkeleton } from '@semcore/ui/skeleton';
 ## BubbleChartSkeleton
 
 ```jsx
-import { BubbleChartSkeleton } from '@semcore/ui/skeleton';
+import { BubbleChartSkeleton } from '@semcore/skeleton';
 ```
 
 ## ScatterPlotChartSkeleton
 
 ```jsx
-import { ScatterPlotChartSkeleton } from '@semcore/ui/skeleton';
+import { ScatterPlotChartSkeleton } from '@semcore/skeleton';
 ```
 
 ## VennChartSkeleton
 
 ```jsx
-import { VennChartSkeleton } from '@semcore/ui/skeleton';
+import { VennChartSkeleton } from '@semcore/skeleton';
 ```
 
 ## RadialTreeChartSkeleton
 
 ```jsx
-import { RadialTreeChartSkeleton } from '@semcore/ui/skeleton';
+import { RadialTreeChartSkeleton } from '@semcore/skeleton';
 ```
 
 <script setup>import { data as types } from '@types.data.ts';</script>

--- a/website/docs/components/slider/slider-api.md
+++ b/website/docs/components/slider/slider-api.md
@@ -7,7 +7,7 @@ tabs: Design('slider'), A11y('slider-a11y'), API('slider-api'), Example('slider-
 ## Slider
 
 ```jsx
-import Slider from '@semcore/ui/slider';
+import Slider from '@semcore/slider';
 <Slider />;
 ```
 
@@ -16,21 +16,21 @@ import Slider from '@semcore/ui/slider';
 ## Slider.Bar
 
 ```jsx
-import Slider from '@semcore/ui/slider';
+import Slider from '@semcore/slider';
 <Slider.Bar />;
 ```
 
 ## Slider.Knob
 
 ```jsx
-import Slider from '@semcore/ui/slider';
+import Slider from '@semcore/slider';
 <Slider.Knob />;
 ```
 
 ## Slider.Options & Slider.Item
 
 ```jsx
-import Slider from '@semcore/ui/slider';
+import Slider from '@semcore/slider';
 <Slider.Options>
   <Slider.Item />
 </Slider.Options>;

--- a/website/docs/components/spin-container/spin-container-api.md
+++ b/website/docs/components/spin-container/spin-container-api.md
@@ -7,7 +7,7 @@ tabs: Design('spin-container'), A11y('spin-container-a11y'), API('spin-container
 ## SpinContainer
 
 ```jsx
-import SpinContainer from '@semcore/ui/spin-container';
+import SpinContainer from '@semcore/spin-container';
 <SpinContainer />;
 ```
 
@@ -18,7 +18,7 @@ import SpinContainer from '@semcore/ui/spin-container';
 Content wrapper with proper `position` and `z-index`.
 
 ```jsx
-import SpinContainer from '@semcore/ui/spin-container';
+import SpinContainer from '@semcore/spin-container';
 <SpinContainer.Content />;
 ```
 
@@ -27,7 +27,7 @@ import SpinContainer from '@semcore/ui/spin-container';
 A semitransparent box with a [Spin](../spin/spin.md) displayed over the content.
 
 ```jsx
-import SpinContainer from '@semcore/ui/spin-container';
+import SpinContainer from '@semcore/spin-container';
 <SpinContainer.Overlay />;
 ```
 

--- a/website/docs/components/spin/spin-api.md
+++ b/website/docs/components/spin/spin-api.md
@@ -9,7 +9,7 @@ tabs: Design('spin'), A11y('spin-a11y'), API('spin-api'), Example('spin-code'), 
 Note that Spin is built with SVG inside.
 
 ```jsx
-import Spin from '@semcore/ui/spin';
+import Spin from '@semcore/spin';
 <Spin />;
 ```
 

--- a/website/docs/components/switch/switch-api.md
+++ b/website/docs/components/switch/switch-api.md
@@ -7,7 +7,7 @@ tabs: Design('switch'), A11y('switch-a11y'), API('switch-api'), Example('switch-
 ## Switch
 
 ```jsx
-import Switch from '@semcore/ui/switch';
+import Switch from '@semcore/switch';
 <Switch />;
 ```
 
@@ -16,7 +16,7 @@ import Switch from '@semcore/ui/switch';
 ## Switch.Value
 
 ```jsx
-import Switch from '@semcore/ui/switch';
+import Switch from '@semcore/switch';
 <Switch.Value />;
 ```
 
@@ -25,7 +25,7 @@ import Switch from '@semcore/ui/switch';
 ## Switch.Addon
 
 ```jsx
-import Switch from '@semcore/ui/switch';
+import Switch from '@semcore/switch';
 <Switch.Addon />;
 ```
 

--- a/website/docs/components/tab-line/tab-line-api.md
+++ b/website/docs/components/tab-line/tab-line-api.md
@@ -9,7 +9,7 @@ tabs: Design('tab-line'), A11y('tab-line-a11y'), API('tab-line-api'), Example('t
 Wrap over the tab elements.
 
 ```jsx
-import TabLine from '@semcore/ui/tab-line';
+import TabLine from '@semcore/tab-line';
 <TabLine />;
 ```
 
@@ -20,7 +20,7 @@ import TabLine from '@semcore/ui/tab-line';
 This tab element may contain `Addon` and `Text`. The structure is similar to [Button](/components/button/button). It takes some properties of the TabLine (for example, `size`, `disabled`) and can override them.
 
 ```jsx
-import TabLine from '@semcore/ui/tab-line';
+import TabLine from '@semcore/tab-line';
 <TabLine.Item />;
 ```
 
@@ -31,7 +31,7 @@ import TabLine from '@semcore/ui/tab-line';
 The addon inside the tab (most commonly an icon) sets the correct indents depending on the size. It takes all the properties of the `Box`.
 
 ```jsx
-import TabLine from '@semcore/ui/tab-line';
+import TabLine from '@semcore/tab-line';
 <TabLine.Item.Addon />;
 ```
 
@@ -42,7 +42,7 @@ This ordinary text sets the appropriate indents depending on the size. If a simp
 It takes all the properties of the `Box`.
 
 ```jsx
-import TabLine from '@semcore/ui/tab-line';
+import TabLine from '@semcore/tab-line';
 <TabLine.Item.Text />;
 ```
 

--- a/website/docs/components/tab-panel/tab-panel-api.md
+++ b/website/docs/components/tab-panel/tab-panel-api.md
@@ -10,7 +10,7 @@ tabs: Design('tab-panel'), A11y('tab-panel-a11y'), API('tab-panel-api'), Example
 Wrap over the tab elements.
 
 ```jsx
-import TabPanel from '@semcore/ui/tab-panel';
+import TabPanel from '@semcore/tab-panel';
 <TabPanel />;
 ```
 
@@ -25,7 +25,7 @@ It's recommended to use links in tabs, so that user can open them in a new brows
 :::
 
 ```jsx
-import TabPanel from '@semcore/ui/tab-panel';
+import TabPanel from '@semcore/tab-panel';
 <TabPanel.Item />;
 ```
 
@@ -38,7 +38,7 @@ The addon inside the tab (most commonly an icon) sets the correct indents depend
 It takes all the properties of the `Box`.
 
 ```jsx
-import TabPanel from '@semcore/ui/tab-panel';
+import TabPanel from '@semcore/tab-panel';
 <TabPanel.Item.Addon />;
 ```
 
@@ -49,7 +49,7 @@ This ordinary text sets the appropriate indents depending on the size. If plain 
 It takes all the properties of the `Box`.
 
 ```jsx
-import TabPanel from '@semcore/ui/tab-panel';
+import TabPanel from '@semcore/tab-panel';
 <TabPanel.Item.Text />;
 ```
 

--- a/website/docs/components/tag/tag-api.md
+++ b/website/docs/components/tag/tag-api.md
@@ -17,7 +17,7 @@ tabs: Design('tag'), A11y('tag-a11y'), API('tag-api'), Example('tag-code'), Chan
 Accepts all `Box` properties.
 
 ```jsx
-import { TagContainer } from '@semcore/ui/tag';
+import { TagContainer } from '@semcore/tag';
 <TagContainer.Close />;
 ```
 
@@ -28,7 +28,7 @@ The addon inside the tag (most commonly an icon) sets the correct indents depend
 It takes all the properties of the `Box`.
 
 ```jsx
-import Tag from '@semcore/ui/tag';
+import Tag from '@semcore/tag';
 <Tag.Addon />;
 ```
 
@@ -39,7 +39,7 @@ This ordinary text sets the appropriate indents depending on the size. If a simp
 It takes all the properties of the `Box`.
 
 ```jsx
-import Tag from '@semcore/ui/tag';
+import Tag from '@semcore/tag';
 <Tag.Text />;
 ```
 
@@ -50,7 +50,7 @@ A special addon for round elements inside a tag (most often a picture) places th
 It accepts all `Box` properties.
 
 ```jsx
-import Tag from '@semcore/ui/tag';
+import Tag from '@semcore/tag';
 <Tag.Circle />;
 ```
 

--- a/website/docs/components/textarea/textarea-api.md
+++ b/website/docs/components/textarea/textarea-api.md
@@ -9,7 +9,7 @@ tabs: Design('textarea'), A11y('textarea-a11y'), API('textarea-api'), Example('t
 Component represents native `textarea` tag and takes all its properties such as `value` and `defaultValue`.
 
 ```jsx
-import Textarea from '@semcore/ui/textarea';
+import Textarea from '@semcore/textarea';
 <Textarea />;
 ```
 

--- a/website/docs/components/time-picker/time-picker-api.md
+++ b/website/docs/components/time-picker/time-picker-api.md
@@ -7,7 +7,7 @@ tabs: Design('time-picker'), A11y('time-picker-a11y'), API('time-picker-api'), E
 ## Time picker
 
 ```jsx
-import Timepicker from '@semcore/ui/time-picker';
+import Timepicker from '@semcore/time-picker';
 ```
 
 <TypesView type="TimePickerProps" :types={...types} />
@@ -17,7 +17,7 @@ import Timepicker from '@semcore/ui/time-picker';
 <TypesView type="TimePickerItemProps" :types={...types} />
 
 ```jsx
-import Timepicker from '@semcore/ui/time-picker';
+import Timepicker from '@semcore/time-picker';
 <Timepicker>
   <Timepicker.Hours />
   <Timepicker.Minutes />
@@ -29,7 +29,7 @@ import Timepicker from '@semcore/ui/time-picker';
 <TypesView type="TimePickerFormatProps" :types={...types} />
 
 ```jsx
-import Timepicker from '@semcore/ui/time-picker';
+import Timepicker from '@semcore/time-picker';
 <Timepicker.Format />;
 ```
 
@@ -38,7 +38,7 @@ import Timepicker from '@semcore/ui/time-picker';
 It is a usual `span`-element, it takes the HTML-attributes available for it.
 
 ```jsx
-import Timepicker from '@semcore/ui/time-picker';
+import Timepicker from '@semcore/time-picker';
 <Timepicker.Separator />;
 ```
 

--- a/website/docs/components/tooltip/tooltip-api.md
+++ b/website/docs/components/tooltip/tooltip-api.md
@@ -13,7 +13,7 @@ tabs: Design('tooltip'), A11y('tooltip-a11y'), API('tooltip-api'), Example('tool
 ## Tooltip
 
 ```jsx
-import Tooltip from '@semcore/ui/tooltip';
+import Tooltip from '@semcore/tooltip';
 <Tooltip />;
 ```
 
@@ -22,7 +22,7 @@ import Tooltip from '@semcore/ui/tooltip';
 ## Hint
 
 ```jsx
-import { Hint } from '@semcore/ui/tooltip';
+import { Hint } from '@semcore/tooltip';
 <Hint />;
 ```
 
@@ -31,7 +31,7 @@ import { Hint } from '@semcore/ui/tooltip';
 ## DescriptionTooltip
 
 ```jsx
-import { DescriptionTooltip } from '@semcore/ui/tooltip';
+import { DescriptionTooltip } from '@semcore/tooltip';
 <DescriptionTooltip />;
 ```
 

--- a/website/docs/components/widget-empty/widget-empty-api.md
+++ b/website/docs/components/widget-empty/widget-empty-api.md
@@ -9,7 +9,7 @@ tabs: Design('widget-empty'), A11y('widget-empty-a11y'), API('widget-empty-api')
 Use this state to display "No data" (including "Nothing found") empty states.
 
 ```jsx
-import { NoData } from '@semcore/ui/widget-empty';
+import { NoData } from '@semcore/widget-empty';
 <NoData />;
 ```
 
@@ -20,7 +20,7 @@ import { NoData } from '@semcore/ui/widget-empty';
 Use this state to display error messages.
 
 ```jsx
-import { Error } from '@semcore/ui/widget-empty';
+import { Error } from '@semcore/widget-empty';
 <Error />;
 ```
 
@@ -31,7 +31,7 @@ import { Error } from '@semcore/ui/widget-empty';
 Use this component to display customized empty states.
 
 ```jsx
-import WidgetEmpty from '@semcore/ui/widget-empty';
+import WidgetEmpty from '@semcore/widget-empty';
 <WidgetEmpty />;
 ```
 

--- a/website/docs/components/wizard/wizard-api.md
+++ b/website/docs/components/wizard/wizard-api.md
@@ -6,7 +6,7 @@ tabs: Design('wizard'), A11y('wizard-a11y'), API('wizard-api'), Example('wizard-
 ## Wizard
 
 ```jsx
-import Wizard from '@semcore/ui/wizard';
+import Wizard from '@semcore/wizard';
 <Wizard />;
 ```
 
@@ -15,7 +15,7 @@ import Wizard from '@semcore/ui/wizard';
 ## Wizard.Sidebar
 
 ```jsx
-import Wizard from '@semcore/ui/wizard';
+import Wizard from '@semcore/wizard';
 <Wizard.Sidebar />;
 ```
 
@@ -24,7 +24,7 @@ import Wizard from '@semcore/ui/wizard';
 ## Wizard.Stepper
 
 ```jsx
-import Wizard from '@semcore/ui/wizard';
+import Wizard from '@semcore/wizard';
 <Wizard.Stepper />;
 ```
 
@@ -35,7 +35,7 @@ import Wizard from '@semcore/ui/wizard';
 ## Wizard.Step
 
 ```jsx
-import Wizard from '@semcore/ui/wizard';
+import Wizard from '@semcore/wizard';
 <Wizard.Step />;
 ```
 
@@ -44,7 +44,7 @@ import Wizard from '@semcore/ui/wizard';
 ## Wizard.StepBack
 
 ```jsx
-import Wizard from '@semcore/ui/wizard';
+import Wizard from '@semcore/wizard';
 <Wizard.StepBack />;
 ```
 
@@ -53,7 +53,7 @@ import Wizard from '@semcore/ui/wizard';
 ## Wizard.StepNext
 
 ```jsx
-import Wizard from '@semcore/ui/wizard';
+import Wizard from '@semcore/wizard';
 <Wizard.StepNext />;
 ```
 

--- a/website/docs/core-principles/writing-code/wrapping-components.md
+++ b/website/docs/core-principles/writing-code/wrapping-components.md
@@ -7,7 +7,7 @@ title: Wrapping components
 Intergalactic components are built with polymorphic typings, that means that you can provide `tag` property that will redefine allowed properties list.
 
 ```tsx
-import Button from '@semcore/ui/button';
+import Button from '@semcore/button';
 <Button
   href="">
 // Error: Property 'href' does not exist on type... // [!code error]
@@ -37,7 +37,7 @@ import Button from '@semcore/ui/button';
 The `tag` property is not included in the component's props, so you can't make wrappers by simple using that.
 
 ```tsx
-import Select, { SelectProps } from '@semcore/ui/select'
+import Select, { SelectProps } from '@semcore/select'
 
 const WrappedSelect = ({
   tag, // Property tag does not exist on type SelectProps. // [!code error]

--- a/website/docs/data-display/area-chart/area-chart-api.md
+++ b/website/docs/data-display/area-chart/area-chart-api.md
@@ -11,7 +11,7 @@ For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-cha
 ## Chart.Area
 
 ```js
-import { Chart } from '@semcore/ui/d3-chart';
+import { Chart } from '@semcore/d3-chart';
 ```
 
 <TypesView type="AreaChartProps" :types={...types} />
@@ -21,7 +21,7 @@ import { Chart } from '@semcore/ui/d3-chart';
 It have children components `Dots, Null`.
 
 ```js
-import { Area } from '@semcore/ui/d3-chart';
+import { Area } from '@semcore/d3-chart';
 
 <Area>
   <Area.Dots />

--- a/website/docs/data-display/bar-chart/bar-chart-api.md
+++ b/website/docs/data-display/bar-chart/bar-chart-api.md
@@ -11,7 +11,7 @@ For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-cha
 ## Chart.Bar
 
 ```js
-import { Chart } from '@semcore/ui/d3-chart';
+import { Chart } from '@semcore/d3-chart';
 ```
 
 <TypesView type="BarChartProps" :types={...types} />
@@ -19,7 +19,7 @@ import { Chart } from '@semcore/ui/d3-chart';
 ## Bar
 
 ```js
-import { Bar } from '@semcore/ui/d3-chart';
+import { Bar } from '@semcore/d3-chart';
 ```
 
 <TypesView type="BarProps" :types={...types} />

--- a/website/docs/data-display/bar-horizontal-compact/bar-horizontal-compact-api.md
+++ b/website/docs/data-display/bar-horizontal-compact/bar-horizontal-compact-api.md
@@ -12,7 +12,7 @@ For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-cha
 
 
 ```js
-import { Chart } from '@semcore/ui/d3-chart';
+import { Chart } from '@semcore/d3-chart';
 ```
 
 <TypesView type="CompactHorizontalBarChartProps" :types={...types} />
@@ -22,7 +22,7 @@ import { Chart } from '@semcore/ui/d3-chart';
 
 
 ```js
-import { CompactHorizontalBar } from '@semcore/ui/d3-chart';
+import { CompactHorizontalBar } from '@semcore/d3-chart';
 
 <CompactHorizontalBar />;
 ```

--- a/website/docs/data-display/bar-horizontal/bar-horizontal-api.md
+++ b/website/docs/data-display/bar-horizontal/bar-horizontal-api.md
@@ -13,7 +13,7 @@ For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-cha
 For Horizontal view, you should pass `true` into `invertAxis` prop
 
 ```js
-import { Chart } from '@semcore/ui/d3-chart';
+import { Chart } from '@semcore/d3-chart';
 ```
 
 <TypesView type="BarChartProps" :types={...types} />
@@ -23,7 +23,7 @@ import { Chart } from '@semcore/ui/d3-chart';
 Horizontal chart Bar.
 
 ```js
-import { HorizontalBar } from '@semcore/ui/d3-chart';
+import { HorizontalBar } from '@semcore/d3-chart';
 ```
 
 <TypesView type="HorizontalBarProps" :types={...types} />
@@ -33,7 +33,7 @@ import { HorizontalBar } from '@semcore/ui/d3-chart';
 It have children components `Bar, HorizontalBar`.
 
 ```js
-import { GroupBar } from '@semcore/ui/d3-chart';
+import { GroupBar } from '@semcore/d3-chart';
 
 <GroupBar>
   <GroupBar.Bar />

--- a/website/docs/data-display/bubble-chart/bubble-chart-api.md
+++ b/website/docs/data-display/bubble-chart/bubble-chart-api.md
@@ -11,7 +11,7 @@ For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-cha
 ## Chart.Bubble
 
 ```js
-import { Chart } from '@semcore/ui/d3-chart';
+import { Chart } from '@semcore/d3-chart';
 ```
 
 <TypesView type="BubbleChartProps" :types={...types} />
@@ -19,7 +19,7 @@ import { Chart } from '@semcore/ui/d3-chart';
 ## Bubble
 
 ```js
-import { Bubble } from '@semcore/ui/d3-chart';
+import { Bubble } from '@semcore/d3-chart';
 
 <Bubble />;
 ```
@@ -29,7 +29,7 @@ import { Bubble } from '@semcore/ui/d3-chart';
 ## Bubble.Tooltip
 
 ```js
-import { Bubble } from '@semcore/ui/d3-chart';
+import { Bubble } from '@semcore/d3-chart';
 
 <Bubble.Tooltip />;
 ```
@@ -37,7 +37,7 @@ import { Bubble } from '@semcore/ui/d3-chart';
 ## Bubble.Circle
 
 ```js
-import { Bubble } from '@semcore/ui/d3-chart';
+import { Bubble } from '@semcore/d3-chart';
 
 <Bubble.Circle />;
 ```

--- a/website/docs/data-display/chart-legend/chart-legend-api.md
+++ b/website/docs/data-display/chart-legend/chart-legend-api.md
@@ -9,7 +9,7 @@ tabs: Design('chart-legend'), API('chart-legend-api'), Example('chart-legend-cod
 For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-chart/d3-chart-api).
 
 ```js
-import { ChartLegend } from '@semcore/ui/d3-chart';
+import { ChartLegend } from '@semcore/d3-chart';
 
 <ChartLegend />;
 ```

--- a/website/docs/data-display/cigarette-chart/cigarette-chart-api.md
+++ b/website/docs/data-display/cigarette-chart/cigarette-chart-api.md
@@ -11,7 +11,7 @@ For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-cha
 ## Chart.Cigarette
 
 ```js
-import { Chart } from '@semcore/ui/d3-chart';
+import { Chart } from '@semcore/d3-chart';
 ```
 
 <TypesView type="CigaretteChartProps" :types={...types} />

--- a/website/docs/data-display/d3-chart/d3-chart-api.md
+++ b/website/docs/data-display/d3-chart/d3-chart-api.md
@@ -9,7 +9,7 @@ tabs: Design('d3-chart'), A11y('d3-chart-a11y'), API('d3-chart-api'), Example('d
 Root element for all charts.
 
 ```js
-import { Plot } from '@semcore/ui/d3-chart';
+import { Plot } from '@semcore/d3-chart';
 ```
 
 <TypesView type="PlotProps" :types={...types} />
@@ -19,7 +19,7 @@ import { Plot } from '@semcore/ui/d3-chart';
 It have children components `Title, Ticks, Grid`.
 
 ```js
-import { XAxis, YAxis } from '@semcore/ui/d3-chart';
+import { XAxis, YAxis } from '@semcore/d3-chart';
 
 <XAxis>
   <XAxis.Title />
@@ -43,7 +43,7 @@ import { XAxis, YAxis } from '@semcore/ui/d3-chart';
 Container watch to size block.
 
 ```js
-import { ResponsiveContainer } from '@semcore/ui/d3-chart';
+import { ResponsiveContainer } from '@semcore/d3-chart';
 ```
 
 <TypesView type="ResponsiveContainerProps" :types={...types} />
@@ -53,7 +53,7 @@ import { ResponsiveContainer } from '@semcore/ui/d3-chart';
 Component for show line after hover on chart.
 
 ```js
-import { HoverLine } from '@semcore/ui/d3-chart';
+import { HoverLine } from '@semcore/d3-chart';
 ```
 
 <TypesView type="HoverProps" :types={...types} />
@@ -63,7 +63,7 @@ import { HoverLine } from '@semcore/ui/d3-chart';
 Component for show sector after hover on chart.
 
 ```js
-import { HoverRect } from '@semcore/ui/d3-chart';
+import { HoverRect } from '@semcore/d3-chart';
 ```
 
 <TypesView type="HoverProps" :types={...types} />
@@ -91,7 +91,7 @@ type Pattern = {
 ## ReferenceLine
 
 ```js
-import { ReferenceLine } from '@semcore/ui/d3-chart';
+import { ReferenceLine } from '@semcore/d3-chart';
 ```
 
 <TypesView type="ReferenceLineProps" :types={...types} />

--- a/website/docs/data-display/d3-chart/d3-chart-code.md
+++ b/website/docs/data-display/d3-chart/d3-chart-code.md
@@ -134,7 +134,7 @@ By default, the title is set to the right for the Oy axis, and at the top for th
 ::: sandbox
 
 <script lang="tsx">
-import { Bar, XAxis, Plot, YAxis } from '@semcore/ui/d3-chart';
+import { Bar, XAxis, Plot, YAxis } from '@semcore/d3-chart';
   export Demo from 'stories/components/d3-chart/docs/examples/d3-chart/axes-titles.tsx';
 </script>
 
@@ -315,7 +315,7 @@ The fill data is used for rendering charts like an `Area` while symbol data is n
 
 <script  lang="tsx">
 import React from 'react';
-import { Chart, Pattern } from '@semcore/ui/d3-chart';
+import { Chart, Pattern } from '@semcore/d3-chart';
 
 const customPattern: Pattern = {
   fill: {

--- a/website/docs/data-display/donut-chart/donut-chart-api.md
+++ b/website/docs/data-display/donut-chart/donut-chart-api.md
@@ -11,7 +11,7 @@ For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-cha
 ## Chart.Donut
 
 ```js
-import { Chart } from '@semcore/ui/d3-chart';
+import { Chart } from '@semcore/d3-chart';
 ```
 
 <TypesView type="DonutChartProps" :types={...types} />
@@ -21,7 +21,7 @@ import { Chart } from '@semcore/ui/d3-chart';
 It have children components `Pie`, `Label`, `EmptyData`.
 
 ```js
-import { Donut } from '@semcore/ui/d3-chart';
+import { Donut } from '@semcore/d3-chart';
 
 <Donut>
   <Donut.EmptyData />

--- a/website/docs/data-display/histogram-chart/histogram-chart-api.md
+++ b/website/docs/data-display/histogram-chart/histogram-chart-api.md
@@ -19,7 +19,7 @@ For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-cha
 For Horizontal view, you should pass `true` into `invertAxis` prop
 
 ```js
-import { Chart } from '@semcore/ui/d3-chart';
+import { Chart } from '@semcore/d3-chart';
 ```
 
 <TypesView type="HistogramChartProps" :types={...types} />

--- a/website/docs/data-display/line-chart/line-chart-api.md
+++ b/website/docs/data-display/line-chart/line-chart-api.md
@@ -11,7 +11,7 @@ For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-cha
 ## Chart.Line
 
 ```js
-import { Chart } from '@semcore/ui/d3-chart';
+import { Chart } from '@semcore/d3-chart';
 ```
 
 <TypesView type="LineChartProps" :types={...types} />
@@ -21,7 +21,7 @@ import { Chart } from '@semcore/ui/d3-chart';
 It have children components `Dots, Null`.
 
 ```js
-import { Line } from '@semcore/ui/d3-chart';
+import { Line } from '@semcore/d3-chart';
 
 <Line>
   <Line.Dots />

--- a/website/docs/data-display/radar-chart/radar-chart-api.md
+++ b/website/docs/data-display/radar-chart/radar-chart-api.md
@@ -9,7 +9,7 @@ tabs: Design('radar-chart'), API('radar-chart-api'), Examples('radar-chart-code'
 For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-chart/d3-chart-api).
 
 ```js
-import { Radar } from '@semcore/ui/d3-chart';
+import { Radar } from '@semcore/d3-chart';
 
 <Radar/>;
 ```
@@ -19,7 +19,7 @@ import { Radar } from '@semcore/ui/d3-chart';
 ## Radar.Axis
 
 ```js
-import { Radar } from '@semcore/ui/d3-chart';
+import { Radar } from '@semcore/d3-chart';
 
 <Radar.Axis/>;
 ```
@@ -29,7 +29,7 @@ import { Radar } from '@semcore/ui/d3-chart';
 ## Radar.Axis.Labels
 
 ```js
-import { Radar } from '@semcore/ui/d3-chart';
+import { Radar } from '@semcore/d3-chart';
 
 <Radar.Axis.Labels/>;
 ```
@@ -39,7 +39,7 @@ import { Radar } from '@semcore/ui/d3-chart';
 ## Radar.Axis.Ticks
 
 ```js
-import { Radar } from '@semcore/ui/d3-chart';
+import { Radar } from '@semcore/d3-chart';
 
 <Radar.Axis.Ticks/>;
 ```
@@ -49,7 +49,7 @@ import { Radar } from '@semcore/ui/d3-chart';
 ## Radar.Polygon
 
 ```js
-import { Radar } from '@semcore/ui/d3-chart';
+import { Radar } from '@semcore/d3-chart';
 
 <Radar.Polygon/>;
 ```
@@ -59,7 +59,7 @@ import { Radar } from '@semcore/ui/d3-chart';
 ## Radar.Polygon.Line
 
 ```js
-import { Radar } from '@semcore/ui/d3-chart';
+import { Radar } from '@semcore/d3-chart';
 
 <Radar.Polygon.Line/>;
 ```
@@ -69,7 +69,7 @@ import { Radar } from '@semcore/ui/d3-chart';
 ## Radar.Polygon.Dots
 
 ```js
-import { Radar } from '@semcore/ui/d3-chart';
+import { Radar } from '@semcore/d3-chart';
 
 <Radar.Polygon.Dots/>;
 ```

--- a/website/docs/data-display/radial-tree-chart/radial-tree-chart-api.md
+++ b/website/docs/data-display/radial-tree-chart/radial-tree-chart-api.md
@@ -13,7 +13,7 @@ For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-cha
 This chart has children `Title` component.
 
 ```js
-import { RadialTree } from '@semcore/ui/d3-chart';
+import { RadialTree } from '@semcore/d3-chart';
 
 <RadialTree>
   <RadialTree.Radian>

--- a/website/docs/data-display/scatterplot-chart/scatterplot-chart-api.md
+++ b/website/docs/data-display/scatterplot-chart/scatterplot-chart-api.md
@@ -11,7 +11,7 @@ For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-cha
 ## Chart.ScatterPlot
 
 ```js
-import { Chart } from '@semcore/ui/d3-chart';
+import { Chart } from '@semcore/d3-chart';
 ```
 
 <TypesView type="ScatterPlotChartProps" :types={...types} />
@@ -19,7 +19,7 @@ import { Chart } from '@semcore/ui/d3-chart';
 ## ScatterPlot
 
 ```js
-import { ScatterPlot } from '@semcore/ui/d3-chart';
+import { ScatterPlot } from '@semcore/d3-chart';
 
 <ScatterPlot />;
 ```

--- a/website/docs/data-display/stacked-area-chart/stacked-area-chart-api.md
+++ b/website/docs/data-display/stacked-area-chart/stacked-area-chart-api.md
@@ -13,7 +13,7 @@ For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-cha
 For stacked view, you should pass `true` into `stacked` prop
 
 ```js
-import { Chart } from '@semcore/ui/d3-chart';
+import { Chart } from '@semcore/d3-chart';
 ```
 
 <TypesView type="AreaChartProps" :types={...types} />
@@ -23,7 +23,7 @@ import { Chart } from '@semcore/ui/d3-chart';
 It have children components `Area`.
 
 ```js
-import { StackedArea } from '@semcore/ui/d3-chart';
+import { StackedArea } from '@semcore/d3-chart';
 
 <StackedArea>
   <StackedArea.Area />

--- a/website/docs/data-display/stacked-bar-chart/stacked-bar-chart-api.md
+++ b/website/docs/data-display/stacked-bar-chart/stacked-bar-chart-api.md
@@ -13,7 +13,7 @@ For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-cha
 For stacked view, you should pass `stack` into `type` prop
 
 ```js
-import { Chart } from '@semcore/ui/d3-chart';
+import { Chart } from '@semcore/d3-chart';
 ```
 
 <TypesView type="BarChartProps" :types={...types} />
@@ -23,7 +23,7 @@ import { Chart } from '@semcore/ui/d3-chart';
 It have children components `Bar, HorizontalBar`.
 
 ```js
-import { StackBar } from '@semcore/ui/d3-chart';
+import { StackBar } from '@semcore/d3-chart';
 
 <StackBar>
   <StackBar.Bar />

--- a/website/docs/data-display/stacked-horizontal-bar/stacked-horizontal-bar-api.md
+++ b/website/docs/data-display/stacked-horizontal-bar/stacked-horizontal-bar-api.md
@@ -13,7 +13,7 @@ For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-cha
 For Horizontal view, you should pass `true` into `invertAxis` prop, for stack view, you should pass `stack` into `type` prop.
 
 ```js
-import { Chart } from '@semcore/ui/d3-chart';
+import { Chart } from '@semcore/d3-chart';
 ```
 
 <TypesView type="BarChartProps" :types={...types} />
@@ -23,7 +23,7 @@ import { Chart } from '@semcore/ui/d3-chart';
 It have children components `Bar, HorizontalBar`.
 
 ```js
-import { StackBar } from '@semcore/ui/d3-chart';
+import { StackBar } from '@semcore/d3-chart';
 
 <StackBar>
   <StackBar.Bar />

--- a/website/docs/data-display/venn-chart/venn-chart-api.md
+++ b/website/docs/data-display/venn-chart/venn-chart-api.md
@@ -11,7 +11,7 @@ For all common D3 chart properties, refer to [D3 chart API](/data-display/d3-cha
 ## Chart.Venn
 
 ```js
-import { Chart } from '@semcore/ui/d3-chart';
+import { Chart } from '@semcore/d3-chart';
 ```
 
 <TypesView type="VennChartProps" :types={...types} />
@@ -21,7 +21,7 @@ import { Chart } from '@semcore/ui/d3-chart';
 It have children components `Circle`, `Intersection`.
 
 ```js
-import { Venn } from '@semcore/ui/d3-chart';
+import { Venn } from '@semcore/d3-chart';
 
 <Venn>
   <Venn.Circle />

--- a/website/docs/get-started-guide/dev-starter-guide/dev-starter-guide.md
+++ b/website/docs/get-started-guide/dev-starter-guide/dev-starter-guide.md
@@ -143,7 +143,7 @@ import { Box } from '@semcore/base-components';
 `Box` serves as the foundation for other components, making its features available throughout the entire library. For example:
 
 ```jsx
-import Button from '@semcore/ui/button';
+import Button from '@semcore/button';
 
 <Button tag="a" mb={2} w="200px">
   Still Box 🙀
@@ -154,7 +154,7 @@ Additionally, consider exploring the [Flex](/layout/box-system/box-system-api#fl
 
 
 ```jsx
-import { Flex } from '@semcore/ui/base-components';
+import { Flex } from '@semcore/base-components';
 
 <Flex justifyContent="center" alignItems="center" />;
 ```

--- a/website/docs/get-started-guide/dev-starter-guide/production-tips.md
+++ b/website/docs/get-started-guide/dev-starter-guide/production-tips.md
@@ -82,12 +82,12 @@ There are two ways to implement SSR.
 
 This method will work for you if you're not using the **@semcore/shadow-loader** package (see [CSS extract](#css-extract)).
 
-Use the **@semcore/ui/core** package and the `sstyled.getStyles` function which will return `style` tags with all the necessary styles:
+Use the **@semcore/core** package and the `sstyled.getStyles` function which will return `style` tags with all the necessary styles:
 
 ```jsx
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { sstyled } from '@semcore/ui/core';
+import { sstyled } from '@semcore/core';
 import App from './App';
 
 const body = ReactDOM.renderToString(<App />);

--- a/website/docs/layout/box-system/box-system-api.md
+++ b/website/docs/layout/box-system/box-system-api.md
@@ -9,7 +9,7 @@ tabs: Spacing system('box-system-spacing'), API('box-system-api'), Example('box-
 Component responsible for spacings and sizes 📐
 
 ```jsx
-import { Box } from '@semcore/ui/base-components';
+import { Box } from '@semcore/base-components';
 <Box />;
 ```
 
@@ -20,7 +20,7 @@ import { Box } from '@semcore/ui/base-components';
 The layout building component is a wrapper over CSS-flex. It inherits all properties from `Box`.
 
 ```jsx
-import { Flex } from '@semcore/ui/base-components';
+import { Flex } from '@semcore/base-components';
 <Flex />;
 ```
 

--- a/website/docs/patterns/global-errors/global-errors-api.md
+++ b/website/docs/patterns/global-errors/global-errors-api.md
@@ -8,7 +8,7 @@ tabs: Design('global-errors'), A11y('global-errors-a11y'), API('global-errors-ap
 The component that can be used to display any global errors on the page.
 
 ```jsx
-import Error from '@semcore/ui/errors';
+import Error from '@semcore/errors';
 <Error />;
 ```
 
@@ -19,7 +19,7 @@ import Error from '@semcore/ui/errors';
 Error title. Extends for `<Box/>`.
 
 ```jsx
-import Error from '@semcore/ui/errors';
+import Error from '@semcore/errors';
 <Error.Title />;
 ```
 
@@ -28,7 +28,7 @@ import Error from '@semcore/ui/errors';
 Error description. Extends for `<Box/>`.
 
 ```jsx
-import Error from '@semcore/ui/errors';
+import Error from '@semcore/errors';
 <Error.Description />;
 ```
 
@@ -37,7 +37,7 @@ import Error from '@semcore/ui/errors';
 Container for controls. Extends for `<Box/>`.
 
 ```jsx
-import Error from '@semcore/ui/errors';
+import Error from '@semcore/errors';
 <Error.Controls />;
 ```
 
@@ -46,7 +46,7 @@ import Error from '@semcore/ui/errors';
 Template for the 403 error: user has no access to the page.
 
 ```jsx
-import { AccessDenied } from '@semcore/ui/errors';
+import { AccessDenied } from '@semcore/errors';
 <AccessDenied />;
 ```
 
@@ -57,7 +57,7 @@ import { AccessDenied } from '@semcore/ui/errors';
 Template for the global state for the period of technical works.
 
 ```jsx
-import { Maintenance } from '@semcore/ui/errors';
+import { Maintenance } from '@semcore/errors';
 <Maintenance />;
 ```
 
@@ -68,7 +68,7 @@ import { Maintenance } from '@semcore/ui/errors';
 Template for the 500 error, caused by some technical problems.
 
 ```jsx
-import { PageError } from '@semcore/ui/errors';
+import { PageError } from '@semcore/errors';
 <PageError />;
 ```
 
@@ -79,7 +79,7 @@ import { PageError } from '@semcore/ui/errors';
 Template for the 404 error: page not found.
 
 ```jsx
-import { PageNotFound } from '@semcore/ui/errors';
+import { PageNotFound } from '@semcore/errors';
 <PageNotFound />;
 ```
 
@@ -90,7 +90,7 @@ import { PageNotFound } from '@semcore/ui/errors';
 Template for the 404 error, but for a project page.
 
 ```jsx
-import { ProjectNotFound } from '@semcore/ui/errors';
+import { ProjectNotFound } from '@semcore/errors';
 <ProjectNotFound />;
 ```
 

--- a/website/docs/style/css-injection/css-injection-local.md
+++ b/website/docs/style/css-injection/css-injection-local.md
@@ -48,7 +48,7 @@ Write your own styles for our components using one of the following methods:
 * CSS-in-JS
 
 ```jsx
-import { sstyled } from '@semcore/ui/core';
+import { sstyled } from '@semcore/core';
 const styles = sstyled.css`
   SWhatever {
     some-styles: 'Cool';
@@ -71,7 +71,7 @@ import styles from './custom.shadow.css';
 Pass the new styles to the `styles` property of our component:
 
 ```jsx
-import Button from '@semcore/ui/Button';
+import Button from '@semcore/button';
 export default (props) => <Button styles={styles} {...props} />;
 ```
 
@@ -90,8 +90,8 @@ Look at the source of styles in GitHub, styles are written in the same format.
 **You can use variables as properties:**
 
 ```jsx
-import { sstyled } from '@semcore/ui/core';
-import Button from '@semcore/ui/button';
+import { sstyled } from '@semcore/core';
+import Button from '@semcore/button';
 
 const styles = sstyled.css`
   SButton {

--- a/website/docs/style/icon/icon-api.md
+++ b/website/docs/style/icon/icon-api.md
@@ -8,7 +8,7 @@ tabs: Design('icon'), A11y('icon-a11y'), API('icon-api'), Example('icon-code'), 
 Any icon can be obtained using a template.
 
 ```js
-import IconNameSize from '@semcore/ui/icon/iconName/size';
+import IconNameSize from '@semcore/icon/iconName/size';
 ```
 
 <TypesView type="IconProps" :types={...types} />

--- a/website/docs/style/illustration/illustration-api.md
+++ b/website/docs/style/illustration/illustration-api.md
@@ -6,7 +6,7 @@ tabs: Design('illustration'), A11y('illustration-a11y'), API('illustration-api')
 ## Illustration
 
 ```jsx
-import Coffee from '@semcore/ui/illustration/Coffee';
+import Coffee from '@semcore/illustration/Coffee';
 <Coffee />;
 ```
 
@@ -17,7 +17,7 @@ import Coffee from '@semcore/ui/illustration/Coffee';
 Any illustration can be obtained using a template.
 
 ```js
-import IllustrationName from '@semcore/ui/illustration/illustrationName';
+import IllustrationName from '@semcore/illustration/illustrationName';
 ```
 
 ## getIllustrationPath

--- a/website/docs/style/typography/typography-api.md
+++ b/website/docs/style/typography/typography-api.md
@@ -52,17 +52,8 @@ import { Blockquote } from '@semcore/typography';
 
 ## FormatText
 
-A wrapper component required to add styles to native tags.
-
-::: tip
-Note that the component is in another package `intergalactic/format-text`.
+::: warning
+`FormatText` is deprecated. To style native tags, wrap them in `Text`. Refer to the [Native typography tags example](./typography-code#native-typography-tags)
 :::
-
-```jsx
-import FormatText from '@semcore/format-text';
-<FormatText />;
-```
-
-<TypesView type="FormatTextProps" :types={...types} />
 
 <script setup>import { data as types } from '@types.data.ts';</script>

--- a/website/docs/style/typography/typography-api.md
+++ b/website/docs/style/typography/typography-api.md
@@ -8,7 +8,7 @@ tabs: Design('typography'), A11y('typography-a11y'), API('typography-api'), Exam
 It's a main component for text in our interfaces. By default, this is a `span` tag.
 
 ```jsx
-import { Text } from '@semcore/ui/typography';
+import { Text } from '@semcore/typography';
 <Text />;
 ```
 
@@ -19,7 +19,7 @@ import { Text } from '@semcore/ui/typography';
 A list tagged with ʻul`. It's possible to set a custom marker for all items.
 
 ```jsx
-import { List } from '@semcore/ui/typography';
+import { List } from '@semcore/typography';
 <List />;
 ```
 
@@ -31,7 +31,7 @@ A list item tagged with `li`. It's possible to set a custom marker.
 Also, it is possible to customise content with `<List.Item.Content />`;
 
 ```jsx
-import { List } from '@semcore/ui/typography';
+import { List } from '@semcore/typography';
 <List.Item />;
 <List.Item.Content />;
 ```
@@ -44,7 +44,7 @@ import { List } from '@semcore/ui/typography';
 Quotes from great people 🙊
 
 ```jsx
-import { Blockquote } from '@semcore/ui/typography';
+import { Blockquote } from '@semcore/typography';
 <Blockquote />;
 ```
 
@@ -59,7 +59,7 @@ Note that the component is in another package `intergalactic/format-text`.
 :::
 
 ```jsx
-import FormatText from '@semcore/ui/format-text';
+import FormatText from '@semcore/format-text';
 <FormatText />;
 ```
 

--- a/website/docs/table-group/data-table/data-table-api.md
+++ b/website/docs/table-group/data-table/data-table-api.md
@@ -6,7 +6,7 @@ tabs: Design('data-table'), A11y('data-table-a11y'), API('data-table-api'), Exam
 ## DataTable
 
 ```jsx
-import DataTable from '@semcore/ui/data-table';
+import DataTable from '@semcore/data-table';
 <DataTable />;
 ```
 

--- a/website/docs/utils/neighbor-location/neighbor-location-api.md
+++ b/website/docs/utils/neighbor-location/neighbor-location-api.md
@@ -15,7 +15,7 @@ Use the `neighborLocation` component property instead.
 Root wrapper-component doesn't create a node but provides a context for defining neighbors.
 
 ```jsx
-import NeighborLocation from '@semcore/ui/base-components';
+import NeighborLocation from '@semcore/base-components';
 
 <NeighborLocation />;
 ```
@@ -27,7 +27,7 @@ import NeighborLocation from '@semcore/ui/base-components';
 Component for detect neighbors.
 
 ```jsx
-import NeighborLocation from '@semcore/ui/base-components';
+import NeighborLocation from '@semcore/base-components';
 
 <NeighborLocation.Detect />;
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

1. Removed /ui/ from import paths in docs (examples, api, and some other pages)
2. Added deprecated warning for FormatText in typography API, forgot to do it earlier
3. Removed some redundant code from Skeleton in Table example

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
