### PR TITLE
UIK-3517 Added missed types description

### DIFF
--- a/semcore/base-components/CHANGELOG.md
+++ b/semcore/base-components/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.2] - 2025-07-14
+
+### Changed
+
+- Type description for `PopperPopperProps`/`PopperProps`/`ScrollAreaProps`/`ScrollBarProps`/`BoxProps`.
+
 ## [16.1.1] - 2025-07-04
 
 ### Changed

--- a/semcore/base-components/src/components/flex-box/Box/useBox.tsx
+++ b/semcore/base-components/src/components/flex-box/Box/useBox.tsx
@@ -154,9 +154,9 @@ export type BoxProps = StyledProps & {
   bottom?: number | string;
   /** CSS `right` property */
   right?: number | string;
-
+  /** CSS `zIndex` property */
   zIndex?: number;
-
+  /** Box content */
   children?: React.ReactNode;
 };
 

--- a/semcore/base-components/src/components/popper/Popper.types.ts
+++ b/semcore/base-components/src/components/popper/Popper.types.ts
@@ -73,7 +73,7 @@ export type PopperProps = OutsideClickProps &
     computeStyles?: Partial<OptionsComputeStyles>;
     /** PopperJS modifier settings responsible for subscribing to global events */
     eventListeners?: Partial<OptionsEventListeners>;
-    /** @ignore */
+    /** Internal */
     onFirstUpdate?: Options['onFirstUpdate'];
     /**
      * Flag for disable Popover (if true, it will close Popper and it will not respond to handlers)
@@ -83,11 +83,12 @@ export type PopperProps = OutsideClickProps &
     /**
      * Disabled focus trap, autofocus and focus return
      */
-    disableEnforceFocus?: boolean /**
+    disableEnforceFocus?: boolean;
+    /**
      * If enabled, after reaching the end of popper the browser focus goes to the start of popper and vice versa.
      * If disabled, after reading the end of popper the browser focus returns to trigger and popper is being closed.
      * @default `true` (`false` in Tooltip)
-     */;
+    */
     focusLoop?: boolean;
     /**
      * If enabled, you will need to use setTrigger function from children rendering function to set popper trigger.
@@ -97,7 +98,7 @@ export type PopperProps = OutsideClickProps &
      * If set, popper will be placed near the place mouse cursor entered the trigger
      */
     cursorAnchoring?: boolean;
-
+    /** Sets a margin that reduces the maximum size of the popper  */
     popperMargin?: number;
   };
 
@@ -134,7 +135,7 @@ export type PopperPopperProps = BoxProps &
    * @deprecated
    */
     keyboardFocused?: boolean;
-
+    /** Automatically focus a popper when it opens */
     autoFocus?: boolean | 'enforced';
   };
 

--- a/semcore/base-components/src/components/scroll-area/ScrollBar.types.ts
+++ b/semcore/base-components/src/components/scroll-area/ScrollBar.types.ts
@@ -39,9 +39,13 @@ export type ScrollAreaProps = BoxProps & {
    */
   disableAutofocusToContent?: boolean;
 
+  /** Top offset for scroll positioning */
   topOffset?: number;
+  /** Right offset for scroll positioning */
   rightOffset?: number;
+  /** Bottom offset for scroll positioning */
   bottomOffset?: number;
+  /** Left offset for scroll positioning */
   leftOffset?: number;
 
   /**
@@ -68,7 +72,7 @@ export interface IScrollBarProps extends ScrollBarProps, UnknownProperties {}
 export type ScrollBarProps = BoxProps & {
   /** The direction of the scroll that can be calculated automatically  */
   orientation?: 'horizontal' | 'vertical';
-
+  /** Reference to the scrollable container element */
   container?: React.RefObject<HTMLElement>;
 };
 

--- a/semcore/base-trigger/CHANGELOG.md
+++ b/semcore/base-trigger/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.2.5] - 2025-07-14
+
+### Changed
+
+- Type description for `FilterTriggerProps`.
+
 ## [16.2.4] - 2025-07-07
 
 ### Changed

--- a/semcore/base-trigger/src/index.d.ts
+++ b/semcore/base-trigger/src/index.d.ts
@@ -68,6 +68,7 @@ export interface IFilterTriggerProps extends FilterTriggerProps, UnknownProperti
 export type FilterTriggerProps = BaseTriggerProps & {
   /** Click on the filter cleaning cross */
   onClear?: (event: React.SyntheticEvent) => void;
+  /** Specifies the locale for i18n support */
   locale?: string;
   /** List of props that will be added to the select inside of filter */
   includeInputProps?: string[];

--- a/semcore/breadcrumbs/CHANGELOG.md
+++ b/semcore/breadcrumbs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.2.4] - 2025-07-14
+
+### Changed
+
+- Type description for `BreadcrumbsProps` & `BreadcrumbsItemProps`.
+
 ## [16.2.3] - 2025-07-04
 
 ### Changed

--- a/semcore/breadcrumbs/src/index.d.ts
+++ b/semcore/breadcrumbs/src/index.d.ts
@@ -8,6 +8,7 @@ export type BreadcrumbsProps = BoxProps & {
    * Links divider
    * */
   separator?: React.ReactNode;
+  /** Specifies the locale for i18n support */
   locale?: string;
 };
 
@@ -16,6 +17,7 @@ export interface IBreadcrumbsItemProps extends BreadcrumbsItemProps, UnknownProp
 export type BreadcrumbsItemProps = BoxProps & {
   /** The property is responsible for the activity of the element */
   active?: boolean;
+  /** Specifies the locale for i18n support */
   locale?: string;
 };
 

--- a/semcore/bulk-textarea/CHANGELOG.md
+++ b/semcore/bulk-textarea/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.2.4] - 2025-07-14
+
+### Changed
+
+- Type description for `BulkTextareaProps`.
+
 ## [16.2.3] - 2025-07-04
 
 ### Changed

--- a/semcore/bulk-textarea/src/BulkTextarea.types.ts
+++ b/semcore/bulk-textarea/src/BulkTextarea.types.ts
@@ -7,29 +7,43 @@ import type { ErrorsNavigationProps } from './components/ErrorsNavigation';
 import type { InputFieldProps } from './components/InputField/InputField';
 
 export type BulkTextareaProps<T extends string | string[]> = {
+  /** The current value */
   value?: InputFieldProps<T>['value'];
+  /** Callback when the value changes */
   onChange?: InputFieldProps<T>['onBlur'];
+  /** Placeholder text */
   placeholder?: InputFieldProps<T>['placeholder'];
+  /** Component size */
   size?: InputFieldProps<T>['size'];
+  /** State for show errors or valid(green) borders */
   state?: InputFieldProps<T>['state'];
+  /** Defines whether the textarea is disabled */
   disabled?: InputFieldProps<T>['disabled'];
+  /** Defines whether the textarea is readonly */
   readonly?: InputFieldProps<T>['readonly'];
-
+  /** Minimum number of rows to display */
   minRows?: InputFieldProps<T>['minRows'];
+  /** Maximum number of rows to display */
   maxRows?: InputFieldProps<T>['maxRows'];
-
+  /** A moment when a validation occurs */
   validateOn?: InputFieldProps<T>['validateOn'];
+  /** A function to valide the line */
   lineValidation?: InputFieldProps<T>['lineValidation'];
+  /** Line delimeters */
   linesDelimiters?: InputFieldProps<T>['linesDelimiters'];
+  /** Defines the props for paste action */
   pasteProps?: InputFieldProps<T>['pasteProps'];
-
+  /** Maximum number of allowed lines/values */
   maxLines?: InputFieldProps<T>['maxLines'];
+  /** Function to process individual lines during input */
   lineProcessing?: InputFieldProps<T>['lineProcessing'];
-
+  /** List of errors */
   errors?: InputFieldProps<T>['errors'];
+  /** Defines whether to show errors or not */
   showErrors?: boolean;
-
+  /** Internal */
   onErrorsChange?: InputFieldProps<T>['onErrorsChange'];
+  /** Internal */
   onShowErrorsChange?: InputFieldProps<T>['onShowErrorsChange'];
 };
 

--- a/semcore/carousel/CHANGELOG.md
+++ b/semcore/carousel/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.5] - 2025-07-14
+
+### Changed
+
+-  Type description for `CarouselProps`.
+
 ## [16.1.4] - 2025-07-04
 
 ### Changed

--- a/semcore/carousel/CHANGELOG.md
+++ b/semcore/carousel/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Changed
 
--  Type description for `CarouselProps`.
+- Type description for `CarouselProps`.
 
 ## [16.1.4] - 2025-07-04
 

--- a/semcore/carousel/src/Carousel.types.ts
+++ b/semcore/carousel/src/Carousel.types.ts
@@ -19,8 +19,9 @@ export type CarouselProps = BoxProps & {
   /** Disables infinite items change in the carousel
    * @default false */
   bounded?: boolean;
-  /** @ignore  */
+  /** Internal */
   step?: number;
+  /** Specifies the locale for i18n support */
   locale?: string;
   /** Enable zoom feature for carousel items */
   zoom?: boolean;

--- a/semcore/checkbox/CHANGELOG.md
+++ b/semcore/checkbox/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.5] - 2025-07-14
+
+### Changed
+
+- Type description for `CheckboxProps`.
+
 ## [16.0.4] - 2025-07-04
 
 ### Changed

--- a/semcore/checkbox/src/index.d.ts
+++ b/semcore/checkbox/src/index.d.ts
@@ -9,7 +9,9 @@ export type CheckboxState = 'normal' | 'invalid';
 /** @deprecated */
 export interface ICheckboxProps extends CheckboxProps, UnknownProperties {}
 export type CheckboxProps = BoxProps & {
+  /** Callback when the value changes */
   onChange?: (checked: boolean, e?: React.SyntheticEvent<HTMLInputElement>) => void;
+  /** Controls the checked state of the checkbox (controlled mode) */
   checked?: boolean;
   /** Default state of uncontrolled checkbox */
   defaultChecked?: boolean;

--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.8] - 2025-07-14
+
+### Changed
+
+- Type description for `PlotProps`/`ReferenceLineProps`/`AreaChartProps`/`BarChartProps`/`BubbleChartProps`/`CigaretteChartProps`/`DonutChartProps`/`HistogramChartProps`/`LineChartProps`/`RadialTreeProps`/`ScatterPlotChartProps`/`VennChartProps`/`CompactHorizontalBarChartProps`.
+
 ## [16.0.7] - 2025-07-03
 
 ### Fixed

--- a/semcore/d3-chart/src/RadialTree.tsx
+++ b/semcore/d3-chart/src/RadialTree.tsx
@@ -109,6 +109,7 @@ export type RadialTreeProps = {
    * Used to define the active radian in controlled way. Active radian is highlighted with inreased cap size.
    */
   activeKey?: string | null;
+  /** Callback when active key changes */
   onActiveKeyChange?: (activeKey: string | null) => void;
   /**
    * Default value for `activeKey` property.

--- a/semcore/d3-chart/src/component/Chart/AreaChart.type.ts
+++ b/semcore/d3-chart/src/component/Chart/AreaChart.type.ts
@@ -9,11 +9,17 @@ import type { interpolateValue } from '../../utils';
 export type AreaChartData = Array<Record<string, number | typeof interpolateValue | Date>>;
 
 export type AreaChartProps = BaseChartProps<AreaChartData> & {
+  /** Field name that groups the data points */
   groupKey: string;
+  /** Custom x-axis scale */
   xScale?: ScaleLinear<any, any> | ScaleTime<any, any>;
+  /** Custom y-axis scale */
   yScale?: ScaleLinear<any, any>;
+  /** Controls whether to display dots on the area chart lines */
   showDots?: boolean;
+  /** D3 curve factory for line interpolation (e.g., curveLinear, curveCardinal) */
   curve?: CurveFactory;
+  /**  Enables stacked area chart mode */
   stacked?: boolean;
 };
 

--- a/semcore/d3-chart/src/component/Chart/BarChart.type.ts
+++ b/semcore/d3-chart/src/component/Chart/BarChart.type.ts
@@ -16,15 +16,18 @@ type BarKey = string;
 export type BarChartData = Array<Record<BarKey, string | number | Date>>;
 
 export type BarChartProps = BaseChartProps<BarChartData> & {
+  /** Field name that groups the data points */
   groupKey: string;
+  /** Custom x-axis scale */
   xScale?: ScaleBand<any> | ScaleTime<any, any>;
+  /** Custom y-axis scale */
   yScale?: ScaleLinear<any, any>;
+  /** Controls whether bars are grouped side-by-side or stacked */
   type?: 'stack' | 'group';
+  /** Optional trend line data to overlay on the bars */
   trend?: Record<LegendItemKey, TrendItem[]>;
-
   /** Handle click by `HoverRect`. `index` is an index of the data array. */
   onClickHoverRect?: (index: number, e: React.SyntheticEvent) => void;
-
   /** Handle click by Bar. */
   onClickBar?: (barItem: number, barKey: BarKey, e: React.SyntheticEvent) => void;
 };

--- a/semcore/d3-chart/src/component/Chart/BubbleChart.type.ts
+++ b/semcore/d3-chart/src/component/Chart/BubbleChart.type.ts
@@ -18,8 +18,11 @@ export type BubbleChartData = Array<{
 }>;
 
 export type BubbleChartProps = BaseChartProps<BubbleChartData> & {
+  /** Field name that groups the data points */
   groupKey?: never;
+  /** Custom x-axis scale */
   xScale?: ScaleLinear<any, any>;
+  /** Custom y-axis scale */
   yScale?: ScaleLinear<any, any>;
 };
 

--- a/semcore/d3-chart/src/component/Chart/CigaretteChart.type.ts
+++ b/semcore/d3-chart/src/component/Chart/CigaretteChart.type.ts
@@ -12,10 +12,15 @@ export type CigaretteChartProps = Intergalactic.InternalTypings.EfficientOmit<
   BaseChartProps<CigaretteChartData>,
   'xScale' | 'yScale'
 > & {
+  /** Title text displayed in the tooltip */
   tooltipTitle?: string;
+  /** Controls whether the tooltip shows all data or single item data */
   tooltipViewType?: 'all' | 'single';
+  /** Header content for the chart */
   header?: React.ReactNode;
+  /** Animation duration in milliseconds */
   duration?: number;
+  /** Click handler that receives the data key and event */
   onClick?: (key: DataKey, event: React.SyntheticEvent) => void;
 };
 

--- a/semcore/d3-chart/src/component/Chart/CompactHorizontalBarChart.type.ts
+++ b/semcore/d3-chart/src/component/Chart/CompactHorizontalBarChart.type.ts
@@ -10,9 +10,13 @@ type BarKey = string;
 export type CompactHorizontalBarChartData = Array<Record<BarKey, number | string>>;
 
 export type CompactHorizontalBarChartProps = BaseChartProps<CompactHorizontalBarChartData> & {
+  /** Field name from data array for the x-axis values */
   x: string;
+  /** Field name from data array for the y-axis values */
   y: string;
+  /** Custom x-axis scale */
   xScale?: ScaleBand<any> | ScaleTime<any, any>;
+  /** Custom y-axis scale */
   yScale?: ScaleLinear<any, any>;
 
   /** Handle click by `HoverRect`. `index` is an index of the data array. */

--- a/semcore/d3-chart/src/component/Chart/DonutChart.type.ts
+++ b/semcore/d3-chart/src/component/Chart/DonutChart.type.ts
@@ -8,11 +8,17 @@ import type { BaseChartProps } from './AbstractChart.type';
 export type DonutChartData = Record<string, number>;
 
 export type DonutChartProps = BaseChartProps<DonutChartData> & {
+  /** Internal */
   groupKey?: never;
+  /** Custom x-axis scale */
   xScale?: ScaleLinear<any, any>;
+  /** Custom y-axis scale */
   yScale?: ScaleLinear<any, any>;
+  /** Controls the inner radius of the donut */
   innerRadius?: number;
+  /** Creates a semi-donut chart when enabled */
   halfsize?: boolean;
+  /** Content displayed in the center of the donut */
   innerLabel?: React.ReactNode;
 };
 

--- a/semcore/d3-chart/src/component/Chart/HistogramChart.type.ts
+++ b/semcore/d3-chart/src/component/Chart/HistogramChart.type.ts
@@ -7,8 +7,11 @@ import type { BaseChartProps } from './AbstractChart.type';
 export type HistogramChartData = Array<Record<string, number | Date>>;
 
 export type HistogramChartProps = BaseChartProps<HistogramChartData> & {
+  /** Field name that groups the data points */
   groupKey: string;
+  /** Custom x-axis scale */
   xScale?: ScaleBand<any> | ScaleTime<any, any>;
+  /** Custom y-axis scale */
   yScale?: ScaleLinear<any, any>;
 };
 

--- a/semcore/d3-chart/src/component/Chart/LineChart.type.ts
+++ b/semcore/d3-chart/src/component/Chart/LineChart.type.ts
@@ -16,12 +16,19 @@ type AreaItem = {
 export type LineChartData = Array<Record<string, string | number | typeof interpolateValue | Date>>;
 
 export type LineChartProps = BaseChartProps<LineChartData> & {
+  /**  Field name that groups the data points */
   groupKey: string;
+  /** Optional area data for rendering filled areas under lines */
   area?: Record<LegendItemKey, AreaItem[]>;
+  /** Custom x-axis scale */
   xScale?: ScaleLinear<any, any> | ScaleTime<any, any>;
+  /** Custom y-axis scale */
   yScale?: ScaleLinear<any, any>;
+  /** Controls whether to display dots on the line chart */
   showDots?: boolean;
+  /** D3 curve factory for line interpolation */
   curve?: CurveFactory;
+  /** Curve factory specifically for area rendering */
   areaCurve?: CurveFactory;
 };
 

--- a/semcore/d3-chart/src/component/Chart/ScatterPlotChart.type.ts
+++ b/semcore/d3-chart/src/component/Chart/ScatterPlotChart.type.ts
@@ -8,9 +8,13 @@ import type { interpolateValue } from '../../utils';
 export type ScatterPlotChartData = Array<Record<string, number | typeof interpolateValue | Date>>;
 
 export type ScatterPlotChartProps = BaseChartProps<ScatterPlotChartData> & {
+  /** Field name that groups the data points */
   groupKey: string;
+  /** Custom x-axis scale */
   xScale?: ScaleLinear<any, any> | ScaleTime<any, any>;
+  /** Custom y-axis scale */
   yScale?: ScaleLinear<any, any>;
+  /**  Optional field name for additional value data */
   valueKey?: string;
 };
 

--- a/semcore/d3-chart/src/component/Chart/VennChart.type.ts
+++ b/semcore/d3-chart/src/component/Chart/VennChart.type.ts
@@ -7,8 +7,11 @@ import type { BaseChartProps } from './AbstractChart.type';
 export type VennChartData = Record<string, number>;
 
 export type VennChartProps = BaseChartProps<VennChartData> & {
+  /** Internal */
   groupKey?: never;
+  /** Custom x-axis scale */
   xScale?: ScaleLinear<any, any>;
+  /** Custom y-axis scale */
   yScale?: ScaleLinear<any, any>;
 };
 

--- a/semcore/d3-chart/src/types/Plot.d.ts
+++ b/semcore/d3-chart/src/types/Plot.d.ts
@@ -33,6 +33,7 @@ export type PlotProps = Context &
     /** Enables charts patterns that enhances charts accessibility */
     patterns?: PatternsConfig;
 
+    /** Event emitter for chart interactions */
     eventEmitter?: InstanceType<typeof PlotEventEmitter>;
   };
 

--- a/semcore/d3-chart/src/types/Reference.d.ts
+++ b/semcore/d3-chart/src/types/Reference.d.ts
@@ -11,7 +11,7 @@ export type ReferenceLineProps = Context & {
   position?: 'top' | 'right' | 'bottom' | 'left';
   /** Value element of data */
   value?: any;
-
+  /** Reference line title */
   title?: string;
 };
 

--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.7] - 2025-07-14
+
+### Changed
+
+- Type description for `DataTableProps`/`CellRenderProps`.
+
 ## [16.0.6] - 2025-07-04
 
 ### Changed

--- a/semcore/data-table/src/components/Body/Body.types.ts
+++ b/semcore/data-table/src/components/Body/Body.types.ts
@@ -6,15 +6,25 @@ import type { DTUse, VirtualScroll } from '../DataTable/DataTable.types';
 import type { DTColumn } from '../Head/Column.types';
 
 export type CellRenderProps = {
+  /** The column key for the cell data */
   dataKey: string;
+  /** The complete row data object */
   row: DTRow;
+  /** The column configuration object */
   column: DTColumn;
+  /** Zero-based row index in the table */
   rowIndex: number;
+  /** Zero-based column index in the table */
   columnIndex: number;
+  /** The name/key of the column */
   columnName: string;
+  /** Cell value */
   value: string | React.ReactElement;
+  /** Function that returns the default cell rendering */
   defaultRender: () => React.ReactNode;
+  /** Indicates if this cell spans multiple rows */
   isMergedRows: boolean;
+  /** Indicates if this cell spans multiple columns */
   isMergedColumns: boolean;
 };
 

--- a/semcore/data-table/src/components/DataTable/DataTable.types.ts
+++ b/semcore/data-table/src/components/DataTable/DataTable.types.ts
@@ -88,10 +88,13 @@ export type DataTableProps<D extends DataTableData> = DataTableAriaProps &
      */
     expandedRows?: Set<string>;
 
+    /** Configuration for virtual scroll */
     virtualScroll?: VirtualScroll;
 
+    /** Configuration for table columns including headers, sorting, and layout */
     columns: ColumnsConfig;
 
+    /** Configuration for sticky headers, height, scroll bars, etc. */
     headerProps?: {
       /**
        * Sticky header
@@ -113,10 +116,10 @@ export type DataTableProps<D extends DataTableData> = DataTableAriaProps &
       withScrollBar?: boolean;
     };
 
+    /** Function to add custom props to rows */
     rowProps?: DataTableBodyProps['rowProps'];
-
+    /** Custom cell renderer function */
     renderCell?: DataTableBodyProps['renderCell'];
-
     /**
    * Name of a unique key for each row data item
    */
@@ -127,6 +130,7 @@ export type DataTableProps<D extends DataTableData> = DataTableAriaProps &
      */
     selectedRows?: UniqRowKey[];
 
+    /** Callback when row selection changes */
     onSelectedRowsChange?: (
       selectedRows: UniqRowKey[],
       event?: React.SyntheticEvent<HTMLElement>,

--- a/semcore/date-picker/CHANGELOG.md
+++ b/semcore/date-picker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.5] - 2025-07-14
+
+### Changed
+
+- Type description for `CalendarProps`.
+
 ## [16.1.4] - 2025-07-04
 
 ### Changed

--- a/semcore/date-picker/src/index.d.ts
+++ b/semcore/date-picker/src/index.d.ts
@@ -37,13 +37,9 @@ export type CalendarProps = BoxProps & {
    * Array of dates blocked for selection
    */
   disabled?: DisabledDates;
-  /**
-   * @ignore
-   * */
+  /** Internal */
   highlighted?: DateConstructorParams[];
-  /**
-   * @ignore
-   * */
+  /** Internal */
   onHighlightedChange?: (date: Date[]) => void;
   /**
    * The selected date, accepts everything which is accepted by `new Date()`
@@ -58,7 +54,7 @@ export type CalendarProps = BoxProps & {
    * @default new Date()
    * */
   displayedPeriod?: Date;
-
+  /** Controls whether to render dates from previous/next months */
   renderOutdated?: boolean;
 };
 
@@ -77,16 +73,27 @@ export type CalendarMonthsContext = {
 /** @deprecated */
 export interface ICalendarUnitProps extends CalendarUnitProps, UnknownProperties {}
 export type CalendarUnitProps = BoxProps & {
+  /** Indicates if the calendar unit is part of a selected date range */
   selected?: boolean;
+  /** Marks units from previous/next months that appear in the current month view */
   outdated?: boolean;
+  /** Prevents interaction with the unit */
   disabled?: boolean;
+  /** Highlights the current date */
   today?: boolean;
+  /** Marks the beginning of a selected date range */
   startSelected?: boolean;
+  /** Marks the end of a selected date range */
   endSelected?: boolean;
+  /** Shows preview highlighting during range selection */
   highlighted?: boolean;
+  /** Marks the start of a highlighted range */
   startHighlighted?: boolean;
+  /** Marks the end of a highlighted range */
   endHighlighted?: boolean;
+  /** The actual Date object this unit represents */
   date?: Date;
+  /** Content to display within the unit (typically the day number) */
   children?: React.ReactNode;
 };
 

--- a/semcore/drag-and-drop/CHANGELOG.md
+++ b/semcore/drag-and-drop/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.5] - 2025-07-14
+
+### Changed
+
+- Type description for `DragAndDropProps`.
+
 ## [16.1.4] - 2025-07-04
 
 ### Changed

--- a/semcore/drag-and-drop/src/index.d.ts
+++ b/semcore/drag-and-drop/src/index.d.ts
@@ -34,6 +34,7 @@ export type DragAndDropProps = BoxProps & {
    * When provided, drag and drop listens to whole page keyboard events. Doesn't provide `onCustomFocusChange` callback.
    */
   customFocus?: number | string;
+  /** Specifies the locale for i18n support */
   locale?: string;
 };
 

--- a/semcore/dropdown-menu/CHANGELOG.md
+++ b/semcore/dropdown-menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.6] - 2025-07-14
+
+### Changed
+
+- Type description for `DropdownMenuContext`/`DropdownMenuProps`.
+
 ## [16.1.5] - 2025-06-23
 
 ### Fixed

--- a/semcore/dropdown-menu/src/index.d.ts
+++ b/semcore/dropdown-menu/src/index.d.ts
@@ -43,6 +43,7 @@ export type DropdownMenuProps = DropdownProps & {
    * highlightedIndex -  Index of the selected item
    */
   onHighlightedIndexChange?: (highlightedIndex: number | null) => void;
+  /** Specifies the locale for i18n support */
   locale?: string;
   /**
    * Flag for menu that using as actions on DropdownMenu.Item
@@ -127,10 +128,25 @@ export type DropdownMenuItemTitleProps = FlexProps & {
 /** @deprecated */
 export interface IDropdownMenuContext extends DropdownMenuContext, UnknownProperties {}
 export type DropdownMenuContext = DropdownContext & {
+  /**
+    * Tracks which menu item is currently highlighted/focused for keyboard navigation
+  **/
   highlightedIndex?: number;
+  /**
+    * Returns props for the menu list container
+  **/
   getListProps: PropGetterFn;
+  /**
+    * Returns props for individual menu items
+  **/
   getItemProps: PropGetterFn;
+  /**
+    * Returns props for item hint/description elements
+  **/
   getItemHintProps: PropGetterFn;
+  /**
+    *  Returns props for item title elements
+  **/
   getItemTitleProps: PropGetterFn;
 };
 

--- a/semcore/dropdown/CHANGELOG.md
+++ b/semcore/dropdown/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.5] - 2025-07-14
+
+### Changed
+
+- Type description for `DropdownProps`.
+
 ## [16.0.4] - 2025-07-04
 
 ### Changed

--- a/semcore/dropdown/src/index.d.ts
+++ b/semcore/dropdown/src/index.d.ts
@@ -21,6 +21,7 @@ export type DropdownProps = PopperProps & {
    * @default 'min'
    * */
   stretch?: 'min' | 'fixed' | false;
+  /** Specifies the locale for i18n support */
   locale?: string;
 };
 

--- a/semcore/errors/CHANGELOG.md
+++ b/semcore/errors/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.6] - 2025-07-14
+
+### Changed
+
+- Type description for `ProjectNotFoundProps`.
+
 ## [16.0.5] - 2025-07-04
 
 ### Changed

--- a/semcore/errors/src/index.d.ts
+++ b/semcore/errors/src/index.d.ts
@@ -31,7 +31,9 @@ export type ProjectNotFoundProps = WithI18nEnhanceProps & {
    * @default /projects
    */
   projectsLink?: string;
+  /** Link to contact support */
   contactsLink?: string;
+  /** Link to support team */
   supportTeamLink?: string;
   /**
    * HTML tag of the error title

--- a/semcore/feature-popover/CHANGELOG.md
+++ b/semcore/feature-popover/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.5] - 2025-07-14
+
+### Changed
+
+- Type description for `FeaturePopoverPopperProps`.
+
 ## [16.1.4] - 2025-07-04
 
 ### Changed

--- a/semcore/feature-popover/src/index.d.ts
+++ b/semcore/feature-popover/src/index.d.ts
@@ -24,7 +24,7 @@ export type FeaturePopoverPopperProps = PopperPopperProps & {
    * @default 200
    */
   duration?: number;
-
+  /** Specifies the locale for i18n support */
   locale?: string;
 };
 

--- a/semcore/feedback-form/CHANGELOG.md
+++ b/semcore/feedback-form/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.5] - 2025-07-14
+
+### Changed
+
+- Type description for `FeedbackFormProps`/`FeedbackRatingProps`.
+
 ## [16.1.4] - 2025-07-04
 
 ### Changed

--- a/semcore/feedback-form/src/component/feedback-rating/FeedbackRating.type.ts
+++ b/semcore/feedback-form/src/component/feedback-rating/FeedbackRating.type.ts
@@ -20,40 +20,41 @@ export type FeedbackRatingProps = Intergalactic.InternalTypings.EfficientOmit<
   FeedbackFormProps,
   'initialValues' | 'loading'
 > & {
-  /** status of form */
+  /** Status of form */
   status: 'default' | 'success' | 'error' | 'loading';
 
-  /** flag for show/hide notification */
+  /** Flag for show/hide notification */
   notificationVisible: boolean;
-  /** */
+  /** Notification close callback */
   onNotificationClose: () => void;
-  /** text in notification panel */
+  /** Text in notification panel */
   notificationText: string;
-  /** title in notification panel */
+  /** Title in notification panel */
   notificationTitle?: string;
-  /** optional link in notification panel */
+  /** Optional link in notification panel */
   learnMoreLink?: string;
-  /** rating value */
+  /** Rating value */
   rating: number;
-  /** visible modal form flag */
+  /** Visible modal form flag */
   visible: boolean;
-
+  /** Visibility changes callback */
   onVisibleChange: (visible: boolean, rating: number) => void;
 
-  /** width for modal with form */
+  /** Width for modal with form */
   modalWidth?: number | string;
 
-  /** header of modal with form */
+  /** Header of modal with form */
   header: React.ReactNode;
-  /** text for submit button of form */
+  /** Text for submit button of form */
   submitText?: string;
-  /** config for form fields */
+  /** Config for form fields */
   formConfig: FormConfigItem[];
 
+  /** Initial form values including rating */
   initialValues: Record<string, any> & { rating: number };
-
+  /** Email address shown in error messages */
   errorFeedbackEmail: string;
-
+  /** Specifies the locale for i18n support */
   locale?: string;
 };
 

--- a/semcore/feedback-form/src/index.d.ts
+++ b/semcore/feedback-form/src/index.d.ts
@@ -9,7 +9,7 @@ import { default as FeedbackRating } from './component/feedback-rating/FeedbackR
 /** @deprecated */
 export type IFeedbackForm = FeedbackFormProps;
 export type FeedbackFormProps = FormProps & {
-  /* The event is called when the form is submitted */
+  /** The event is called when the form is submitted */
   onSubmit: (values: any, form: any, callback?: (errors?: {}) => void) => {} | Promise<{}> | void;
   /**
    * The property is in charge of the spinner showing

--- a/semcore/format-text/CHANGELOG.md
+++ b/semcore/format-text/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.6] - 2025-07-14
+
+### Changed
+
+- Type description for `FormatTextProps`.
+
 ## [16.0.5] - 2025-07-04
 
 ### Changed

--- a/semcore/format-text/src/FormatText.tsx
+++ b/semcore/format-text/src/FormatText.tsx
@@ -14,6 +14,7 @@ import style from './style/format-text.shadow.css';
 /** @deprecated */
 export interface IFormatTextProps extends FormatTextProps, UnknownProperties {}
 export type FormatTextProps = BoxProps & {
+  /** Controls the overall text size scale for the formatted content */
   size?: 's' | 'm' | 'l';
 };
 

--- a/semcore/fullscreen-modal/CHANGELOG.md
+++ b/semcore/fullscreen-modal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.5] - 2025-07-14
+
+### Changed
+
+- Type description for `FullscreenModalHeaderProps`.
+
 ## [16.1.4] - 2025-06-24
 
 ### Fixed

--- a/semcore/fullscreen-modal/src/index.d.ts
+++ b/semcore/fullscreen-modal/src/index.d.ts
@@ -19,7 +19,9 @@ export interface IFullscreenModalHeaderProps
   extends FullscreenModalHeaderProps,
   UnknownProperties {}
 export type FullscreenModalHeaderProps = BoxProps & {
+  /** Title content displayed in the modal header */
   title?: React.ReactNode;
+  /** Description text that appears alongside the title */
   description?: React.ReactNode;
 };
 

--- a/semcore/icon/CHANGELOG.md
+++ b/semcore/icon/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.2.4] - 2025-07-14
+
+### Changed
+
+- Type description for `IconProps`.
+
 ## [16.2.3] - 2025-06-24
 
 ### Changed

--- a/semcore/icon/src/index.d.ts
+++ b/semcore/icon/src/index.d.ts
@@ -6,8 +6,11 @@ import { KeyboardFocusProps } from '@semcore/core/lib/utils/enhances/keyboardFoc
 export interface IIconProps extends IconProps, UnknownProperties {}
 export type IconProps = BoxProps &
   KeyboardFocusProps & {
+    /** Icon width */
     width?: string | number;
+    /** Icon height */
     height?: string | number;
+    /** SVG viewBox attribute */
     viewBox?: string;
     /** Make an icon interactive */
     interactive?: boolean;

--- a/semcore/inline-edit/CHANGELOG.md
+++ b/semcore/inline-edit/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.5] - 2025-07-14
+
+### Changed
+
+- Type description for `InlineEditProps`.
+
 ## [16.0.4] - 2025-07-04
 
 ### Changed

--- a/semcore/inline-edit/src/index.d.ts
+++ b/semcore/inline-edit/src/index.d.ts
@@ -9,7 +9,7 @@ export type InlineEditProps = BoxProps & {
    * Determines which children should be displayed
    */
   editable?: boolean;
-
+  /** Callback for editable states changes */
   onEditableChange?: (editable: boolean, event?: React.SyntheticEvent) => void;
   /**
    * Default value if `editable` property is not provided
@@ -21,6 +21,7 @@ export type InlineEditProps = BoxProps & {
    * Note: there not pair callback that expects switch to edit mode, you should be handled by yourself
    */
   onEdit?: () => void;
+  /** Specifies the locale for i18n support */
   locale?: string;
 };
 

--- a/semcore/inline-input/CHANGELOG.md
+++ b/semcore/inline-input/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.6] - 2025-07-14
+
+### Changed
+
+- Type description for `InlineInputProps`.
+
 ## [16.1.5] - 2025-07-07
 
 ### Fixed

--- a/semcore/inline-input/src/index.d.ts
+++ b/semcore/inline-input/src/index.d.ts
@@ -58,6 +58,7 @@ export type InlineInputProps = BoxProps & {
    * Triggered after all previous macrotasks completed (internally called inside of `setTimeout`)
    */
   onBlurBehavior?: 'cancel' | 'confirm' | 'none';
+  /** Specifies the locale for i18n support */
   locale?: string;
 };
 

--- a/semcore/input-tags/CHANGELOG.md
+++ b/semcore/input-tags/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.5] - 2025-07-14
+
+### Changed
+
+- Type description for `InputTagsProps`.
+
 ## [16.0.4] - 2025-07-04
 
 ### Changed

--- a/semcore/input-tags/src/InputTags.tsx
+++ b/semcore/input-tags/src/InputTags.tsx
@@ -51,6 +51,7 @@ export type InputTagsProps = Omit<InputProps, 'size'> &
      * @default [',', ';', '|', 'Enter', 'Tab']
      * */
     delimiters?: string[];
+    /** Specifies the locale for i18n support */
     locale?: string;
   };
 

--- a/semcore/modal/CHANGELOG.md
+++ b/semcore/modal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.5] - 2025-07-14
+
+### Changed
+
+- Type description for `ModalProps`.
+
 ## [16.1.4] - 2025-06-24
 
 ### Fixed

--- a/semcore/modal/src/index.d.ts
+++ b/semcore/modal/src/index.d.ts
@@ -31,9 +31,8 @@ export type ModalProps = PortalProps &
      * @default false
      */
     disablePreventScroll?: boolean;
-
+    /** Specifies the locale for i18n support */
     locale?: string;
-
     /**
      * Props for render modal without background and paddings. Useful in carousel for example
      */

--- a/semcore/notice-bubble/CHANGELOG.md
+++ b/semcore/notice-bubble/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.5] - 2025-07-14
+
+### Changed
+
+- Type description for `NoticeBubbleContainerProps`.
+
 ## [16.1.4] - 2025-07-04
 
 ### Changed

--- a/semcore/notice-bubble/src/index.d.ts
+++ b/semcore/notice-bubble/src/index.d.ts
@@ -10,6 +10,7 @@ export type NoticeBubbleContainerProps = BoxProps &
   PortalProps & {
     /** Manager copy */
     manager?: NoticeBubbleManagerClass;
+    /** Specifies the locale for i18n support */
     locale?: string;
   };
 

--- a/semcore/notice-global/CHANGELOG.md
+++ b/semcore/notice-global/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.5] - 2025-07-14
+
+### Changed
+
+- Type description for `NoticeGlobalProps`.
+
 ## [16.1.4] - 2025-07-04
 
 ### Changed

--- a/semcore/notice-global/src/index.d.ts
+++ b/semcore/notice-global/src/index.d.ts
@@ -25,6 +25,7 @@ export type NoticeGlobalProps = FadeInOutProps & {
    * Callback on a click on the close button
    */
   onClose?: (event: React.SyntheticEvent) => void;
+  /** Specifies the locale for i18n support */
   locale?: string;
 };
 

--- a/semcore/notice/CHANGELOG.md
+++ b/semcore/notice/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.5] - 2025-07-14
+
+### Changed
+
+- Type description for `NoticeProps`.
+
 ## [16.1.4] - 2025-07-04
 
 ### Changed

--- a/semcore/notice/src/index.d.ts
+++ b/semcore/notice/src/index.d.ts
@@ -27,6 +27,7 @@ export type NoticeProps = BoxProps &
      * @default 250
      */
     duration?: number;
+    /** Specifies the locale for i18n support */
     locale?: string;
   };
 

--- a/semcore/pagination/CHANGELOG.md
+++ b/semcore/pagination/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.5] - 2025-07-14
+
+### Changed
+
+- Type description for `PaginationProps`.
+
 ## [16.1.4] - 2025-07-04
 
 ### Changed

--- a/semcore/pagination/src/index.d.ts
+++ b/semcore/pagination/src/index.d.ts
@@ -25,6 +25,7 @@ export type PaginationProps = BoxProps &
      * @param pageNumber
      */
     onCurrentPageChange?: (pageNumber: number) => void;
+    /** Specifies the locale for i18n support */
     locale?: string;
     /**
      * Sizes for pagination panel

--- a/semcore/product-head/CHANGELOG.md
+++ b/semcore/product-head/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.5] - 2025-07-14
+
+### Changed
+
+- Type description for `InfoItemProps`/`HeaderTitleProps`.
+
 ## [16.0.4] - 2025-07-04
 
 ### Changed

--- a/semcore/product-head/src/Info.tsx
+++ b/semcore/product-head/src/Info.tsx
@@ -15,6 +15,7 @@ import style from './style/info.shadow.css';
 /** @deprecated */
 export interface IInfoItemProps extends InfoItemProps, UnknownProperties {}
 export type InfoItemProps = BoxProps & {
+  /** A label content that appears before the main item content */
   label?: React.ReactNode;
 };
 

--- a/semcore/product-head/src/Title.tsx
+++ b/semcore/product-head/src/Title.tsx
@@ -15,6 +15,7 @@ import style from './style/title.shadow.css';
 /** @deprecated */
 export interface IHeaderTitleProps extends HeaderTitleProps, UnknownProperties {}
 export type HeaderTitleProps = BoxProps & {
+  /** A tool name that appears as part of the header title */
   toolName?: React.ReactNode;
 };
 

--- a/semcore/progress-bar/CHANGELOG.md
+++ b/semcore/progress-bar/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.5] - 2025-07-14
+
+### Changed
+
+- Type description for `ValueProps`.
+
 ## [16.0.4] - 2025-07-04
 
 ### Changed

--- a/semcore/progress-bar/src/index.d.ts
+++ b/semcore/progress-bar/src/index.d.ts
@@ -25,9 +25,13 @@ export type ProgressBarProps = BoxProps & {
 /** @deprecated */
 export interface IValueProps extends ValueProps, UnknownProperties {}
 export type ValueProps = BoxProps & {
+  /** Controls the size of the value bar */
   size?: 's' | 'm' | 'l';
+  /** Progress value */
   value?: number;
+  /** Animation diration in milliseconds for transitions */
   duration?: number;
+  /** Color theme */
   theme?: string;
 };
 

--- a/semcore/select/CHANGELOG.md
+++ b/semcore/select/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.5] - 2025-07-14
+
+### Changed
+
+- Type description for `SelectProps`/`SelectOptionCheckboxProps`.
+
 ## [16.1.4] - 2025-07-04
 
 ### Changed

--- a/semcore/select/src/index.d.ts
+++ b/semcore/select/src/index.d.ts
@@ -69,6 +69,7 @@ export type SelectProps<T extends SelectValue = SelectValue> = DropdownMenuProps
      * If provided, adds a hidden <input /> tag with the given name for enhancing accessibility.
      */
     name?: string;
+    /** Specifies the locale for i18n support */
     locale?: string;
     /**
      * If enabled, after opening select popper view will be scrolled to selected option or, if there are multiple selected options, to the first selected option.
@@ -98,7 +99,7 @@ export type SelectOptionCheckboxProps = BoxProps & {
   theme?: string;
   /** Visual indeterminate state */
   indeterminate?: boolean;
-
+  /** Controls the selected state */
   selected?: boolean;
 };
 

--- a/semcore/side-panel/CHANGELOG.md
+++ b/semcore/side-panel/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.5] - 2025-07-14
+
+### Changed
+
+- Type description for `SidePanelPanelProps`.
+
 ## [16.1.4] - 2025-07-04
 
 ### Changed

--- a/semcore/side-panel/src/index.d.ts
+++ b/semcore/side-panel/src/index.d.ts
@@ -55,6 +55,7 @@ export type SidePanelOverlayProps = FadeInOutProps & BoxProps & {};
 export interface ISidePanelPanelProps extends SidePanelPanelProps, UnknownProperties {}
 export type SidePanelPanelProps = SlideProps &
   BoxProps & {
+    /** Callback that is triggered when click outside is occured */
     onOutsideClick?: (e?: React.SyntheticEvent) => void;
   };
 

--- a/semcore/skeleton/CHANGELOG.md
+++ b/semcore/skeleton/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.5] - 2025-07-14
+
+### Changed
+
+- Type description for `SkeletonProps`/`LineChartSkeletonProps`/`AreaChartSkeletonProps`/`BarChartSkeletonProps`/`HistogramChartSkeleton`.
+
 ## [16.0.4] - 2025-07-04
 
 ### Changed

--- a/semcore/skeleton/src/index.d.ts
+++ b/semcore/skeleton/src/index.d.ts
@@ -20,9 +20,8 @@ export type SkeletonProps = BoxProps &
      * @default invert
      */
     theme?: 'dark' | 'invert';
-
+    /** Specifies the locale for i18n support */
     locale?: string;
-
     /**
      * Enable ResizeObserver for parent Element to recalculate skeleton size.
      * @default false
@@ -47,18 +46,22 @@ export type SkeletonTextProps = BoxProps & {
 };
 
 export type AreaChartSkeletonProps = SkeletonProps & {
+  /** Controls the area curve interpolation style for the skeleton pattern */
   type?: 'linear' | 'monotone';
 };
 
 export type BarChartSkeletonProps = SkeletonProps & {
+  /** Controls the orientation of the bar chart skeleton */
   layout?: 'horizontal' | 'vertical';
 };
 
 export type HistogramChartSkeletonProps = SkeletonProps & {
+  /** Controls the orientation of the histogram chart skeleton */
   layout?: 'horizontal' | 'vertical';
 };
 
 export type LineChartSkeletonProps = SkeletonProps & {
+  /** Controls the line interpolation style for the skeleton pattern */
   type?: 'linear' | 'monotone';
 };
 

--- a/semcore/slider/CHANGELOG.md
+++ b/semcore/slider/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.5] - 2025-07-14
+
+### Changed
+
+- Type description for `SliderProps`.
+
 ## [16.0.4] - 2025-07-04
 
 ### Changed

--- a/semcore/slider/src/index.d.ts
+++ b/semcore/slider/src/index.d.ts
@@ -51,7 +51,7 @@ export type SliderProps<Value extends SliderValue = SliderValue> = BoxProps & {
    * Disable element
    */
   disabled?: boolean;
-
+  /** Predefined slider options */
   options?: SliderOption<Value>[];
 };
 

--- a/semcore/spin/CHANGELOG.md
+++ b/semcore/spin/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.5] - 2025-07-14
+
+### Changed
+
+- Type description for `SpinProps`.
+
 ## [16.0.4] - 2025-07-04
 
 ### Changed

--- a/semcore/spin/src/index.d.ts
+++ b/semcore/spin/src/index.d.ts
@@ -19,7 +19,7 @@ export type SpinProps = BoxProps & {
    * otherwise only horizontal alignment will occur.
    * */
   centered?: boolean;
-
+  /** Specifies the locale for i18n support */
   locale?: string;
 };
 

--- a/semcore/tag/CHANGELOG.md
+++ b/semcore/tag/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.5] - 2025-07-14
+
+### Changed
+
+- Type description for `TagProps`.
+
 ## [16.1.4] - 2025-07-04
 
 ### Changed

--- a/semcore/tag/src/index.d.ts
+++ b/semcore/tag/src/index.d.ts
@@ -48,6 +48,7 @@ export type TagProps = BoxProps & {
   addonLeft?: React.ElementType;
   /** Right addon tag */
   addonRight?: React.ElementType;
+  /** Specifies the locale for i18n support */
   locale?: string;
 };
 

--- a/semcore/time-picker/CHANGELOG.md
+++ b/semcore/time-picker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.5] - 2025-07-14
+
+### Changed
+
+- Type description for `TimePickerProps`.
+
 ## [16.1.4] - 2025-07-04
 
 ### Changed

--- a/semcore/time-picker/src/index.d.ts
+++ b/semcore/time-picker/src/index.d.ts
@@ -19,6 +19,7 @@ export type TimePickerProps = Omit<InputProps, 'size'> & {
   size?: 'm' | 'l';
   /** 12-hour time format */
   is12Hour?: boolean;
+  /** Specifies the locale for i18n support */
   locale?: string;
 };
 

--- a/semcore/widget-empty/CHANGELOG.md
+++ b/semcore/widget-empty/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.5] - 2025-07-14
+
+### Changed
+
+- Type description for `WidgetNoDataProps`.
+
 ## [16.0.4] - 2025-06-26
 
 ### Changed

--- a/semcore/widget-empty/src/index.d.ts
+++ b/semcore/widget-empty/src/index.d.ts
@@ -28,7 +28,7 @@ export type WidgetNoDataProps = WidgetEmptyProps &
   WithI18nEnhanceProps & {
     /** Error description. If it is absent, use the local default one */
     description?: React.ReactNode;
-    /* Data types */
+    /** Data types */
     type?: iconNamesWidgetEmpty;
   };
 

--- a/semcore/wizard/CHANGELOG.md
+++ b/semcore/wizard/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.5] - 2025-07-14
+
+### Changed
+
+- Type description for `WizardProps`/`WizardStepperProps`/`WizardStepBackProps`/`WizardStepNextProps`.
+
 ## [16.1.4] - 2025-07-04
 
 ### Changed

--- a/semcore/wizard/src/index.d.ts
+++ b/semcore/wizard/src/index.d.ts
@@ -13,6 +13,7 @@ export type WizardProps = ModalProps & {
    * Active step value
    */
   step: WizardStep;
+  /** Specifies the locale for i18n support */
   locale?: string;
 };
 
@@ -60,20 +61,24 @@ export type WizardStepperProps<T extends WizardStep = WizardStep> = BoxProps & {
    *  Is the step completed
    */
   completed?: boolean;
-
+  /** Disables interaction with the stepper */
   disabled?: boolean;
 };
 
 export type WizardStepBackProps<T extends WizardStep = WizardStep> = ButtonProps & {
+  /** Callback invoked when navigating to the previous step */
   onActive?:
     | ((step: T, e: React.SyntheticEvent<HTMLElement>) => void)
     | React.Dispatch<React.SetStateAction<T>>;
+  /** Step name being navigated to */
   stepName?: string;
 };
 export type WizardStepNextProps<T extends WizardStep = WizardStep> = ButtonProps & {
+  /** Callback invoked when navigating to the next step */
   onActive?:
     | ((step: T, e: React.SyntheticEvent<HTMLElement>) => void)
     | React.Dispatch<React.SetStateAction<T>>;
+  /** Step name being navigated to */
   stepName?: string;
 };
 


### PR DESCRIPTION
## Motivation and Context

Description for some component props are not added/rendered on the API tab. Fix ensures they are correctly extracted and displayed.

## How has this been tested?

It's been tested manually.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
