### PR TITLE
[tooltip] fixed incorrect sybmols link if Popper and Tooltip has different core package

### DIFF
--- a/semcore/core/CHANGELOG.md
+++ b/semcore/core/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 ### Added
 
 - `featureHighlight` tokens to dark.json.
+- `newInstance` method for create new component instances from the existing.
 
 ## [16.0.3] - 2025-07-02
 

--- a/semcore/core/src/core-types/Component.ts
+++ b/semcore/core/src/core-types/Component.ts
@@ -292,6 +292,7 @@ export namespace Intergalactic {
       __context: Context;
       __additionalContext: AdditionalContext;
       displayName: string;
+      newInstance: () => Component<BaseTag, Props, Context>;
     };
     export type InferJsxIntrinsicElement<T extends React.DetailedHTMLProps<any, any>> =
       T extends React.DetailedHTMLProps<infer _, infer Element> ? Element : HTMLElement;

--- a/semcore/core/src/coreFactory.tsx
+++ b/semcore/core/src/coreFactory.tsx
@@ -371,6 +371,13 @@ function createComponent<ComponentProps, ChildComponentProps = {}, ContextType =
   ) {
     return createComponent(_OriginComponent, _childComponents, _options);
   };
+  Component.newInstance = function (
+          _OriginComponent = OriginComponent,
+          _childComponents = childComponents,
+          _options = options,
+  ) {
+    return createComponent(_OriginComponent, _childComponents, _options);
+  };
   Component[CORE_COMPONENT] = true;
   return Component;
 }

--- a/semcore/d3-chart/src/Tooltip.jsx
+++ b/semcore/d3-chart/src/Tooltip.jsx
@@ -137,6 +137,14 @@ class TooltipRoot extends Component {
   }
 }
 
+function PopperTrigger(props) {
+  const { Element: STrigger, styles } = props;
+
+  return sstyled(styles)(
+    <STrigger render={Popper.Trigger} />,
+  );
+}
+
 function PopperPopper(props) {
   const { Element: STooltip, styles, $visible, x, y } = props;
 
@@ -208,7 +216,7 @@ function Footer(props) {
 Footer.style = style;
 
 const Tooltip = createElement(TooltipRoot, {
-  Trigger: Popper.Trigger,
+  Trigger: PopperTrigger,
   Popper: PopperPopper,
   Title,
   Footer,

--- a/semcore/d3-chart/src/Tooltip.jsx
+++ b/semcore/d3-chart/src/Tooltip.jsx
@@ -137,12 +137,8 @@ class TooltipRoot extends Component {
   }
 }
 
-function PopperTrigger(props) {
-  const { Element: STrigger, styles } = props;
-
-  return sstyled(styles)(
-    <STrigger render={Popper.Trigger} />,
-  );
+function PopperTrigger() {
+  return <Root render={Popper.Trigger} />;
 }
 
 function PopperPopper(props) {

--- a/semcore/tooltip/CHANGELOG.md
+++ b/semcore/tooltip/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.5] - 2025-07-28
+
+### Fixed
+
+- Error with `CREATE_COMPONENT` symbol and different core versions for Popper and Tooltip packages.
+
 ## [16.0.4] - 2025-06-23
 
 ### Fixed

--- a/semcore/tooltip/src/Tooltip.jsx
+++ b/semcore/tooltip/src/Tooltip.jsx
@@ -9,7 +9,7 @@ import {
   ZIndexStackingContextProvider,
 } from '@semcore/core/lib/utils/zIndexStacking';
 import { Box } from '@semcore/flex-box';
-import Popper from '@semcore/popper';
+import PopperOrigin from '@semcore/popper';
 import Portal from '@semcore/portal';
 import React from 'react';
 
@@ -28,6 +28,7 @@ const defaultProps = {
   focusLoop: false,
   liveRegion: true,
 };
+const Popper = PopperOrigin.newInstance();
 
 class TooltipRoot extends Component {
   static displayName = 'Tooltip';

--- a/semcore/tooltip/src/Tooltip.jsx
+++ b/semcore/tooltip/src/Tooltip.jsx
@@ -1,4 +1,4 @@
-import { createComponent, Component, CREATE_COMPONENT, sstyled, Root } from '@semcore/core';
+import { createComponent, Component, sstyled, Root } from '@semcore/core';
 import resolveColorEnhance from '@semcore/core/lib/utils/enhances/resolveColorEnhance';
 import { isAdvanceMode } from '@semcore/core/lib/utils/findComponent';
 import logger from '@semcore/core/lib/utils/logger';
@@ -9,13 +9,11 @@ import {
   ZIndexStackingContextProvider,
 } from '@semcore/core/lib/utils/zIndexStacking';
 import { Box } from '@semcore/flex-box';
-import PopperOrigin from '@semcore/popper';
+import Popper from '@semcore/popper';
 import Portal from '@semcore/portal';
 import React from 'react';
 
 import style from './style/tooltip.shadow.css';
-
-const Popper = PopperOrigin[CREATE_COMPONENT]();
 
 const defaultProps = {
   placement: 'top',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually and with existing tests
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
