### PR TITLE
[website] removed replacing intergalactic with semcore in sandboxes

### DIFF
--- a/website/docs/.vitepress/theme/Sandbox.vue
+++ b/website/docs/.vitepress/theme/Sandbox.vue
@@ -34,11 +34,11 @@ const dataToLzCompressedJson = (data) => {
 
 const { playgroundId, htmlCode: codeEncoded, rawCode: rawCodeEncoded, hideCode: hideCodeEncoded, stylesIsolation } = defineProps({ playgroundId: String, htmlCode: String, rawCode: String, hideCode: String, stylesIsolation: Boolean })
 const htmlCode = computed(() => {
-  let code = atob(codeEncoded!).replace(/intergalactic\//g, "@semcore/ui/");
+  let code = atob(codeEncoded!);
   return code.replace('tabindex="0" v-pre=""><code>', 'v-pre=""><code>');
 });
 const codesandboxUrl = computed(() => {
-  let code = rawCode.replace(/'intergalactic\//g, "'@semcore/ui/");
+  let code = rawCode;
   const dependencies = {};
   const lines = code!.split('\n');
   for (const line of lines) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Removed the logic that replaced "intergalactic" with "semcore/ui" in our Sandboxes (because we don't have intergalactic imports anymore, and that replacement broke rendering of urls containing "intergalactic").

## Before and after
<img width="749" height="771" alt="imagen" src="https://github.com/user-attachments/assets/926d3afa-4286-4530-a19c-5d61ce246018" />
<img width="710" height="507" alt="imagen" src="https://github.com/user-attachments/assets/9f32138e-62af-47a2-9e41-8451cbee280f" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
