### PR TITLE
UIK-3282/focus loss in safari pagination

### DIFF
--- a/semcore/pagination/CHANGELOG.md
+++ b/semcore/pagination/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.6] - 2025-08-07
+
+### Fixed
+
+- Focus loss in Safari when navigating to first/last page with pagination buttons.
+
 ## [16.1.5] - 2025-07-23
 
 ### Changed

--- a/semcore/pagination/__tests__/pagination.browser-test.tsx
+++ b/semcore/pagination/__tests__/pagination.browser-test.tsx
@@ -233,23 +233,14 @@ test.describe('Interactions', () => {
       await page.keyboard.press('Enter');
       await expect(input).toHaveAttribute('value', '1');
 
-      if (browserName === 'webkit') {
-        await page.keyboard.press('Tab');
-        await page.keyboard.press('Enter');
-      } else {
-        await expect(nextPage).toBeFocused();
-        await page.keyboard.press('Enter');
-      }
+      await expect(nextPage).toBeFocused();
+      await page.keyboard.press('Enter');
       await page.keyboard.press('Shift+Tab');
       await page.waitForTimeout(50);
       await page.keyboard.press('Shift+Tab');
-      if (browserName === 'webkit') return; // disabled for webkit because it fails on cd, in debug mode works well
       await expect(firstPage).toBeFocused();
       await page.keyboard.press('Enter');
       await expect(input).toHaveAttribute('value', '1');
-      //   if (browserName === 'webkit') {
-      //     await page.keyboard.press('Shift+Tab');
-      //   }
       await page.keyboard.press('Tab');
       await page.waitForTimeout(50);
       await page.keyboard.press('Tab');

--- a/semcore/pagination/src/Pagination.jsx
+++ b/semcore/pagination/src/Pagination.jsx
@@ -123,11 +123,11 @@ class PaginationRoot extends Component {
       currentPage,
       disabled,
       onClick: () => {
-        const nextPage = currentPage - 1;
+        const followingPage = currentPage - 1;
 
-        this.handlePageChange(nextPage);
+        this.handlePageChange(followingPage);
 
-        if (nextPage <= 1) {
+        if (followingPage <= 1) {
           this.returnLostFocusTo(this.nextPageButtonRef);
         }
       },
@@ -144,11 +144,11 @@ class PaginationRoot extends Component {
       currentPage,
       disabled,
       onClick: () => {
-        const nextPage = currentPage + 1;
+        const followingPage = currentPage + 1;
 
-        this.handlePageChange(nextPage);
+        this.handlePageChange(followingPage);
 
-        if (nextPage >= totalPages) {
+        if (followingPage >= totalPages) {
           this.returnLostFocusTo(this.prevPageButtonRef);
         }
       },

--- a/semcore/pagination/src/Pagination.jsx
+++ b/semcore/pagination/src/Pagination.jsx
@@ -51,19 +51,10 @@ class PaginationRoot extends Component {
     }
   }
 
-  returnLostFocus = () => {
-    setTimeout(() => {
-      if (document.activeElement !== document.body) return;
-
-      const prevPageButton = this.prevPageButtonRef.current;
-      const nextPageButton = this.nextPageButtonRef.current;
-
-      if (prevPageButton && !prevPageButton.disabled) {
-        prevPageButton.focus();
-      } else if (nextPageButton && !nextPageButton.disabled) {
-        nextPageButton.focus();
-      }
-    }, 0);
+  returnLostFocusTo = (ref) => {
+    requestAnimationFrame(() => {
+      ref.current?.focus();
+    });
   };
 
   handlePageChange = (currentPage) => {
@@ -73,7 +64,6 @@ class PaginationRoot extends Component {
     }
     this.handlers.currentPage(currentPage);
     this.setState({ dirtyCurrentPage: undefined });
-    this.returnLostFocus();
   };
 
   handlePageValueChange = (value) => {
@@ -117,7 +107,10 @@ class PaginationRoot extends Component {
     const disabled = currentPage <= 1;
     return {
       disabled,
-      onClick: () => this.handlePageChange(1),
+      onClick: () => {
+        this.handlePageChange(1);
+        this.returnLostFocusTo(this.nextPageButtonRef);
+      },
       getI18nText,
       size,
     };
@@ -129,22 +122,38 @@ class PaginationRoot extends Component {
     return {
       currentPage,
       disabled,
-      onClick: () => this.handlePageChange(currentPage - 1),
+      onClick: () => {
+        const nextPage = currentPage - 1;
+
+        this.handlePageChange(nextPage);
+
+        if (nextPage <= 1) {
+          this.returnLostFocusTo(this.nextPageButtonRef);
+        }
+      },
       getI18nText,
-      ref: this.nextPageButtonRef,
+      ref: this.prevPageButtonRef,
       size,
     };
   };
 
   getNextPageProps = () => {
     const { currentPage, totalPages, getI18nText, size } = this.asProps;
-    const disabled = !(currentPage < totalPages);
+    const disabled = currentPage >= totalPages;
     return {
       currentPage,
       disabled,
-      onClick: () => this.handlePageChange(currentPage + 1),
+      onClick: () => {
+        const nextPage = currentPage + 1;
+
+        this.handlePageChange(nextPage);
+
+        if (nextPage >= totalPages) {
+          this.returnLostFocusTo(this.prevPageButtonRef);
+        }
+      },
       getI18nText,
-      ref: this.prevPageButtonRef,
+      ref: this.nextPageButtonRef,
       size,
     };
   };

--- a/semcore/pagination/src/Pagination.jsx
+++ b/semcore/pagination/src/Pagination.jsx
@@ -199,7 +199,10 @@ class PaginationRoot extends Component {
       totalPages,
       children: formatter.format(totalPages),
       isLastOrSingle: currentPage === totalPages,
-      onClick: () => this.handlePageChange(totalPages),
+      onClick: () => {
+        this.handlePageChange(totalPages);
+        this.returnLostFocusTo(this.prevPageButtonRef);
+      },
       getI18nText,
       size,
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

In Safari, focus is lost when using `Next`/`Prev` buttons to reach the first or last page. The fix ensures focus remains on the buttons.

## How has this been tested?

I've updated browser test.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
