### PR TITLE
[UIK-3992][modal] prevent hiding modal after scrollbar interaction

### DIFF
--- a/semcore/fullscreen-modal/CHANGELOG.md
+++ b/semcore/fullscreen-modal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.6] - 2025-08-07
+
+### Changed
+
+- Updated styles to reflect internal `Modal` changes preventing unexpected closing during scrollbar interaction.
+
 ## [16.1.5] - 2025-07-23
 
 ### Changed

--- a/semcore/fullscreen-modal/src/style/fullscreen-modal.shadow.css
+++ b/semcore/fullscreen-modal/src/style/fullscreen-modal.shadow.css
@@ -1,5 +1,9 @@
 SFullscreenOverlay {
-  padding: 0;
+  > div {
+    padding: 0;
+    width: 100%;
+    height: 100%;
+  }
 }
 
 SFullscreenModal {

--- a/semcore/modal/CHANGELOG.md
+++ b/semcore/modal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.1.6] - 2025-08-07
+
+### Fixed
+
+- `Modal` hides after scrollbar interaction.
+
 ## [16.1.5] - 2025-07-23
 
 ### Changed
@@ -12,7 +18,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 ### Fixed
 
-- Modal doesn't close on ESC key press when no element inside is focused.
+- `Modal` doesn't close on ESC key press when no element inside is focused.
 
 ## [16.1.3] - 2025-06-23
 

--- a/semcore/modal/__tests__/modal.browser-test.tsx
+++ b/semcore/modal/__tests__/modal.browser-test.tsx
@@ -358,21 +358,21 @@ test.describe('Modal positioning ans styles', () => {
 
     await page.setContent(htmlContent);
 
-    const overlay = page.locator('[data-ui-name="Modal.Overlay"]');
+    const overlayContentWrapper = page.locator('[data-ui-name="Modal.Overlay"] > div');
     await page.keyboard.press('Tab');
     await page.keyboard.press('Enter');
 
     await page.waitForSelector('text=Got it!');
 
-    await expect(overlay).toHaveCSS('padding', '40px');
+    await expect(overlayContentWrapper).toHaveCSS('padding', '40px');
 
     await page.setViewportSize({ width: 1280, height: 320 });
 
-    await expect(overlay).toHaveCSS('padding', '40px');
+    await expect(overlayContentWrapper).toHaveCSS('padding', '40px');
 
     await page.setViewportSize({ width: 320, height: 320 });
 
-    await expect(overlay).toHaveCSS('padding', '12px');
+    await expect(overlayContentWrapper).toHaveCSS('padding', '12px');
 
     await expect(page).toHaveScreenshot();
   });
@@ -384,13 +384,13 @@ test.describe('Modal positioning ans styles', () => {
 
     await page.setContent(htmlContent);
 
-    const overlay = page.locator('[data-ui-name="Modal.Overlay"]');
+    const overlayContentWrapper = page.locator('[data-ui-name="Modal.Overlay"] > div');
     await page.keyboard.press('Tab');
     await page.keyboard.press('Enter');
 
     await page.waitForSelector('text=Got it!');
 
-    await expect(overlay).toHaveCSS('padding', '40px');
+    await expect(overlayContentWrapper).toHaveCSS('padding', '40px');
 
     await page.mouse.wheel(0, 600);
     await new Promise((resolve) => setTimeout(resolve, 500));
@@ -531,5 +531,61 @@ test.describe('Confirmation modal dialog pattern', () => {
       await page.keyboard.press('Shift+Tab');
       await expect(bths.nth(1)).toBeFocused();
     });
+  });
+});
+
+test.describe('Modal outside click interaction', () => {
+  test('Basic case', async ({ page }) => {
+    const standPath = 'stories/components/modal/docs/examples/modal_window_height_is_bigger_than_the_browser_page.tsx';
+    const htmlContent = await e2eStandToHtml(standPath, 'en');
+
+    await page.setContent(htmlContent);
+
+    const trigger = page.getByRole('button', { name: 'Open modal' });
+    const modal = page.locator('[data-ui-name="Modal"]');
+    const overlay = page.locator('[data-ui-name="Modal.Overlay"]');
+
+    await trigger.click();
+    await modal.waitFor();
+
+    const overlayBox = await overlay.boundingBox();
+
+    expect(overlayBox).toBeTruthy();
+
+    /*
+      16px - approximate scrollbar width
+    */
+    const x = overlayBox!.x + overlayBox!.width - 20;
+    const y = overlayBox!.y + overlayBox!.height / 2;
+    await page.mouse.click(x, y);
+
+    await modal.waitFor({ state: 'hidden' });
+  });
+
+  test('Edge case', async ({ page }) => {
+    const standPath = 'stories/components/modal/docs/examples/modal_window_height_is_bigger_than_the_browser_page.tsx';
+    const htmlContent = await e2eStandToHtml(standPath, 'en');
+
+    await page.setContent(htmlContent);
+
+    const trigger = page.getByRole('button', { name: 'Open modal' });
+    const modal = page.locator('[data-ui-name="Modal"]');
+    const overlay = page.locator('[data-ui-name="Modal.Overlay"]');
+
+    await trigger.click();
+    await modal.waitFor();
+
+    const overlayBox = await overlay.boundingBox();
+
+    expect(overlayBox).toBeTruthy();
+
+    /*
+      16px - approximate scrollbar width
+    */
+    const x = overlayBox!.x + overlayBox!.width - 8;
+    const y = overlayBox!.y + overlayBox!.height / 2;
+    await page.mouse.click(x, y);
+
+    await modal.waitFor({ state: 'visible' });
   });
 });

--- a/semcore/modal/src/Modal.jsx
+++ b/semcore/modal/src/Modal.jsx
@@ -1,4 +1,5 @@
 import { FadeInOut, Slide } from '@semcore/animation';
+import { Flex } from '@semcore/base-components';
 import Button from '@semcore/button';
 import { createComponent, Component, sstyled, Root } from '@semcore/core';
 import i18nEnhance from '@semcore/core/lib/utils/enhances/i18nEnhance';
@@ -160,17 +161,20 @@ function Window(props) {
 
 function Overlay(props) {
   const SOverlay = Root;
+  const SOverlayContentWrapper = Flex;
   const { Children, styles, onOutsideClick, visible } = props;
-  const overlayRef = React.useRef(null);
+  const overlayContentWrapperRef = React.useRef(null);
   usePreventScroll(visible, props.disablePreventScroll);
-  useContextTheme(overlayRef, visible);
+  useContextTheme(overlayContentWrapperRef, visible);
   const zIndex = useZIndexStacking('z-index-modal');
 
   return sstyled(styles)(
-    <SOverlay render={FadeInOut} ref={overlayRef} zIndex={zIndex}>
-      <OutsideClick root={overlayRef} onOutsideClick={onOutsideClick}>
-        <Children />
-      </OutsideClick>
+    <SOverlay render={FadeInOut} zIndex={zIndex}>
+      <SOverlayContentWrapper ref={overlayContentWrapperRef}>
+        <OutsideClick root={overlayContentWrapperRef} onOutsideClick={onOutsideClick}>
+          <Children />
+        </OutsideClick>
+      </SOverlayContentWrapper>
     </SOverlay>,
   );
 }

--- a/semcore/modal/src/style/modal.shadow.css
+++ b/semcore/modal/src/style/modal.shadow.css
@@ -43,17 +43,23 @@ SWindow[ghost] {
   box-shadow: none;
 }
 
+SOverlayContentWrapper {
+  flex: 1;
+  max-width: 100%;
+  box-sizing: border-box;
+  padding: var(--intergalactic-spacing-10x, 40px);
+}
+
 SOverlay {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
   position: fixed;
   top: 0;
   bottom: 0;
   left: 0;
   right: 0;
   margin: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: var(--intergalactic-spacing-10x, 40px);
   background: var(--intergalactic-overlay-primary, rgba(25, 27, 35, 0.7));
   overflow: auto;
   -webkit-overflow-scrolling: touch;
@@ -61,6 +67,7 @@ SOverlay {
   & SOverlay {
     background: var(--intergalactic-overlay-secondary, rgba(25, 27, 35, 0.4));
   }
+  
 }
 
 @media (max-width: 767px) {
@@ -68,7 +75,7 @@ SOverlay {
     min-width: 60%;
   }
 
-  SOverlay {
+  SOverlayContentWrapper {
     padding: var(--intergalactic-spacing-3x, 12px);
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Scrollbar interaction causes `Modal` to close. The solution slightly restructures layout for `Modal.Overlay`  separating container and content. 

## How has this been tested?

Manually + I've added browser test.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
