### PR TITLE
[UIK-3649][pills] fixed focus outline on the pill

### DIFF
--- a/semcore/pills/CHANGELOG.md
+++ b/semcore/pills/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.0.6] - 2025-08-12
+
+### Fixed
+
+- The focus outline on the left pill is not visible when hovering over the next pill.
+
 ## [16.0.5] - 2025-07-23
 
 ### Changed

--- a/semcore/pills/src/style/pills.shadow.css
+++ b/semcore/pills/src/style/pills.shadow.css
@@ -50,7 +50,11 @@ SPill[selected] {
   border-color: var(--intergalactic-border-info-active, #006dca);
   z-index: 3;
 }
-SPill:focus-visible, SPill:hover, SPill:active {
+SPill:focus-visible, SPill[selected] {
+  z-index: 3;
+}
+
+SPill:hover, SPill:active {
   z-index: 2;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
The focus outline on the left pill is not visible when hovering over the next pill.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
