### PR TITLE
[UIK-4079][data-table] prevent double call of onSortChange

### DIFF
--- a/semcore/data-table/CHANGELOG.md
+++ b/semcore/data-table/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 
 - Unnecessary re-render when data was updated but old values were still used.
 - Shadows remain after resizing table width.
+- `onSortChange` is called twice when click is on a sort icon.
 
 ### Changed
 

--- a/semcore/data-table/__tests__/data-table-header.browser-test.tsx
+++ b/semcore/data-table/__tests__/data-table-header.browser-test.tsx
@@ -520,6 +520,16 @@ test.describe('One level header - Sorting', () => {
     const htmlContent = await e2eStandToHtml(standPath, 'en');
     await page.setContent(htmlContent);
 
+    const messages: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'log') {
+        const text = msg.text();
+        if (text === 'Sorted') {
+          messages.push(text);
+        }
+      }
+    });
+
     const columns = page.locator('[data-ui-name="Head.Column"]');
     const buttonLink1 = columns.first().locator('button[data-ui-name="ButtonLink"]');
 
@@ -529,10 +539,13 @@ test.describe('One level header - Sorting', () => {
       await expect(columns.nth(i)).not.toHaveAttribute('aria-sort');
     }
     await expect(columns.first()).not.toHaveAttribute('aria-sort');
-
+    expect(messages.length).toBe(0);
     await buttonLink1.click();
     await expect(buttonLink1).toHaveAttribute('aria-label', 'descending');
     await expect(columns.first()).toHaveAttribute('aria-sort', 'descending');
+
+    expect(messages.length).toBe(1);
+    expect(messages).toEqual(['Sorted']);
 
     await buttonLink1.click();
     await expect(buttonLink1).toHaveAttribute('aria-label', 'ascending');
@@ -540,12 +553,22 @@ test.describe('One level header - Sorting', () => {
     for (let i = 1; i < count; i++) {
       await expect(columns.nth(i)).not.toHaveAttribute('aria-sort');
     }
+    expect(messages.length).toBe(2);
   });
 
   test('Verify sorting with undefined as default value by keyboard interactions', async ({ page }) => {
     const standPath = 'stories/components/data-table/tests/examples/header-tests/sorting-default-undefined.tsx';
     const htmlContent = await e2eStandToHtml(standPath, 'en');
     await page.setContent(htmlContent);
+    const messages: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'log') {
+        const text = msg.text();
+        if (text === 'Sorted') {
+          messages.push(text);
+        }
+      }
+    });
 
     const columns = page.locator('[data-ui-name="Head.Column"]');
     const buttonLink1 = columns.first().locator('button[data-ui-name="ButtonLink"]');
@@ -558,6 +581,7 @@ test.describe('One level header - Sorting', () => {
       await expect(columns.nth(i)).not.toHaveAttribute('aria-sort');
     }
     await expect(columns.first()).not.toHaveAttribute('aria-sort');
+    expect(messages.length).toBe(0);
 
     await page.keyboard.press('ArrowDown');
     await expect(page.locator('[data-ui-name="Body.Cell"][aria-colindex="1"]').first()).toBeFocused();
@@ -570,10 +594,13 @@ test.describe('One level header - Sorting', () => {
     await page.keyboard.press('Enter');
     await expect(buttonLink2).toHaveAttribute('aria-label', 'descending');
     await expect(columns.nth(1)).toHaveAttribute('aria-sort', 'descending');
+    expect(messages.length).toBe(1);
+    expect(messages).toEqual(['Sorted']);
 
     await buttonLink2.click();
     await expect(buttonLink2).toHaveAttribute('aria-label', 'ascending');
     await expect(columns.nth(1)).toHaveAttribute('aria-sort', 'ascending');
+    expect(messages.length).toBe(2);
   });
 });
 
@@ -686,10 +713,6 @@ test.describe('Multi level Header', () => {
       await page.keyboard.press('Enter');
       await page.keyboard.press('ArrowDown');
       await expect(checkbox).toBeFocused();
-
-      // but
-      // await page.keyboard.press('Tab');  - moves to the next focusable element outside table
-      // await page.keyboard.press('Shift+Tab');
     });
 
     await test.step('Verify interaction with Select', async () => {

--- a/semcore/data-table/src/components/Head/Column.tsx
+++ b/semcore/data-table/src/components/Head/Column.tsx
@@ -217,6 +217,8 @@ export class Column<
   };
 
   handleSortClick = (e: React.SyntheticEvent<HTMLElement>) => {
+    e.stopPropagation();
+
     const { sort, onSortChange, name, sortable } = this.asProps;
 
     if (

--- a/stories/components/data-table/tests/examples/header-tests/sorting-default-undefined.tsx
+++ b/stories/components/data-table/tests/examples/header-tests/sorting-default-undefined.tsx
@@ -28,6 +28,7 @@ const Demo = () => {
     newSort,
   ) => {
     setSort(newSort as DataTableSort<SortableColumn>);
+    console.log('Sorted');
   };
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

`onSortChange` is triggered twice on a single sort action. The fix ensures it fires only once.

## How has this been tested?

Manually

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
