### PR TITLE
[website] fixed heading margins on API pages

### DIFF
--- a/website/docs/.vitepress/theme/FormattedTypeString.vue
+++ b/website/docs/.vitepress/theme/FormattedTypeString.vue
@@ -10,7 +10,7 @@
   <dialog ref="dialog" @click="handleDialogClick">
     <TypesView :type="subTypeModal.referenceTo" :types="types" v-if="subTypeModal && types[subTypeModal.referenceTo]" />
     <div v-if="subTypeModal && !types[subTypeModal.referenceTo]">
-      <h3 class="types-viewer-name">External type</h3>
+      <h3>External type</h3>
       <div>
         Type <code>{{ subTypeModal.displayText }}</code> is external and not available in the documentation preview.
       </div>

--- a/website/docs/.vitepress/theme/TypesView.vue
+++ b/website/docs/.vitepress/theme/TypesView.vue
@@ -1,5 +1,5 @@
 <template>
-  <h3 class="types-viewer-name">{{ types[type].declaration.name }}</h3>
+  <h3>{{ types[type].declaration.name }}</h3>
   <FormattedTypeString :type="types[type].declaration.type" :types="types" />
   <table v-if="filteredTypes.length > 0">
     <tr>

--- a/website/docs/.vitepress/theme/style.css
+++ b/website/docs/.vitepress/theme/style.css
@@ -572,6 +572,12 @@ video {
   margin-top: 24px;
 }
 
+/* First heading in modals on API pages */
+
+.vp-doc dialog :is(h1, h2, h3, h4, h5, h6):not(* ~ :is(h1, h2, h3, h4, h5, h6)):not([class]) {
+  margin-top: unset;
+}
+
 /* Styles for changelogs */
 .vp-doc .custom-block.details {
   margin: 0;
@@ -595,8 +601,6 @@ video {
 .vp-doc .collapsed-versions h2 {
   margin: 0 0 12px;
 }
-
-/* To remove hover styles that our components in the sandboxes are inheriting from the website */
 
 h1[class],
 h2[class],
@@ -641,6 +645,8 @@ h6[class] {
 .vp-doc a:not([class]):visited {
   color: var(--vp-c-indigo-2);
 }
+
+/* To remove hover styles that our components in the sandboxes are inheriting from the website */
 
 .vp-doc a:not([class]):hover {
   color: var(--vp-c-indigo-1);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Headings on API pages didn't have margins and were too close to the content.

## Before & After

<img width="1307" height="898" alt="imagen" src="https://github.com/user-attachments/assets/efefd9c8-d39f-476b-b97c-6ab43974f10f" />

<img width="1329" height="536" alt="imagen" src="https://github.com/user-attachments/assets/cefeeb12-c68a-43f8-b7ce-1cb643437e70" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
