### PR TITLE
[UIK-4212][base-components, core] added ability to set custom html tags for components with another tag property

### DIFF
--- a/semcore/base-components/CHANGELOG.md
+++ b/semcore/base-components/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.3.0] - 2025-09-20
+
+### Added
+
+- Ability to use two tags in `tag` property. First for some logic like `Ellipsis` or `Select.Trigger` and second for real `html` tag.
+
 ## [16.2.3] - 2025-09-17
 
 ### Changed

--- a/semcore/base-components/src/components/flex-box/Box/index.tsx
+++ b/semcore/base-components/src/components/flex-box/Box/index.tsx
@@ -5,6 +5,11 @@ import useBox, { type BoxProps } from './useBox';
 
 function Box(props: any, ref: any) {
   const [Tag, boxProps] = useBox(props, ref);
+  if (Array.isArray(Tag)) {
+    const [FirstTag, htmlTag] = Tag;
+    return <FirstTag {...boxProps} tag={htmlTag} />;
+  }
+
   return <Tag {...boxProps} />;
 }
 

--- a/semcore/core/CHANGELOG.md
+++ b/semcore/core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangelog.com/en/1.0.0/).
 
+## [16.4.0] - 2025-09-20
+
+### Added
+
+- Ability to use two tags in `tag` property. First for some logic like `Ellipsis` or `Select.Trigger` and second for real `html` tag.
+
 ## [16.3.0] - 2025-09-08
 
 ### Added

--- a/semcore/core/src/core-types/Component.ts
+++ b/semcore/core/src/core-types/Component.ts
@@ -238,7 +238,7 @@ export namespace Intergalactic {
       | React.FC
       | ReactFCLike;
     export type ComponentProps<
-      Tag extends ComponentTag,
+      Tag extends ComponentTag | [ComponentTag, keyof JSX.IntrinsicElements],
       BaseTag extends ComponentTag | never,
       Props,
       Context = never,
@@ -251,10 +251,10 @@ export namespace Intergalactic {
         ReturnResult,
         AdditionalContext
       >;
-    } & ComponentBasicProps<Tag> &
+    } & ComponentBasicProps<Tag extends [ComponentTag, keyof JSX.IntrinsicElements] ? Tag[0] : Tag> &
     MergeProps<
       EfficientOmit<Props, 'tag' | 'children'>,
-      MergeProps<ComponentPropsNesting<Tag>, ComponentPropsNesting<BaseTag>>
+      MergeProps<ComponentPropsNesting<Tag extends [ComponentTag, keyof JSX.IntrinsicElements] ? Tag[0] : Tag>, ComponentPropsNesting<BaseTag>>
     >;
     export type PropsRenderingResultComponentProps<
       Tag extends ComponentTag,
@@ -319,7 +319,7 @@ export namespace Intergalactic {
     BaseProps = {},
     Context = {},
     AdditionalContext extends any[] = never[],
-  > = (<Tag extends InternalTypings.ComponentTag = BaseTag, Props extends BaseProps = BaseProps>(
+  > = (<Tag extends InternalTypings.ComponentTag | [InternalTypings.ComponentTag, keyof JSX.IntrinsicElements] = BaseTag, Props extends BaseProps = BaseProps>(
     props: InternalTypings.ComponentProps<Tag, BaseTag, Props, Context, AdditionalContext>,
   ) => InternalTypings.ComponentRenderingResults) &
   InternalTypings.ComponentAdditive<BaseTag, Tag, BaseProps, Context, AdditionalContext>;

--- a/stories/components/ellipsis/test/ellipsis.stories.tsx
+++ b/stories/components/ellipsis/test/ellipsis.stories.tsx
@@ -3,6 +3,7 @@ import Ellipsis from '@semcore/ellipsis';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import TableWithLinksExample from './examples/in_table_with_link';
+import MultipleTagsInOneComponentsExample from './examples/multiple_tags_in_one_components';
 import OnChangePropsExample from './examples/on_change_props';
 import TextCasesExample from './examples/text_cases';
 import TrimWithTextSizeExample, { defaultProps as sizeEllipsisProps } from './examples/trim_with_special_text_size';
@@ -41,4 +42,8 @@ export const OnChangeProps: StoryObj<EllipsisProps> = {
 export const TrimWithTextSize: StoryObj<EllipsisProps> = {
   render: TrimWithTextSizeExample,
   args: sizeEllipsisProps,
+};
+
+export const MultipleTagsInOneComponents: StoryObj<EllipsisProps> = {
+  render: MultipleTagsInOneComponentsExample,
 };

--- a/stories/components/ellipsis/test/examples/multiple_tags_in_one_components.tsx
+++ b/stories/components/ellipsis/test/examples/multiple_tags_in_one_components.tsx
@@ -1,0 +1,16 @@
+import { Box } from '@semcore/base-components';
+import Ellipsis from '@semcore/ellipsis';
+import { Text } from '@semcore/typography';
+import React from 'react';
+
+const Demo = () => {
+  return (
+    <Box w='240px'>
+      <Text tag={[Ellipsis, 'h2']} size={400} bold noWrap>
+        2. Very long text Very long text Very long text
+      </Text>
+    </Box>
+  );
+};
+
+export default Demo;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
As we have property `tag` for change some components behavior we can't at the same time change `html` tag of this component. I added ability to set `tag` as a tuple `[OUR_CUSTOM_TAG, HTML_TAG]`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually. I added test story in ellipsis
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [ ] I have added new tests on added of fixed functionality.
