### PR TITLE
[UIK-3813][d3-chart] fixed legend pattern interaction

### DIFF
--- a/semcore/d3-chart/CHANGELOG.md
+++ b/semcore/d3-chart/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG.md standards are inspired by [keepachangelog.com](https://keepachangel
 ### Fixed
 
 - Chart content remains visible after unchecking single legend item in Bar, Horizontal Bar, Histogram, and Stacked Horizontal Bar charts.
-
+- Clicking on pattern icons in legend items with checkboxes has no effect despite interactive cursor.
 
 ## [16.2.0] - 2025-10-03
 

--- a/semcore/d3-chart/__tests__/index.test.tsx
+++ b/semcore/d3-chart/__tests__/index.test.tsx
@@ -13,6 +13,7 @@ import {
   XAxis,
   makeDataHintsContainer,
   Chart,
+  ChartLegend,
   // @ts-ignore
 } from '../src';
 import { PlotA11yView } from '../src/a11y/PlotA11yView';
@@ -265,6 +266,36 @@ describe('XAxis', () => {
       await expect(await snapshot(component)).toMatchImageSnapshot(task);
     },
   );
+});
+
+describe('ChartLegend', () => {
+  test.concurrent('should support pattern interactivity for shape=\'checkbox\'', () => {
+    const onChangeHandler = vi.fn();
+
+    const legendItems = [{
+      id: 'id1',
+      label: `Line 1`,
+      checked: true,
+      color: `chart-palette-order`,
+    }];
+
+    const { container } = render(
+      <ChartLegend
+        items={legendItems}
+        onChangeVisibleItem={onChangeHandler}
+        patterns
+        aria-label='Area chart legend'
+      />,
+    );
+
+    const svg = container.querySelector('svg');
+
+    expect(svg).not.toBe(null);
+
+    fireEvent.click(svg!);
+
+    expect(onChangeHandler).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('utils', () => {

--- a/semcore/d3-chart/src/component/ChartLegend/LegendItem/LegendItem.tsx
+++ b/semcore/d3-chart/src/component/ChartLegend/LegendItem/LegendItem.tsx
@@ -164,7 +164,7 @@ function Shape(props: IRootComponentProps & ShapeProps & DOMAttributes<HTMLLabel
           aria-labelledby={props['aria-labelledby']}
         />
         {patterns && (
-          <Box mt='2px' mr={1}>
+          <Box mt='2px' mr={1} onClick={() => onChange(!checked)}>
             <SPatternSymbol color={color} patternKey={patternKey} aria-hidden />
           </Box>
         )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Pattern icons inside legend items with checkboxes appear interactive due to the pointer cursor but do not respond to clicks.

## How has this been tested?

I've added unit test.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have added changelog note to corresponding `CHANGELOG.md` file with planned publish date.
- [x] I have added new tests on added of fixed functionality.
