### PR TITLE
[docs] add lost illustration to showcase page

### DIFF
--- a/website/docs/style/illustration/illustrations-list.js
+++ b/website/docs/style/illustration/illustrations-list.js
@@ -13,6 +13,10 @@ const illustartionsList = {
       group: 'States',
     },
     {
+      name: 'Nexttime',
+      group: 'States',
+    },
+    {
       name: 'NothingFound',
       group: 'States',
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Found that `Nexttime` illustration for our `Illustration` component isn't shown on the showcase page.

<img width="740" height="391" alt="image" src="https://github.com/user-attachments/assets/4f0c9d05-4194-4586-ac6e-1af2f2f39557" />

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

Manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.
