### PR TITLE
[docs] linked counter to textarea

### DIFF
--- a/website/docs/components/textarea/textarea-code.md
+++ b/website/docs/components/textarea/textarea-code.md
@@ -17,3 +17,7 @@ To control the automatic stretching, you can set limits on the number of lines u
 </script>
 
 :::
+
+## Input limit
+
+The [Counter in forms](../counter/counter-code#counter-in-forms) example demonstrates handling input limits in Textarea.

--- a/website/docs/components/textarea/textarea.md
+++ b/website/docs/components/textarea/textarea.md
@@ -33,7 +33,7 @@ Avoid making the textarea smaller than 160-200px in width and 3-4 rows in height
 
 ## Counter
 
-Textarea may include a counter displaying the number of characters entered, character limits, etc.
+Textarea may include a counter displaying the number of characters entered, character limits, etc. Refer to [Counter](../counter/counter#appearance) to learn more about limiting input in Textarea.
 
 The counter can be positioned next to the text label or close to the textarea itself.
 


### PR DESCRIPTION
## Motivation and Context

Linked counter from Textarea, so the information about handling limits in Textarea is more accessible.
Reason: I received a question about how to handle limits in Textarea and discovered that it's described only in Counter and there's no links from Textarea to Counter.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
