### PR TITLE
[UIK-4444][data-table] handle blur with both keyboard and mouns interactions

### DIFF
--- a/semcore/data-table/src/components/Head/Column.tsx
+++ b/semcore/data-table/src/components/Head/Column.tsx
@@ -215,7 +215,7 @@ export class Column<
 
   handleBlur = (e: React.FocusEvent<HTMLElement>) => {
     const relatedTarget = e.relatedTarget as HTMLElement | undefined;
-    if (!isFocusInside(e.currentTarget, relatedTarget) && lastInteraction.isKeyboard()) {
+    if (!isFocusInside(e.currentTarget, relatedTarget)) {
       this.setState({ sortVisible: false });
     }
   };


### PR DESCRIPTION
## Changelog

### @semcore/data-table

#### Fixed

- Sorted column remains visually selected after sorting another column via mouse when sorted was focused

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
