### PR TITLE
[UIK-4865][website] added tbody and thead to DO-DONT tables

### DIFF
--- a/website/docs/.vitepress/theme/DosDonts.vue
+++ b/website/docs/.vitepress/theme/DosDonts.vue
@@ -1,17 +1,21 @@
 <template>
   <table class="dosdonts">
-    <tr>
-      <th>Don’t</th>
-      <th>Do</th>
-    </tr>
-    <tr>
-      <td>
-        <slot name="dont"></slot>
-      </td>
-      <td>
-        <slot name="do"></slot>
-      </td>
-    </tr>
+    <thead>
+      <tr>
+        <th>Don’t</th>
+        <th>Do</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <slot name="dont"></slot>
+        </td>
+        <td>
+          <slot name="do"></slot>
+        </td>
+      </tr>
+    </tbody>
   </table>
 </template>
 
@@ -35,6 +39,7 @@
 
 .dosdonts tr {
   border-bottom: none;
+  background: transparent;
 }
 
 .dosdonts th {


### PR DESCRIPTION
## Motivation and Context

Added tbody and thead to the "do and don't" tables to get rid of the warnings from vitepress:
<img width="1294" height="327" alt="image" src="https://github.com/user-attachments/assets/a1fb96eb-a1d2-4beb-8bcc-4f94669cd800" />

These tables are used in the Content section, e.g.: http://localhost:5173/intergalactic/content/capitalization/capitalization

## How has this been tested?

Manually checked that warnings don't appear anymore.
Tables' look isn't affected.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
