### PR TITLE
[UIK-4878] TrendHistogram displayName and playground

### DIFF
--- a/playground/entries/Chart/MiniChart.tsx
+++ b/playground/entries/Chart/MiniChart.tsx
@@ -12,6 +12,8 @@ const MiniCharts = [
   'scoreSemiDonut',
   'trendArea',
   'trendLine',
+  'trendBar',
+  'trendHistogram',
 ] as const;
 
 type MiniChartProps = {
@@ -54,6 +56,34 @@ const TypeToMiniChartComponent: { [key in MiniChartProps['type']]: React.JSX.Ele
   trendLine: (
     <MiniChart.TrendLine
       data={[20, 50, 33, 80, 70, 35, 10, 40, 90, 50]}
+      w='140px'
+      h='40px'
+    />
+  ),
+  trendBar: (
+    <MiniChart.TrendBar
+      data={[
+        { value: 10 },
+        { value: 20 },
+        { value: 50 },
+        { value: 80, color: 'chart-palette-order-1' },
+        { value: 45 },
+        { value: 66 },
+      ]}
+      w='140px'
+      h='40px'
+    />
+  ),
+  trendHistogram: (
+    <MiniChart.TrendHistogram
+      data={[
+        { value: 10 },
+        { value: 20 },
+        { value: 50 },
+        { value: 80, color: 'chart-palette-order-3' },
+        { value: 45 },
+        { value: 66, color: 'chart-palette-order-6' },
+      ]}
       w='140px'
       h='40px'
     />

--- a/semcore/mini-chart/src/component/trend/Bar.tsx
+++ b/semcore/mini-chart/src/component/trend/Bar.tsx
@@ -115,4 +115,4 @@ export const TrendHistogram = createComponent<'svg', TrendBarProps, {}, typeof T
   },
 );
 
-TrendBar.displayName = 'MiniChart.TrendHistogram';
+TrendHistogram.displayName = 'MiniChart.TrendHistogram';


### PR DESCRIPTION
## Changelog

### @semcore/mini-chart

#### Fixed

- TrendBar and TrendHistogram `displayName`

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

- TrendBar and TrendHistogram are missing from the [mini-chart playground](http://localhost:5173/intergalactic/data-display/mini-chart/mini-chart)
- their displayNames are wrong (can be seen in the playground)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
