### PR TITLE
[dropdown-menu] prevent focus items if focus already in popper

### DIFF
--- a/semcore/dropdown-menu/__tests__/dropdown-menu.browser-test.tsx
+++ b/semcore/dropdown-menu/__tests__/dropdown-menu.browser-test.tsx
@@ -1318,6 +1318,35 @@ test.describe(`${TAG.FUNCTIONAL}`, () => {
     await expect(page.getByText('project 10').first()).toBeVisible();
   });
 
+  test('Verify Focus on input search when menu opened by keyboard ', {
+    tag: [TAG.PRIORITY_HIGH,
+      TAG.KEYBOARD,
+      '@dropdown-menu'],
+  }, async ({ page }) => {
+    await loadPage(page, 'stories/components/dropdown-menu/tests/examples/test-with-content-on-page.tsx', 'en');
+
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Enter');
+    await locators.menuitem(page).first().waitFor({ state: 'visible' });
+    await page.waitForTimeout(200); // this timeout needed for the test to make sure that focus does not move
+
+    await expect(page.getByRole('textbox')).toBeFocused();
+  });
+
+  test('Verify Focus on input search when menu opened by mouse ', {
+    tag: [TAG.PRIORITY_HIGH,
+      TAG.MOUSE,
+      '@dropdown-menu'],
+  }, async ({ page }) => {
+    await loadPage(page, 'stories/components/dropdown-menu/tests/examples/test-with-content-on-page.tsx', 'en');
+
+    await page.getByRole('combobox').first().click();
+    await locators.menuitem(page).first().waitFor({ state: 'visible' });
+    await page.waitForTimeout(200); // this timeout needed for the test to make sure that focus does not move
+
+    await expect(page.getByRole('textbox')).toBeFocused();
+  });
+
   test.describe('DD menu with input tags as trigger', () => {
     test('Verify focus order', {
       tag: [TAG.PRIORITY_HIGH,

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -112,7 +112,9 @@ class DropdownMenuRoot extends AbstractDropdown {
 
   afterOpenPopper() {
     const { selected, options } = this.menuElements;
+    const isFocusAlreadyInPopper = isFocusInside(this.popperRef.current);
 
+    if (isFocusAlreadyInPopper) return;
     if (selected && options && !this.menuRef.current?.dataset.isVirtual) return;
 
     super.afterOpenPopper();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
