### PR TITLE
[UIK-4947][d3-chart] add percent formatter for Cigarette chart

### DIFF
--- a/semcore/d3-chart/__tests__/index.test.tsx
+++ b/semcore/d3-chart/__tests__/index.test.tsx
@@ -763,6 +763,8 @@ describe('Chart.Cigarette', () => {
   beforeEach(cleanup);
 
   test.concurrent('should call percentFormatter and return correct formatted percent', async () => {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => (cb as any)());
+
     const percentFormatter = vi.fn((value: number) => value.toFixed(2));
 
     const { getByLabelText } = render(
@@ -794,6 +796,8 @@ describe('Chart.Cigarette', () => {
     expect(percentFormatter).toHaveNthReturnedWith(1, '23.81');
     expect(percentFormatter).toHaveNthReturnedWith(2, '52.38');
     expect(percentFormatter).toHaveNthReturnedWith(3, '23.81');
+
+    (window.requestAnimationFrame as any).mockRestore();
   });
 });
 

--- a/semcore/d3-chart/__tests__/index.test.tsx
+++ b/semcore/d3-chart/__tests__/index.test.tsx
@@ -759,6 +759,46 @@ describe('Chart.Venn', () => {
   });
 });
 
+describe('Chart.Cigarette', () => {
+  beforeEach(cleanup);
+
+  test.concurrent('should call percentFormatter and return correct formatted percent', async () => {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => (cb as any)());
+
+    const percentFormatter = vi.fn((value: number) => value.toFixed(2));
+
+    const { getByLabelText } = render(
+      <Chart.Cigarette
+        data={{
+          Cats: 5,
+          Capybaras: 11,
+          Birds: 5,
+        }}
+        plotWidth={400}
+        plotHeight={28}
+        showPercentValueInTooltip={true}
+        percentFormatter={percentFormatter}
+        duration={200}
+        aria-label='Cigarette chart'
+      />,
+    );
+
+    const svg = getByLabelText('Chart');
+    fireEvent.mouseMove(svg, {
+      clientX: 200,
+      clientY: 14,
+    });
+
+    expect(percentFormatter).toHaveBeenNthCalledWith(1, (5 * 100) / 21);
+    expect(percentFormatter).toHaveBeenNthCalledWith(2, (11 * 100) / 21);
+    expect(percentFormatter).toHaveBeenNthCalledWith(3, (5 * 100) / 21);
+
+    expect(percentFormatter).toHaveNthReturnedWith(1, '23.81');
+    expect(percentFormatter).toHaveNthReturnedWith(2, '52.38');
+    expect(percentFormatter).toHaveNthReturnedWith(3, '23.81');
+  });
+});
+
 describe('ChartLegend', () => {
   beforeEach(cleanup);
   afterEach(cleanup);

--- a/semcore/d3-chart/__tests__/index.test.tsx
+++ b/semcore/d3-chart/__tests__/index.test.tsx
@@ -763,8 +763,6 @@ describe('Chart.Cigarette', () => {
   beforeEach(cleanup);
 
   test.concurrent('should call percentFormatter and return correct formatted percent', async () => {
-    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => (cb as any)());
-
     const percentFormatter = vi.fn((value: number) => value.toFixed(2));
 
     const { getByLabelText } = render(

--- a/semcore/d3-chart/src/component/Chart/AbstractChart.tsx
+++ b/semcore/d3-chart/src/component/Chart/AbstractChart.tsx
@@ -286,24 +286,6 @@ export abstract class AbstractChart<
     return total;
   }
 
-  protected percentValue(data: ObjectData, key: string): string {
-    const total = this.totalValue(data);
-
-    const value = data[key];
-
-    if (typeof value === 'number' && total !== 0) {
-      const percent = Math.round((100 * value) / total);
-
-      return `${percent}%`;
-    }
-
-    if (value === null) {
-      return `0%`;
-    }
-
-    return NOT_A_VALUE;
-  }
-
   protected getValueScale(values: number[]): number {
     const max = Math.max(...values);
     const min = Math.min(...values);

--- a/semcore/d3-chart/src/component/Chart/CigaretteChart.tsx
+++ b/semcore/d3-chart/src/component/Chart/CigaretteChart.tsx
@@ -369,6 +369,27 @@ class CigaretteChartComponent extends AbstractChart<
     );
   }
 
+  protected percentValue(data: ObjectData, key: string): string {
+    const { percentFormatter } = this.asProps;
+
+    const total = this.totalValue();
+
+    const value = data[key];
+
+    if (typeof value === 'number' && total !== 0) {
+      const rawPercent = (100 * value) / total;
+      const formattedPercent = percentFormatter ? percentFormatter(rawPercent) : Math.round(rawPercent);
+
+      return `${formattedPercent}%`;
+    }
+
+    if (value === null) {
+      return `0%`;
+    }
+
+    return NOT_A_VALUE;
+  }
+
   protected override renderTooltipTotalLine<D extends ObjectData>(dataItem: D) {
     const { showTotalInTooltip, showPercentValueInTooltip } = this.asProps;
 

--- a/semcore/d3-chart/src/component/Chart/CigaretteChart.type.ts
+++ b/semcore/d3-chart/src/component/Chart/CigaretteChart.type.ts
@@ -18,6 +18,8 @@ export type CigaretteChartProps = Intergalactic.InternalTypings.EfficientOmit<
   tooltipViewType?: 'all' | 'single';
   /** Show percent value in tooltip */
   showPercentValueInTooltip?: boolean;
+  /** Custom percent formatter. */
+  percentFormatter?: (value: number) => number;
   /** Header content for the chart */
   header?: React.ReactNode;
   /** Animation duration in milliseconds */

--- a/stories/components/d3-chart/tests/cigarette-chart.stories.tsx
+++ b/stories/components/d3-chart/tests/cigarette-chart.stories.tsx
@@ -34,7 +34,18 @@ export const BasicUsage = {
     tooltipViewType: { control: { type: 'select' }, options: ['all', 'single'] },
     enableMinimalBarWidth: { control: { type: 'boolean' } },
     minimalBarWidth: { control: { type: 'number' } },
-    percentFormatter: { control: { type: 'select' }, options: ['none', 'round', 'floor', 'toFixed2'], mapping: { none: undefined, round: (v: number) => Math.round(v), floor: (v: number) => Math.floor(v), toFixed2: (v: number) => Number(v.toFixed(2)) } },
+    percentFormatter: {
+      control: { type: 'select' },
+      options: ['none', 'round', 'floor', 'ceil', 'toFixed1', 'toFixed2'],
+      mapping: {
+        none: undefined,
+        round: (v: number) => Math.round(v),
+        floor: (v: number) => Math.floor(v),
+        ceil: (v: number) => Math.ceil(v),
+        toFixed1: (v: number) => Number(v.toFixed(1)),
+        toFixed2: (v: number) => Number(v.toFixed(2)),
+      },
+    },
     duration: { control: { type: 'number' } },
     data: {
       control: { type: 'select' },

--- a/stories/components/d3-chart/tests/cigarette-chart.stories.tsx
+++ b/stories/components/d3-chart/tests/cigarette-chart.stories.tsx
@@ -34,6 +34,7 @@ export const BasicUsage = {
     tooltipViewType: { control: { type: 'select' }, options: ['all', 'single'] },
     enableMinimalBarWidth: { control: { type: 'boolean' } },
     minimalBarWidth: { control: { type: 'number' } },
+    percentFormatter: { control: { type: 'select' }, options: ['none', 'round', 'floor', 'toFixed2'], mapping: { none: undefined, round: (v: number) => Math.round(v), floor: (v: number) => Math.floor(v), toFixed2: (v: number) => Number(v.toFixed(2)) } },
     duration: { control: { type: 'number' } },
     data: {
       control: { type: 'select' },

--- a/stories/components/d3-chart/tests/cigarette-chart.stories.tsx
+++ b/stories/components/d3-chart/tests/cigarette-chart.stories.tsx
@@ -36,14 +36,14 @@ export const BasicUsage = {
     minimalBarWidth: { control: { type: 'number' } },
     percentFormatter: {
       control: { type: 'select' },
-      options: ['none', 'round', 'floor', 'ceil', 'toFixed1', 'toFixed2'],
+      options: ['none', 'round', 'floor', 'ceil', 'oneDecimal', 'twoDecimal'],
       mapping: {
         none: undefined,
         round: (v: number) => Math.round(v),
         floor: (v: number) => Math.floor(v),
         ceil: (v: number) => Math.ceil(v),
-        toFixed1: (v: number) => Number(v.toFixed(1)),
-        toFixed2: (v: number) => Number(v.toFixed(2)),
+        oneDecimal: (v: number) => Number(v.toFixed(1)),
+        twoDecimal: (v: number) => Number(v.toFixed(2)),
       },
     },
     duration: { control: { type: 'number' } },

--- a/stories/components/d3-chart/tests/examples/cigarette-chart/basic-usage.tsx
+++ b/stories/components/d3-chart/tests/examples/cigarette-chart/basic-usage.tsx
@@ -76,6 +76,7 @@ export const defaultProps = getChartProps<CigaretteChartProps>({
   invertAxis: true,
   showPercentValueInTooltip: true,
   minimalBarWidth: 2,
+  percentFormatter: undefined,
   tooltipTitle: '',
   tooltipViewType: 'all',
   duration: 200,

--- a/tools/testing-utils/setupTests.ts
+++ b/tools/testing-utils/setupTests.ts
@@ -38,3 +38,5 @@ class ResizeObserverMock {
   disconnect() {}
 }
 (window as any).ResizeObserver = ResizeObserverMock;
+
+(window as any).requestAnimationFrame = vi.fn().mockImplementation((cb) => (cb as any)());

--- a/tools/testing-utils/setupTests.ts
+++ b/tools/testing-utils/setupTests.ts
@@ -38,5 +38,3 @@ class ResizeObserverMock {
   disconnect() {}
 }
 (window as any).ResizeObserver = ResizeObserverMock;
-
-(window as any).requestAnimationFrame = vi.fn().mockImplementation((cb) => (cb as any)());


### PR DESCRIPTION
## Changelog

### @semcore/d3-chart

#### Added

- `percentFormatter` for Cigarette.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Added `percentFormatter` prop for `Chart.Cigarette`.

## How has this been tested?
 I've added unit test.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have added new tests on added of fixed functionality.
