### PR TITLE
[UIK-4915][d3-chart] add cursor style for Bubble chart

### DIFF
--- a/semcore/d3-chart/src/Bubble.jsx
+++ b/semcore/d3-chart/src/Bubble.jsx
@@ -94,6 +94,7 @@ class BubbleRoot extends Component {
       transparent,
       resolveColor,
       patterns,
+      onClick,
     } = this.asProps;
 
     return {
@@ -114,6 +115,7 @@ class BubbleRoot extends Component {
       resolveColor,
       patterns,
       bindHandlerTooltip: this.bindHandlerTooltip,
+      clickable: Boolean(onClick),
       onClickCircleRoot: this.handlerOnClick.bind(this),
     };
   }
@@ -176,6 +178,7 @@ function BubbleCircle(props) {
     bindHandlerTooltip,
     Element,
     visible = true,
+    clickable,
     onClick,
     onClickCircleRoot,
   } = props;
@@ -237,6 +240,7 @@ function BubbleCircle(props) {
         r={z(circleData[value])}
         use:duration={`${duration}ms`}
         transparent={transparent}
+        clickable={clickable || Boolean(onClick)}
       />
       {patterns && (
         <PatternFill

--- a/semcore/d3-chart/src/style/bubble.shadow.css
+++ b/semcore/d3-chart/src/style/bubble.shadow.css
@@ -18,6 +18,10 @@ g[visible='false'] {
   display: none;
 }
 
+SBubble[clickable] {
+  cursor: pointer;
+}
+
 SBubble[color] {
   fill: var(--color);
 }


### PR DESCRIPTION
## Changelog

### @semcore/d3-chart

#### Added

- Added `cursor:pointer` for `Bubble` chart in case bubbles are clickable.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Added `cursor:pointer` for `Bubble` chart in case bubbles are clickable.

## How has this been tested?

Manually

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
