### PR TITLE
[UIK-5126][dot] rewrite atomic types to namespace/deprecate atomic types/update types among the project

### DIFF
--- a/playground/entries/Dot.tsx
+++ b/playground/entries/Dot.tsx
@@ -1,5 +1,5 @@
 import Button from '@semcore/ui/button';
-import type { DotProps } from '@semcore/ui/dot';
+import type { NSDot } from '@semcore/ui/dot';
 import Dot from '@semcore/ui/dot';
 import React from 'react';
 
@@ -8,7 +8,7 @@ import type { PlaygroundEntry } from '../types/Playground';
 import createGithubLink from '../utils/createGHLink';
 
 type AdditionalJSXProps = { value: string };
-export type DotJSXProps = JSXProps<DotProps> & AdditionalJSXProps;
+export type DotJSXProps = JSXProps<NSDot.Props> & AdditionalJSXProps;
 
 function getJSX(props: DotJSXProps) {
   const { handleControlChange, ...dotProps } = props;

--- a/semcore/dot/src/Dot.tsx
+++ b/semcore/dot/src/Dot.tsx
@@ -8,11 +8,11 @@ import uniqueIDEnhancement from '@semcore/core/lib/utils/uniqueID';
 import { cssVariableEnhance } from '@semcore/core/lib/utils/useCssVariable';
 import React from 'react';
 
-import type { DotComponent, DotProps } from './Dot.type';
+import type { NSDot } from './Dot.type';
 import style from './style/dot.shadow.css';
 
 class DotRoot extends Component<
-  Intergalactic.InternalTypings.InferComponentProps<DotComponent>,
+  Intergalactic.InternalTypings.InferComponentProps<NSDot.Component>,
   typeof DotRoot.enhance
 > {
   static displayName = 'Dot';
@@ -30,7 +30,7 @@ class DotRoot extends Component<
       map: (value: string) => `${Number.parseInt(value)}`,
       prop: 'duration',
     }),
-    contextThemeEnhance(({ hidden }: DotProps) => !hidden),
+    contextThemeEnhance(({ hidden }: NSDot.Props) => !hidden),
   ] as const;
 
   ref = React.createRef();
@@ -89,6 +89,6 @@ class DotRoot extends Component<
   }
 }
 
-const Dot = createComponent(DotRoot) as DotComponent;
+const Dot = createComponent(DotRoot) as NSDot.Component;
 
 export default Dot;

--- a/semcore/dot/src/Dot.type.ts
+++ b/semcore/dot/src/Dot.type.ts
@@ -1,8 +1,8 @@
 import type { AnimationProps, BoxProps } from '@semcore/base-components';
 import type { Intergalactic } from '@semcore/core';
 
-export type DotProps = BoxProps &
-  AnimationProps & {
+declare namespace NSDot {
+  type Props = BoxProps & AnimationProps & {
     /** Size of the dot
      * @default m
      */
@@ -15,4 +15,10 @@ export type DotProps = BoxProps &
     hidden?: boolean;
   };
 
-export type DotComponent = Intergalactic.Component<'div', DotProps>;
+  type Component = Intergalactic.Component<'div', Props>;
+}
+
+/** @deprecated It will be removed in v18. */
+export type DotProps = NSDot.Props;
+
+export type { NSDot };

--- a/stories/components/dot/tests/examples/sizes-and-positions.tsx
+++ b/stories/components/dot/tests/examples/sizes-and-positions.tsx
@@ -2,12 +2,12 @@ import { Flex } from '@semcore/ui/base-components';
 import { LinkTrigger } from '@semcore/ui/base-trigger';
 import Button from '@semcore/ui/button';
 import Dot from '@semcore/ui/dot';
-import type { DotProps } from '@semcore/ui/dot';
+import type { NSDot } from '@semcore/ui/dot';
 import Link from '@semcore/ui/link';
 import Pills from '@semcore/ui/pills';
 import React from 'react';
 
-const Demo = (props: DotProps) => {
+const Demo = (props: NSDot.Props) => {
   return (
     <Flex direction='row' gap={2} alignItems='center'>
 
@@ -59,7 +59,7 @@ const Demo = (props: DotProps) => {
   );
 };
 
-export const defaultDotProps: DotProps = {
+export const defaultDotProps: NSDot.Props = {
   size: 'm',
   up: undefined,
 };

--- a/stories/components/dot/tests/examples/with-counter-sizes-and-positions.tsx
+++ b/stories/components/dot/tests/examples/with-counter-sizes-and-positions.tsx
@@ -2,12 +2,12 @@ import { Flex } from '@semcore/ui/base-components';
 import { LinkTrigger } from '@semcore/ui/base-trigger';
 import Button from '@semcore/ui/button';
 import Dot from '@semcore/ui/dot';
-import type { DotProps } from '@semcore/ui/dot';
+import type { NSDot } from '@semcore/ui/dot';
 import Link from '@semcore/ui/link';
 import Pills from '@semcore/ui/pills';
 import React from 'react';
 
-const Demo = (props: DotProps) => {
+const Demo = (props: NSDot.Props) => {
   return (
     <Flex direction='row' gap={2} alignItems='center'>
 
@@ -69,7 +69,7 @@ const Demo = (props: DotProps) => {
   );
 };
 
-export const defaultCounterDotProps: DotProps = {
+export const defaultCounterDotProps: NSDot.Props = {
   size: 'm',
   up: undefined,
 };

--- a/website/docs/components/dot/dot-api.md
+++ b/website/docs/components/dot/dot-api.md
@@ -11,6 +11,6 @@ import Dot from '@semcore/ui/dot';
 <Dot aria-label="..." />;
 ```
 
-<TypesView type="DotProps" :types={...types} />
+<TypesView type="NSDot.Props" :types={...types} />
 
 <script setup>import { data as types } from '@types.data.ts';</script>


### PR DESCRIPTION
## Changelog

### @semcore/dot

#### Fixed

- Deprecated atomic types. Atomic parts are part of `NSDot` namespace.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

Manually

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
