### PR TITLE
[UIK-5125][divider] rewrite atomic types to namespace/deprecate atomic types/update types among the project

### DIFF
--- a/playground/entries/Divider.tsx
+++ b/playground/entries/Divider.tsx
@@ -1,4 +1,4 @@
-import type { DividerProps } from '@semcore/ui/divider';
+import type { NSDivider } from '@semcore/ui/divider';
 import Divider from '@semcore/ui/divider';
 import React from 'react';
 
@@ -6,7 +6,7 @@ import type { JSXProps } from '../types/JSXProps';
 import type { PlaygroundEntry } from '../types/Playground';
 import createGithubLink from '../utils/createGHLink';
 
-export type DividerJSXProps = JSXProps<DividerProps>;
+export type DividerJSXProps = JSXProps<NSDivider.Props>;
 
 function getJSX({ handleControlChange, ...dividerProps }: DividerJSXProps) {
   const { orientation } = dividerProps;

--- a/semcore/divider/src/Divider.tsx
+++ b/semcore/divider/src/Divider.tsx
@@ -4,10 +4,10 @@ import { createComponent, Component, Root, sstyled } from '@semcore/core';
 import resolveColorEnhance from '@semcore/core/lib/utils/enhances/resolveColorEnhance';
 import React from 'react';
 
-import type { DividerComponent } from './Divider.type';
+import type { NSDivider } from './Divider.type';
 import style from './style/divider.shadow.css';
 
-class DividerRoot extends Component<Intergalactic.InternalTypings.InferComponentProps<DividerComponent>, typeof DividerRoot.enhance> {
+class DividerRoot extends Component<Intergalactic.InternalTypings.InferComponentProps<NSDivider.Component>, typeof DividerRoot.enhance> {
   static displayName = 'Divider';
   static style = style;
   static enhance = [resolveColorEnhance()] as const;
@@ -31,6 +31,6 @@ class DividerRoot extends Component<Intergalactic.InternalTypings.InferComponent
   }
 }
 
-const Divider = createComponent(DividerRoot) as DividerComponent;
+const Divider = createComponent(DividerRoot) as NSDivider.Component;
 
 export default Divider;

--- a/semcore/divider/src/Divider.type.ts
+++ b/semcore/divider/src/Divider.type.ts
@@ -1,21 +1,28 @@
 import type { BoxProps } from '@semcore/base-components';
 import type { Intergalactic } from '@semcore/core';
 
-export type DividerProps = BoxProps & {
-  /**
-   * Type of the divider
-   * @default primary
-   */
-  use?: 'primary' | 'secondary';
-  /**
-   * Theme of the divider
-   */
-  theme?: string | 'invert';
-  /**
-   * Orientation of the divider
-   * @default horizontal
-   */
-  orientation?: 'horizontal' | 'vertical';
-};
+declare namespace NSDivider {
+  type Props = BoxProps & {
+    /**
+     * Type of the divider
+     * @default primary
+     */
+    use?: 'primary' | 'secondary';
+    /**
+     * Theme of the divider
+     */
+    theme?: string | 'invert';
+    /**
+     * Orientation of the divider
+     * @default horizontal
+     */
+    orientation?: 'horizontal' | 'vertical';
+  };
 
-export type DividerComponent = Intergalactic.Component<'div', DividerProps>;
+  type Component = Intergalactic.Component<'div', Props>;
+}
+
+/** @deprecated It will be removed in v18. */
+export type DividerProps = NSDivider.Props;
+
+export type { NSDivider };

--- a/stories/components/divider/tests/examples/divider-styles.tsx
+++ b/stories/components/divider/tests/examples/divider-styles.tsx
@@ -1,10 +1,10 @@
 import type { BoxProps } from '@semcore/ui/base-components';
 import { Flex } from '@semcore/ui/base-components';
 import Divider from '@semcore/ui/divider';
-import type { DividerProps } from '@semcore/ui/divider';
+import type { NSDivider } from '@semcore/ui/divider';
 import React from 'react';
 
-type DividerStylesExample = DividerProps & BoxProps;
+type DividerStylesExample = NSDivider.Props;
 const Demo = (props: DividerStylesExample) => {
   return (
     <>

--- a/website/docs/components/divider/divider-api.md
+++ b/website/docs/components/divider/divider-api.md
@@ -11,6 +11,6 @@ import Divider from '@semcore/ui/divider';
 <Divider />;
 ```
 
-<TypesView type="DividerProps" :types={...types} />
+<TypesView type="NSDivider.Props" :types={...types} />
 
 <script setup>import { data as types } from '@types.data.ts';</script>


### PR DESCRIPTION
## Changelog

### @semcore/divider

#### Fixed

- Deprecated atomic types. Atomic parts are part of `NSDivider` namespace.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

Manually

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
