### PR TITLE
[UIK-5127][errors] rewrite atomic types to namespace/deprecate atomic types/update types among the project

### DIFF
--- a/semcore/errors/src/AccessDenied/AccessDenied.tsx
+++ b/semcore/errors/src/AccessDenied/AccessDenied.tsx
@@ -4,12 +4,12 @@ import { createComponent, Component, Root } from '@semcore/core';
 import i18nEnhance from '@semcore/core/lib/utils/enhances/i18nEnhance';
 import React from 'react';
 
-import type { AccessDeniedComponent } from './AccessDenied.type';
+import type { NSAccessDenied } from './AccessDenied.type';
 import Error, { getIconPath } from '../Error';
 import { localizedMessages } from './translations/__intergalactic-dynamic-locales';
 
 class RootAccessDenied extends Component<
-  Intergalactic.InternalTypings.InferComponentProps<AccessDeniedComponent>,
+  Intergalactic.InternalTypings.InferComponentProps<NSAccessDenied.Component>,
   typeof RootAccessDenied.enhance
 > {
   static displayName = 'AccessDenied';
@@ -39,4 +39,4 @@ class RootAccessDenied extends Component<
   }
 }
 
-export default createComponent(RootAccessDenied) as AccessDeniedComponent;
+export default createComponent(RootAccessDenied) as NSAccessDenied.Component;

--- a/semcore/errors/src/AccessDenied/AccessDenied.type.ts
+++ b/semcore/errors/src/AccessDenied/AccessDenied.type.ts
@@ -1,19 +1,26 @@
 import type { Intergalactic } from '@semcore/core';
 import type { WithI18nEnhanceProps } from '@semcore/core/lib/utils/enhances/i18nEnhance';
 
-import type { ErrorsProps } from '../Error.type';
+import type { NSErrors } from '../Error.type';
 
-export type AccessDeniedProps = WithI18nEnhanceProps & {
-  /**
-   * href of the home link
-   * @default /
-   */
-  homeLink?: string;
-  /**
-   * HTML tag of the error title
-   * @default h2
-   */
-  titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'p';
-};
+declare namespace NSAccessDenied {
+  type Props = WithI18nEnhanceProps & {
+    /**
+     * href of the home link
+     * @default /
+     */
+    homeLink?: string;
+    /**
+     * HTML tag of the error title
+     * @default h2
+     */
+    titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'p';
+  };
 
-export type AccessDeniedComponent = Intergalactic.Component<'div', AccessDeniedProps & ErrorsProps>;
+  type Component = Intergalactic.Component<'div', Props & NSErrors.Props>;
+}
+
+/** @deprecated It will be removed in v18. */
+export type AccessDeniedProps = NSAccessDenied.Props;
+
+export type { NSAccessDenied };

--- a/semcore/errors/src/Error.tsx
+++ b/semcore/errors/src/Error.tsx
@@ -4,13 +4,13 @@ import { createComponent, Root, Component, sstyled } from '@semcore/core';
 import { getIllustrationPath } from '@semcore/illustration';
 import React from 'react';
 
-import type { ErrorComponent, ErrorControlsComponent, ErrorDescriptionComponent, ErrorRootComponent, ErrorTitleComponent, IconNamesErrors } from './Error.type';
+import type { NSErrors } from './Error.type';
 import style from './style/errors.shadow.css';
 
-export const getIconPath = (name: IconNamesErrors) => getIllustrationPath(name);
+export const getIconPath = (name: NSErrors.IconName) => getIllustrationPath(name);
 
 class RootError extends Component<
-  Intergalactic.InternalTypings.InferComponentProps<ErrorRootComponent>
+  Intergalactic.InternalTypings.InferComponentProps<NSErrors.Component>
 > {
   static displayName = 'Error';
   static style = style;
@@ -39,17 +39,17 @@ class RootError extends Component<
   }
 }
 
-function Title(props: Intergalactic.InternalTypings.InferComponentProps<ErrorTitleComponent>) {
+function Title(props: Intergalactic.InternalTypings.InferComponentProps<NSErrors.Title.Component>) {
   const STitle = Root;
   return sstyled(props.styles)(<STitle render={Box} data-errors-title tag='h2' />);
 }
 
-function Description(props: Intergalactic.InternalTypings.InferComponentProps<ErrorDescriptionComponent>) {
+function Description(props: Intergalactic.InternalTypings.InferComponentProps<NSErrors.Description.Component>) {
   const SDescription = Root;
   return sstyled(props.styles)(<SDescription render={Box} tag='p' />);
 }
 
-function Controls(props: Intergalactic.InternalTypings.InferComponentProps<ErrorControlsComponent>) {
+function Controls(props: Intergalactic.InternalTypings.InferComponentProps<NSErrors.Controls.Component>) {
   const SControls = Root;
   return sstyled(props.styles)(<SControls render={Box} />);
 }
@@ -58,6 +58,6 @@ const Error = createComponent(RootError, {
   Title,
   Description,
   Controls,
-}) as ErrorComponent;
+}) as NSErrors.Component;
 
 export default Error;

--- a/semcore/errors/src/Error.type.ts
+++ b/semcore/errors/src/Error.type.ts
@@ -3,29 +3,45 @@ import type { Intergalactic, PropGetterFn } from '@semcore/core';
 import type { TIllustrationNamesErrors } from '@semcore/illustration';
 import type React from 'react';
 
-export type IconNamesErrors = TIllustrationNamesErrors;
+declare namespace NSErrors {
+  type Props = FlexProps & {
+    /**
+     * Error icon
+     * Icon as a string is a URL to an image.
+     */
+    icon?: string | React.ReactNode;
+  };
+  type Ctx = {
+    getTextProps: PropGetterFn;
+    getDescriptionProps: PropGetterFn;
+    getControlsProps: PropGetterFn;
+  };
+  type IconName = TIllustrationNamesErrors;
 
-export type ErrorsProps = FlexProps & {
-  /**
-   * Error icon
-   * Icon as a string is a URL to an image.
-   */
-  icon?: string | React.ReactNode;
-};
+  namespace Title {
+    type Component = typeof Box;
+  }
 
-export type ErrorsContext = {
-  getTextProps: PropGetterFn;
-  getDescriptionProps: PropGetterFn;
-  getControlsProps: PropGetterFn;
-};
+  namespace Description {
+    type Component = typeof Box;
+  }
 
-export type ErrorRootComponent = Intergalactic.Component<'div', ErrorsProps, ErrorsContext>;
-export type ErrorTitleComponent = typeof Box;
-export type ErrorDescriptionComponent = typeof Box;
-export type ErrorControlsComponent = typeof Box;
+  namespace Controls {
+    type Component = typeof Box;
+  }
 
-export type ErrorComponent = ErrorRootComponent & {
-  Title: ErrorTitleComponent;
-  Description: ErrorDescriptionComponent;
-  Controls: ErrorControlsComponent;
-};
+  type Component = Intergalactic.Component<'div', Props, Ctx> & {
+    Title: Title.Component;
+    Description: Description.Component;
+    Controls: Controls.Component;
+  };
+}
+
+/** @deprecated It will be removed in v18. */
+export type ErrorsProps = NSErrors.Props;
+/** @deprecated It will be removed in v18. */
+export type ErrorsContext = NSErrors.Ctx;
+/** @deprecated It will be removed in v18. */
+export type IconNamesErrors = NSErrors.IconName;
+
+export type { NSErrors };

--- a/semcore/errors/src/Maintenance/Maintenance.tsx
+++ b/semcore/errors/src/Maintenance/Maintenance.tsx
@@ -5,11 +5,11 @@ import i18nEnhance from '@semcore/core/lib/utils/enhances/i18nEnhance';
 import React from 'react';
 
 import Error, { getIconPath } from '../Error';
-import type { MaintenanceComponent } from './Maintenance.type';
+import type { NSMaintenance } from './Maintenance.type';
 import { localizedMessages } from './translations/__intergalactic-dynamic-locales';
 
 class RootMaintenance extends Component<
-  Intergalactic.InternalTypings.InferComponentProps<MaintenanceComponent>,
+  Intergalactic.InternalTypings.InferComponentProps<NSMaintenance.Component>,
   typeof RootMaintenance.enhance
 > {
   static displayName = 'Maintenance';
@@ -40,4 +40,4 @@ class RootMaintenance extends Component<
   }
 }
 
-export default createComponent(RootMaintenance) as MaintenanceComponent;
+export default createComponent(RootMaintenance) as NSMaintenance.Component;

--- a/semcore/errors/src/Maintenance/Maintenance.type.ts
+++ b/semcore/errors/src/Maintenance/Maintenance.type.ts
@@ -1,23 +1,30 @@
 import type { Intergalactic } from '@semcore/core';
 import type { WithI18nEnhanceProps } from '@semcore/core/lib/utils/enhances/i18nEnhance';
 
-import type { ErrorsProps } from '../Error.type';
+import type { NSErrors } from '../Error.type';
 
-export type MaintenanceProps = WithI18nEnhanceProps & {
-  /**
-   * Tool name
-   */
-  toolName: string;
-  /**
-   * href of the home link
-   * @default /
-   */
-  homeLink?: string;
-  /**
-   * HTML tag of the error title
-   * @default h2
-   */
-  titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'p';
-};
+declare namespace NSMaintenance {
+  type Props = WithI18nEnhanceProps & {
+    /**
+     * Tool name
+     */
+    toolName: string;
+    /**
+     * href of the home link
+     * @default /
+     */
+    homeLink?: string;
+    /**
+     * HTML tag of the error title
+     * @default h2
+     */
+    titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'p';
+  };
 
-export type MaintenanceComponent = Intergalactic.Component<'div', MaintenanceProps & ErrorsProps>;
+  type Component = Intergalactic.Component<'div', Props & NSErrors.Props>;
+}
+
+/** @deprecated It will be removed in v18. */
+export type MaintenanceProps = NSMaintenance.Props;
+
+export type { NSMaintenance };

--- a/semcore/errors/src/PageError/PageError.tsx
+++ b/semcore/errors/src/PageError/PageError.tsx
@@ -7,10 +7,10 @@ import i18nEnhance from '@semcore/core/lib/utils/enhances/i18nEnhance';
 import React from 'react';
 
 import Error, { getIconPath } from '../Error';
-import type { PageErrorComponent } from './PageError.type';
+import type { NSPageError } from './PageError.type';
 import { localizedMessages } from './translations/__intergalactic-dynamic-locales';
 class RootPageError extends Component<
-  Intergalactic.InternalTypings.InferComponentProps<PageErrorComponent>,
+  Intergalactic.InternalTypings.InferComponentProps<NSPageError.Component>,
   typeof RootPageError.enhance
 > {
   static displayName = 'PageError';
@@ -51,4 +51,4 @@ class RootPageError extends Component<
   }
 }
 
-export default createComponent(RootPageError) as PageErrorComponent;
+export default createComponent(RootPageError) as NSPageError.Component;

--- a/semcore/errors/src/PageError/PageError.type.ts
+++ b/semcore/errors/src/PageError/PageError.type.ts
@@ -1,19 +1,26 @@
 import type { Intergalactic } from '@semcore/core';
 import type { WithI18nEnhanceProps } from '@semcore/core/lib/utils/enhances/i18nEnhance';
 
-import type { ErrorsProps } from '../Error.type';
+import type { NSErrors } from '../Error.type';
 
-export type PageErrorProps = WithI18nEnhanceProps & {
-  /**
-   * Page reloading button click handler
-   * @default () => { if (canUseDOM()) { location.reload(); } }
-   */
-  onClick?: (e: React.MouseEvent) => void;
-  /**
-   * HTML tag of the error title
-   * @default h2
-   */
-  titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'p';
-};
+declare namespace NSPageError {
+  type Props = WithI18nEnhanceProps & {
+    /**
+     * Page reloading button click handler
+     * @default () => { if (canUseDOM()) { location.reload(); } }
+     */
+    onClick?: (e: React.MouseEvent) => void;
+    /**
+     * HTML tag of the error title
+     * @default h2
+     */
+    titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'p';
+  };
 
-export type PageErrorComponent = Intergalactic.Component<'div', PageErrorProps & ErrorsProps>;
+  type Component = Intergalactic.Component<'div', Props & NSErrors.Props>;
+}
+
+/** @deprecated It will be removed in v18. */
+export type PageErrorProps = NSPageError.Props;
+
+export type { NSPageError };

--- a/semcore/errors/src/PageNotFound/PageNotFound.tsx
+++ b/semcore/errors/src/PageNotFound/PageNotFound.tsx
@@ -5,11 +5,11 @@ import i18nEnhance from '@semcore/core/lib/utils/enhances/i18nEnhance';
 import React from 'react';
 
 import Error, { getIconPath } from '../Error';
-import type { PageNotFoundComponent, PageNotFoundProps } from './PageNotFound.type';
+import type { NSPageNotFound } from './PageNotFound.type';
 import { localizedMessages } from './translations/__intergalactic-dynamic-locales';
 
 class RootPageNotFound extends Component<
-  Intergalactic.InternalTypings.InferComponentProps<PageNotFoundComponent>,
+  Intergalactic.InternalTypings.InferComponentProps<NSPageNotFound.Component>,
   typeof RootPageNotFound.enhance
 > {
   static displayName = 'PageNotFound';
@@ -40,4 +40,4 @@ class RootPageNotFound extends Component<
   }
 }
 
-export default createComponent(RootPageNotFound) as PageNotFoundComponent; ;
+export default createComponent(RootPageNotFound) as NSPageNotFound.Component;

--- a/semcore/errors/src/PageNotFound/PageNotFound.type.ts
+++ b/semcore/errors/src/PageNotFound/PageNotFound.type.ts
@@ -1,19 +1,26 @@
 import type { Intergalactic } from '@semcore/core';
 import type { WithI18nEnhanceProps } from '@semcore/core/lib/utils/enhances/i18nEnhance';
 
-import type { ErrorsProps } from '../Error.type';
+import type { NSErrors } from '../Error.type';
 
-export type PageNotFoundProps = WithI18nEnhanceProps & {
-  /**
-   * href of the home link
-   * @default /
-   */
-  homeLink?: string;
-  /**
-   * HTML tag of the error title
-   * @default h2
-   */
-  titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'p';
-};
+declare namespace NSPageNotFound {
+  type Props = WithI18nEnhanceProps & {
+    /**
+     * href of the home link
+     * @default /
+     */
+    homeLink?: string;
+    /**
+     * HTML tag of the error title
+     * @default h2
+     */
+    titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'p';
+  };
 
-export type PageNotFoundComponent = Intergalactic.Component<'div', PageNotFoundProps & ErrorsProps>;
+  type Component = Intergalactic.Component<'div', Props & NSErrors.Props>;
+}
+
+/** @deprecated It will be removed in v18. */
+export type PageNotFoundProps = NSPageNotFound.Props;
+
+export type { NSPageNotFound };

--- a/semcore/errors/src/ProjectNotFound/ProjectNotFound.tsx
+++ b/semcore/errors/src/ProjectNotFound/ProjectNotFound.tsx
@@ -6,11 +6,11 @@ import { Text } from '@semcore/typography';
 import React from 'react';
 
 import Error, { getIconPath } from '../Error';
-import type { ProjectNotFoundComponent } from './ProjectNotFound.type';
+import type { NSProjectNotFound } from './ProjectNotFound.type';
 import { localizedMessages } from './translations/__intergalactic-dynamic-locales';
 
 class RootProjectNotFound extends Component<
-  Intergalactic.InternalTypings.InferComponentProps<ProjectNotFoundComponent>,
+  Intergalactic.InternalTypings.InferComponentProps<NSProjectNotFound.Component>,
   typeof RootProjectNotFound.enhance
 > {
   static displayName = 'ProjectNotFound';
@@ -53,4 +53,4 @@ class RootProjectNotFound extends Component<
   }
 }
 
-export default createComponent(RootProjectNotFound) as ProjectNotFoundComponent;
+export default createComponent(RootProjectNotFound) as NSProjectNotFound.Component;

--- a/semcore/errors/src/ProjectNotFound/ProjectNotFound.type.ts
+++ b/semcore/errors/src/ProjectNotFound/ProjectNotFound.type.ts
@@ -1,29 +1,36 @@
 import type { Intergalactic } from '@semcore/core';
 import type { WithI18nEnhanceProps } from '@semcore/core/lib/utils/enhances/i18nEnhance';
 
-import type { ErrorsProps } from '../Error.type';
+import type { NSErrors } from '../Error.type';
 
-export type ProjectNotFoundProps = WithI18nEnhanceProps & {
-  /**
-   * URL for the "Go to Projects" button
-   * @default /projects
-   */
-  projectsLink?: string;
-  /**
-   * URL for the "Contact us" button
-   * @default /company/contacts
-   */
-  contactsLink?: string;
-  /**
-   * URL for the "Support Team" link
-   * @default /company/contacts
-   */
-  supportTeamLink?: string;
-  /**
-   * HTML tag of the error title
-   * @default h2
-   */
-  titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'p';
-};
+declare namespace NSProjectNotFound {
+  type Props = WithI18nEnhanceProps & {
+    /**
+     * URL for the "Go to Projects" button
+     * @default /projects
+     */
+    projectsLink?: string;
+    /**
+     * URL for the "Contact us" button
+     * @default /company/contacts
+     */
+    contactsLink?: string;
+    /**
+     * URL for the "Support Team" link
+     * @default /company/contacts
+     */
+    supportTeamLink?: string;
+    /**
+     * HTML tag of the error title
+     * @default h2
+     */
+    titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'p';
+  };
 
-export type ProjectNotFoundComponent = Intergalactic.Component<'div', ProjectNotFoundProps & ErrorsProps>;
+  type Component = Intergalactic.Component<'div', Props & NSErrors.Props>;
+}
+
+/** @deprecated It will be removed in v18. */
+export type ProjectNotFoundProps = NSProjectNotFound.Props;
+
+export type { NSProjectNotFound };

--- a/stories/components/errors/docs/examples/templates.tsx
+++ b/stories/components/errors/docs/examples/templates.tsx
@@ -5,10 +5,21 @@ import {
   PageNotFound,
   ProjectNotFound,
 } from '@semcore/ui/errors';
-import type { AccessDeniedProps, MaintenanceProps, PageErrorProps, PageNotFoundProps, ProjectNotFoundProps } from '@semcore/ui/errors';
+import type {
+  NSAccessDenied,
+  NSMaintenance,
+  NSPageError,
+  NSPageNotFound,
+  NSProjectNotFound,
+} from '@semcore/ui/errors';
 import React from 'react';
 
-type errorProps = AccessDeniedProps & MaintenanceProps & PageErrorProps & PageNotFoundProps & ProjectNotFoundProps;
+type errorProps =
+  & NSAccessDenied.Props
+  & NSMaintenance.Props
+  & NSPageError.Props
+  & NSPageNotFound.Props
+  & NSProjectNotFound.Props;
 
 const Demo = (props: errorProps) => (
   <>

--- a/website/docs/patterns/global-errors/global-errors-api.md
+++ b/website/docs/patterns/global-errors/global-errors-api.md
@@ -12,7 +12,7 @@ import Error from '@semcore/ui/errors';
 <Error />;
 ```
 
-<TypesView type="ErrorsProps" :types={...types} />
+<TypesView type="NSErrors.Props" :types={...types} />
 
 ## Error.Title
 
@@ -50,7 +50,7 @@ import { AccessDenied } from '@semcore/ui/errors';
 <AccessDenied />;
 ```
 
-<TypesView type="AccessDeniedProps" :types={...types} />
+<TypesView type="NSAccessDenied.Props" :types={...types} />
 
 ## Maintenance
 
@@ -61,7 +61,7 @@ import { Maintenance } from '@semcore/ui/errors';
 <Maintenance />;
 ```
 
-<TypesView type="MaintenanceProps" :types={...types} />
+<TypesView type="NSMaintenance.Props" :types={...types} />
 
 ## PageError
 
@@ -72,7 +72,7 @@ import { PageError } from '@semcore/ui/errors';
 <PageError />;
 ```
 
-<TypesView type="PageErrorProps" :types={...types} />
+<TypesView type="NSPageError.Props" :types={...types} />
 
 ## PageNotFound
 
@@ -83,7 +83,7 @@ import { PageNotFound } from '@semcore/ui/errors';
 <PageNotFound />;
 ```
 
-<TypesView type="PageNotFoundProps" :types={...types} />
+<TypesView type="NSPageNotFound.Props" :types={...types} />
 
 ## ProjectNotFound
 
@@ -94,6 +94,6 @@ import { ProjectNotFound } from '@semcore/ui/errors';
 <ProjectNotFound />;
 ```
 
-<TypesView type="ProjectNotFoundProps" :types={...types} />
+<TypesView type="NSProjectNotFound.Props" :types={...types} />
 
 <script setup>import { data as types } from '@types.data.ts';</script>


### PR DESCRIPTION
## Changelog

### @semcore/errors

#### Fixed

- Deprecated atomic types. Atomic parts are part of `NSErrors/NSAccessDenied/NSMaintenance/NSPageError/NSPageNotFound/NSProjectNotFound` namespaces.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

Manually

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
