### PR TITLE
[UIK-5124][checkbox] rewrite atomic types to namespace/deprecate atomic types/update types among the project

### DIFF
--- a/playground/entries/Checkbox.tsx
+++ b/playground/entries/Checkbox.tsx
@@ -1,4 +1,4 @@
-import type { CheckboxProps } from '@semcore/ui/checkbox';
+import type { NSCheckbox } from '@semcore/ui/checkbox';
 import Checkbox from '@semcore/ui/checkbox';
 import React from 'react';
 
@@ -6,7 +6,7 @@ import type { JSXProps } from '../types/JSXProps';
 import type { PlaygroundEntry } from '../types/Playground';
 import createGithubLink from '../utils/createGHLink';
 
-export type CheckboxJSXProps = JSXProps<CheckboxProps>;
+export type CheckboxJSXProps = JSXProps<NSCheckbox.Props>;
 
 function getJSX({ handleControlChange, ...checkboxProps }: CheckboxJSXProps) {
   return <Checkbox {...checkboxProps} onChange={((value) => handleControlChange?.('checked', value))} />;

--- a/semcore/checkbox/src/Checkbox.tsx
+++ b/semcore/checkbox/src/Checkbox.tsx
@@ -9,15 +9,7 @@ import { useColorResolver } from '@semcore/core/lib/utils/use/useColorResolver';
 import { Text as TypographyText } from '@semcore/typography';
 import React from 'react';
 
-import type {
-  CheckboxCheckMarkComponent,
-  CheckboxComponent,
-  CheckboxProps,
-  CheckboxRootComponent,
-  CheckboxTextComponent,
-  CheckboxValueComponent,
-  CheckboxValueControlComponent,
-} from './Checkbox.type';
+import type { NSCheckbox } from './Checkbox.type';
 import style from './style/checkbox.shadow.css';
 
 type State = {
@@ -25,7 +17,7 @@ type State = {
 };
 
 class CheckboxRoot extends Component<
-  Intergalactic.InternalTypings.InferComponentProps<CheckboxRootComponent>,
+  Intergalactic.InternalTypings.InferComponentProps<NSCheckbox.Component>,
   never,
   {},
   State
@@ -43,7 +35,7 @@ class CheckboxRoot extends Component<
     hoistedDisabled: undefined,
   };
 
-  hoistDisabled = (disabled: CheckboxProps['disabled']) => {
+  hoistDisabled = (disabled: NSCheckbox.Props['disabled']) => {
     logger.warn(
       true,
       `Don't set disabled on Checkbox.Value or Checkbox.Text, set it on Checkbox instead. Otherwise it will produce wrong SSR output.`,
@@ -119,7 +111,7 @@ class CheckboxRoot extends Component<
 }
 
 class ValueRoot extends Component<
-  Intergalactic.InternalTypings.InferChildComponentProps<CheckboxValueComponent, typeof CheckboxRoot, 'Value'>,
+  Intergalactic.InternalTypings.InferChildComponentProps<NSCheckbox.Value.Component, typeof CheckboxRoot, 'Value'>,
   typeof ValueRoot.enhance,
   { checked: (e: React.ChangeEvent<HTMLInputElement>) => boolean }
 > {
@@ -211,7 +203,7 @@ class ValueRoot extends Component<
   }
 }
 
-function Control(props: Intergalactic.InternalTypings.InferChildComponentProps<CheckboxValueControlComponent, typeof ValueRoot, 'Control'>) {
+function Control(props: Intergalactic.InternalTypings.InferChildComponentProps<NSCheckbox.Value.Control.Component, typeof ValueRoot, 'Control'>) {
   const SControl = Root;
   const { indeterminate, styles, state } = props;
   const checkboxRef = React.useRef<HTMLInputElement>(null);
@@ -234,7 +226,7 @@ function Control(props: Intergalactic.InternalTypings.InferChildComponentProps<C
 }
 Control.displayName = 'Control';
 
-function CheckMark(props: Intergalactic.InternalTypings.InferChildComponentProps<CheckboxCheckMarkComponent, typeof ValueRoot, 'CheckMark'>) {
+function CheckMark(props: Intergalactic.InternalTypings.InferChildComponentProps<NSCheckbox.Value.Mark.Component, typeof ValueRoot, 'CheckMark'>) {
   const SCheckbox = Root;
   const SInvalidPattern = InvalidStateBox;
   const { styles, state, checked, indeterminate } = props;
@@ -246,7 +238,7 @@ function CheckMark(props: Intergalactic.InternalTypings.InferChildComponentProps
 }
 CheckMark.displayName = 'CheckMark';
 
-function Text(props: Intergalactic.InternalTypings.InferChildComponentProps<CheckboxTextComponent, typeof CheckboxRoot, 'Text'>) {
+function Text(props: Intergalactic.InternalTypings.InferChildComponentProps<NSCheckbox.Text.Component, typeof CheckboxRoot, 'Text'>) {
   const SText = Root;
   const { styles, color } = props;
 
@@ -267,11 +259,11 @@ Text.displayName = 'Text';
 const Value = createComponent(ValueRoot, {
   Control,
   CheckMark,
-}) as CheckboxValueComponent;
+}) as NSCheckbox.Value.Component;
 
 const Checkbox = createComponent(CheckboxRoot, {
   Text,
   Value,
-}) as CheckboxComponent;
+}) as NSCheckbox.Component;
 
 export default Checkbox;

--- a/semcore/checkbox/src/Checkbox.type.ts
+++ b/semcore/checkbox/src/Checkbox.type.ts
@@ -2,63 +2,87 @@ import type { Box, BoxProps, FlexProps } from '@semcore/base-components';
 import type { PropGetterFn, Intergalactic } from '@semcore/core';
 import type { NSText } from '@semcore/typography';
 
-export type CheckboxSize = 'm' | 'l';
-export type CheckboxState = 'normal' | 'invalid';
+declare namespace NSCheckbox {
+  type Size = 'm' | 'l';
+  type State = 'normal' | 'invalid';
+  type Props = BoxProps & {
+    /** Callback when the value changes */
+    onChange?: (checked: boolean, e?: React.SyntheticEvent<HTMLInputElement>) => void;
+    /** Controls the checked state of the checkbox (controlled mode) */
+    checked?: boolean;
+    /** Default state of uncontrolled checkbox */
+    defaultChecked?: boolean;
+    /** Checkbox text */
+    label?: string;
+    /** Special indeterminate state */
+    indeterminate?: boolean;
+    /** Special disabled state */
+    disabled?: boolean;
+    /**
+     * Checkbox visual state
+     * @default normal
+     */
+    state?: NSCheckbox.State;
+    /**
+     * Checkbox size
+     * @default m
+     */
+    size?: NSCheckbox.Size;
+    /**
+     * Checkbox color
+     */
+    theme?: string;
+  };
+  type Ctx = {
+    getTextProps: PropGetterFn;
+    getValueProps: PropGetterFn;
+  };
 
-export type CheckboxProps = BoxProps & {
-  /** Callback when the value changes */
-  onChange?: (checked: boolean, e?: React.SyntheticEvent<HTMLInputElement>) => void;
-  /** Controls the checked state of the checkbox (controlled mode) */
-  checked?: boolean;
-  /** Default state of uncontrolled checkbox */
-  defaultChecked?: boolean;
-  /** Checkbox text */
-  label?: string;
-  /** Special indeterminate state */
-  indeterminate?: boolean;
-  /** Special disabled state */
-  disabled?: boolean;
-  /**
-   * Checkbox visual state
-   * @default normal
-   */
-  state?: CheckboxState;
-  /**
-   * Checkbox size
-   * @default m
-   */
-  size?: CheckboxSize;
-  /**
-   * Checkbox color
-   */
-  theme?: string;
-};
+  namespace Value {
+    type Props = FlexProps;
 
-export type CheckboxValueProps = FlexProps & CheckboxValueControlProps;
+    namespace Control {
+      type Props = {};
+      type Component = Intergalactic.Component<'input', Props>;
+    }
 
-export type CheckboxValueControlProps = {};
-export type CheckboxValueCheckMarkProps = {};
+    namespace Mark {
+      type Props = {};
+      type Component = Intergalactic.Component<typeof Box, Props>;
+    }
 
-export type CheckboxContext = {
-  getTextProps: PropGetterFn;
-  getValueProps: PropGetterFn;
-};
+    type Component = Intergalactic.Component<'input', Props> & {
+      Control: Control.Component;
+      CheckMark: Mark.Component;
+    };
+  }
 
-export type CheckboxTextProps = NSText.Props;
+  namespace Text {
+    type Props = NSText.Props;
+    type Component = Intergalactic.Component<'span', Props>;
+  }
 
-export type CheckboxValueRootComponent = Intergalactic.Component<'input', CheckboxValueProps>;
-export type CheckboxValueControlComponent = Intergalactic.Component<'input', CheckboxValueControlProps>;
-export type CheckboxCheckMarkComponent = Intergalactic.Component<typeof Box, CheckboxValueCheckMarkProps>;
+  type Component = Intergalactic.Component<'label', Props, Ctx> & {
+    Text: Text.Component;
+    Value: Value.Component;
+  };
+}
 
-export type CheckboxValueComponent = CheckboxValueRootComponent & {
-  Control: CheckboxValueControlComponent;
-  CheckMark: CheckboxCheckMarkComponent;
-};
+/** @deprecated It will be removed in v18. */
+export type CheckboxSize = NSCheckbox.Size;
+/** @deprecated It will be removed in v18. */
+export type CheckboxState = NSCheckbox.State;
+/** @deprecated It will be removed in v18. */
+export type CheckboxProps = NSCheckbox.Props;
+/** @deprecated It will be removed in v18. */
+export type CheckboxValueProps = NSCheckbox.Value.Props;
+/** @deprecated It will be removed in v18. */
+export type CheckboxValueControlProps = NSCheckbox.Value.Control.Props;
+/** @deprecated It will be removed in v18. */
+export type CheckboxValueCheckMarkProps = NSCheckbox.Value.Mark.Props;
+/** @deprecated It will be removed in v18. */
+export type CheckboxContext = NSCheckbox.Ctx;
+/** @deprecated It will be removed in v18. */
+export type CheckboxTextProps = NSCheckbox.Text.Props;
 
-export type CheckboxRootComponent = Intergalactic.Component<'label', CheckboxProps, CheckboxContext>;
-export type CheckboxTextComponent = Intergalactic.Component<'span', CheckboxTextProps>;
-
-export type CheckboxComponent = CheckboxRootComponent & {
-  Text: CheckboxTextComponent;
-  Value: CheckboxValueComponent;
-};
+export type { NSCheckbox };

--- a/semcore/feature-highlight/src/components/checkbox/Checkbox.tsx
+++ b/semcore/feature-highlight/src/components/checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import type { CheckboxProps } from '@semcore/checkbox';
+import type { NSCheckbox } from '@semcore/checkbox';
 import Checkbox from '@semcore/checkbox';
 import { Component, createComponent, Root, sstyled } from '@semcore/core';
 import React from 'react';
@@ -7,7 +7,7 @@ import style from './checkbox.shadow.css';
 import type { HighlightedCheckboxComponent } from './Checkbox.type';
 import { AnimatedSparkles } from '../../inner-components/sparkle/AnimatedSparkles';
 
-class CheckboxFHRoot extends Component<CheckboxProps> {
+class CheckboxFHRoot extends Component<NSCheckbox.Props> {
   static displayName = 'CheckboxFH';
   static style = style;
 

--- a/semcore/feature-highlight/src/components/checkbox/Checkbox.type.ts
+++ b/semcore/feature-highlight/src/components/checkbox/Checkbox.type.ts
@@ -1,15 +1,10 @@
-import type {
-  CheckboxContext,
-  CheckboxProps,
-  CheckboxTextProps,
-  CheckboxValueProps,
-} from '@semcore/checkbox';
+import type { NSCheckbox } from '@semcore/checkbox';
 import type { Intergalactic } from '@semcore/core';
 
 import type { AnimatedSparklesProps } from '../../inner-components/sparkle/AnimatedSparkles';
 
-export type HighlightedCheckboxComponent = Intergalactic.Component<'label', CheckboxProps, CheckboxContext> & {
-  Text: Intergalactic.Component<'span', CheckboxTextProps>;
-  Value: Intergalactic.Component<'input', CheckboxValueProps>;
+export type HighlightedCheckboxComponent = Intergalactic.Component<'label', NSCheckbox.Props, NSCheckbox.Ctx> & {
+  Text: Intergalactic.Component<'span', NSCheckbox.Text.Props>;
+  Value: Intergalactic.Component<'input', NSCheckbox.Value.Props>;
   AnimatedSparkles: Intergalactic.Component<'div', AnimatedSparklesProps>;
 };

--- a/semcore/feedback-form/src/component/feedback-rating/FeedbackRating.type.ts
+++ b/semcore/feedback-form/src/component/feedback-rating/FeedbackRating.type.ts
@@ -1,4 +1,4 @@
-import type { CheckboxProps } from '@semcore/checkbox';
+import type { NSCheckbox } from '@semcore/checkbox';
 import type { Intergalactic } from '@semcore/core';
 import type { IllustrationProps } from '@semcore/illustration';
 import type Notice from '@semcore/notice';
@@ -69,7 +69,7 @@ export type FeedbackRatingItemProps = FieldProps<any, any> & {
   tooltipProps?: string[];
 };
 
-export type FeedbackRatingCheckboxProps = Omit<CheckboxProps, 'label'> & {
+export type FeedbackRatingCheckboxProps = Omit<NSCheckbox.Props, 'label'> & {
   focused: boolean;
   label: React.ReactNode;
 };

--- a/stories/components/checkbox/tests/examples/states.tsx
+++ b/stories/components/checkbox/tests/examples/states.tsx
@@ -1,10 +1,10 @@
 import { Flex } from '@semcore/ui/base-components';
 import Checkbox from '@semcore/ui/checkbox';
-import type { CheckboxProps } from '@semcore/ui/checkbox';
+import type { NSCheckbox } from '@semcore/ui/checkbox';
 import { Text } from '@semcore/ui/typography';
 import React from 'react';
 
-type CheckboxExampleProps = CheckboxProps & { color?: 'string'; autoFocus: boolean };
+type CheckboxExampleProps = NSCheckbox.Props & { color?: 'string'; autoFocus: boolean };
 const Demo = (props: CheckboxExampleProps) => {
   return (
     <Flex m={5} data-test-id='checkbox'>

--- a/stories/components/feature-highlight/tests/examples/checkbox.tsx
+++ b/stories/components/feature-highlight/tests/examples/checkbox.tsx
@@ -1,12 +1,12 @@
 import SummaryAI from '@semcore/icon/SummaryAI/m';
 import { Box, Flex, ScreenReaderOnly } from '@semcore/ui/base-components';
 import Checkbox from '@semcore/ui/checkbox';
-import type { CheckboxProps } from '@semcore/ui/checkbox';
+import type { NSCheckbox } from '@semcore/ui/checkbox';
 import { CheckboxFH, BadgeFH } from '@semcore/ui/feature-highlight';
 import { Text, List } from '@semcore/ui/typography';
 import React from 'react';
 
-export type CheckboxFHAdvancedProps = CheckboxProps & {
+export type CheckboxFHAdvancedProps = NSCheckbox.Props & {
   firstOptionText?: string;
   secondOptionText?: string;
   showBadge?: boolean;

--- a/website/docs/components/checkbox/checkbox-api.md
+++ b/website/docs/components/checkbox/checkbox-api.md
@@ -12,7 +12,7 @@ import Checkbox from '@semcore/ui/checkbox';
 <Checkbox />;
 ```
 
-<TypesView type="CheckboxProps" :types={...types} />
+<TypesView type="NSCheckbox.Props" :types={...types} />
 
 ## Checkbox.Value
 
@@ -49,6 +49,6 @@ import Checkbox from '@semcore/ui/checkbox';
 <Checkbox.Text />;
 ```
 
-<TypesView type="CheckboxTextProps" :types={...types} />
+<TypesView type="NSCheckbox.Text.Props" :types={...types} />
 
 <script setup>import { data as types } from '@types.data.ts';</script>


### PR DESCRIPTION
## Changelog

### @semcore/checkbox

#### Fixed

- Deprecated atomic types. Atomic parts are part of `NSCheckbox` namespaces.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

Manually

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
