### PR TITLE
[UIK-4496][wizard] fixed a11y for small screens (SR didn't read stepper content)

### DIFF
--- a/semcore/wizard/__tests__/index.test.tsx
+++ b/semcore/wizard/__tests__/index.test.tsx
@@ -13,7 +13,7 @@ describe('Wizard', () => {
   beforeEach(cleanup);
 
   test('Should support sidebar and content', async () => {
-    const { getByText } = render(
+    const { getByText, getByRole } = render(
       <Wizard disablePortal visible step={2}>
         <Wizard.Sidebar title='Header'>
           <Wizard.Stepper step={1}>Step 1</Wizard.Stepper>
@@ -29,8 +29,8 @@ describe('Wizard', () => {
     );
 
     expect(getByText('Header')).toBeTruthy();
-    expect(getByText('Step 1')).toBeTruthy();
-    expect(getByText('Step 2')).toBeTruthy();
+    expect(getByRole('tab', { name: 'Step 1' })).toBeTruthy();
+    expect(getByRole('tab', { name: 'Step 2' })).toBeTruthy();
     expect(getByText('StepNext')).toBeTruthy();
     expect(getByText('StepBack')).toBeTruthy();
   });

--- a/semcore/wizard/__tests__/wizard.axe-test.tsx
+++ b/semcore/wizard/__tests__/wizard.axe-test.tsx
@@ -23,6 +23,18 @@ test.describe(`@wizard ${TAG.ACCESSIBILITY}`, () => {
     expect(violations).toEqual([]);
   });
 
+  test('Base example in small viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 800, height: 600 });
+    await loadPage(page, 'stories/components/wizard/docs/examples/basic_example.tsx', 'en');
+
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Enter');
+    await locators.button(page, 'Close').waitFor({ state: 'visible' });
+    const violations = await getAccessibilityViolations({ page });
+
+    expect(violations).toEqual([]);
+  });
+
   test('Custom Step', async ({ page }) => {
     await loadPage(page, 'stories/components/wizard/docs/examples/custom_step.tsx', 'en');
 

--- a/semcore/wizard/__tests__/wizard.browser-test.tsx
+++ b/semcore/wizard/__tests__/wizard.browser-test.tsx
@@ -196,6 +196,16 @@ test.describe(`${TAG.VISUAL}`, () => {
         await expect(page).toHaveScreenshot();
       });
 
+      await test.step('Verify stepper accessible names in small viewport', async () => {
+        await expect(
+          page.getByRole('tab', { name: /Completed step Personal Info/ }),
+        ).toBeVisible();
+        await expect(page.getByRole('tab', { name: /Import source\s+optional/ })).toBeVisible();
+        await expect(
+          page.getByRole('tab', { name: /Sub step name\s+Optional step/ }),
+        ).toBeVisible();
+      });
+
       await test.step('Verify active hovered', async () => {
         await locators.stepperTabs(page).nth(0).hover();
         await expect(page).toHaveScreenshot();
@@ -361,6 +371,12 @@ test.describe(`${TAG.FUNCTIONAL}`, () => {
         await expect(locators.stepperTabs(page).nth(2)).not.toHaveAttribute('aria-disabled', 'true');
         await expect(locators.stepperTabs(page).nth(2)).toHaveAttribute('aria-selected', 'false');
         await expect(locators.stepperTabs(page).nth(2)).toHaveAttribute('tabindex', '-1');
+      });
+
+      await test.step('Verify stepper accessible names', async () => {
+        await expect(page.getByRole('tab', { name: /Completed step Location/ })).toBeVisible();
+        await expect(page.getByRole('tab', { name: 'Keywords' })).toBeVisible();
+        await expect(page.getByRole('tab', { name: 'Schedule' })).toBeVisible();
       });
 
       await test.step('Switch to middle step and check stepper attributes', async () => {

--- a/semcore/wizard/src/Wizard.tsx
+++ b/semcore/wizard/src/Wizard.tsx
@@ -280,8 +280,9 @@ function Stepper(props: Required<WizardStepperProps> & IRootComponentProps) {
       onKeyDown={handlerKeyDown}
     >
       {completed && <ScreenReaderOnly>{getI18nText('completedStep')}</ScreenReaderOnly>}
+      <ScreenReaderOnly><Children /></ScreenReaderOnly>
       <SStepNumber aria-hidden='true'>{completed ? <SCompleted /> : number}</SStepNumber>
-      <SStepDescription>
+      <SStepDescription aria-hidden='true'>
         <Children />
       </SStepDescription>
     </SStepper>,

--- a/stories/components/wizard/docs/__tests__/custom_stepper_test.test.tsx
+++ b/stories/components/wizard/docs/__tests__/custom_stepper_test.test.tsx
@@ -9,7 +9,7 @@ export async function CustomStepperExampleTest({ canvasElement }: { canvasElemen
   // ==== Section 1: Mouse Interactions ====
 
   // Open the modal using a button
-  const trigger = within(document.body).queryByText('Open wizard');
+  const trigger = within(document.body).queryByText('Add Project');
   if (!trigger) {
     throw new Error('Trigger button "Open modal" not found');
   }


### PR DESCRIPTION
## Changelog

### @semcore/wizard

#### Fixed

- SR did not read Stepper content aloud on small screens.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
