### PR TITLE
[UIK-5150][data-table] fixed focus dissapearing on sort icon after mouse leave

### DIFF
--- a/semcore/data-table/__tests__/data-table-header.browser-test.tsx
+++ b/semcore/data-table/__tests__/data-table-header.browser-test.tsx
@@ -493,6 +493,31 @@ test.describe(`${TAG.FUNCTIONAL}`, () => {
         });
       });
 
+      test('Verify focused unsorted sort icon stays visible after mouse leave', {
+        tag: [TAG.PRIORITY_HIGH,
+          TAG.KEYBOARD,
+          TAG.MOUSE,
+          '@data-table'],
+      }, async ({ page }) => {
+        await loadPage(page, 'stories/components/data-table/docs/examples/sorting.tsx', 'en');
+
+        const button = locators.sortButton(page, 1);
+
+        await page.keyboard.press('Tab');
+        await expect(button).toBeFocused();
+        await expect(button).not.toHaveAttribute('aria-label');
+        await expect(button).toBeVisible();
+
+        await locators.getHeadColumn(page, 1).hover();
+        await page.mouse.move(0, 0);
+
+        await expect(button).toBeFocused();
+        await expect(button).toBeVisible();
+
+        await locators.getHeadColumn(page, 3).focus();
+        await expect(button).toBeHidden();
+      });
+
       test('Verify mouse sorting without changing size', {
         tag: [TAG.PRIORITY_HIGH,
           TAG.MOUSE,
@@ -961,6 +986,32 @@ test.describe(`${TAG.FUNCTIONAL}`, () => {
           await page.keyboard.press('ArrowRight');
           await expect(locators.getHeadColumn(page, 7)).toBeFocused();
         });
+      });
+
+      test('Verify focused unsorted sort icon in multi level header stays visible after mouse leave', {
+        tag: [TAG.PRIORITY_HIGH,
+          TAG.KEYBOARD,
+          TAG.MOUSE,
+          '@data-table'],
+      }, async ({ page }) => {
+        await loadPage(page, 'stories/components/data-table/tests/examples/header-tests/sorting/multi-level-sorting.tsx', 'en');
+
+        const button = locators.sortButton(page, 2);
+
+        await locators.getHeadColumn(page, 2).hover();
+        await expect(button).not.toHaveAttribute('aria-label');
+        await expect(button).toBeVisible();
+
+        await button.focus();
+        await expect(button).toBeFocused();
+
+        await page.mouse.move(0, 0);
+
+        await expect(button).toBeFocused();
+        await expect(button).toBeVisible();
+
+        await locators.getHeadColumn(page, 3).focus();
+        await expect(button).toBeHidden();
       });
 
       test('Verify mouse interactions with sorting', {

--- a/semcore/data-table/src/components/Head/Column.tsx
+++ b/semcore/data-table/src/components/Head/Column.tsx
@@ -209,7 +209,12 @@ export class Column<
   };
 
   handleMouseLeave = () => {
-    this.setState({ sortVisible: false });
+    const sortButtonWrapper = this.sortWrapperRef.current;
+    const sortButton = sortButtonWrapper?.children.item(0);
+
+    if (sortButton !== document.activeElement) {
+      this.setState({ sortVisible: false });
+    }
   };
 
   handleBlur = (e: React.FocusEvent<HTMLElement>) => {


### PR DESCRIPTION
## Changelog

### @semcore/data-table

#### Fixed

- The focus disappears and lost when focus not active sorting icon and hover it.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
