### PR TITLE
[UIK-3648][docs] Tiny update for InlineEdit example

### DIFF
--- a/stories/components/inline-edit/docs/examples/pseudo_network_interaction.tsx
+++ b/stories/components/inline-edit/docs/examples/pseudo_network_interaction.tsx
@@ -27,7 +27,7 @@ const Example = () => {
           <InlineEdit.View pr={5}>
             {title}
             {' '}
-            <Box tag={EditM} ml={1} />
+            <Box tag={EditM} ml={1} color='icon-secondary-neutral' />
           </InlineEdit.View>
           <InlineEdit.Edit>
             <InlineInput onConfirm={handleTitle} onCancel={stopEditing} loading={savingTitle}>


### PR DESCRIPTION
## Motivation and Context

Just a tiny tiny update for one of the InlineEdit examples:
- added proper color to the `EditM` icon.

Icons in such cases should be more subtle than text, because it's usually the secondary action. Illustrations will be updated with the https://github.com/semrush/intergalactic/pull/2968, so I didn't change the illustrations here to avoid conflicts.

## How has this been tested?

Manually.

## Screenshots (if appropriate):

Before:
<img width="719" height="180" alt="image" src="https://github.com/user-attachments/assets/c775062b-efd4-4b12-a7aa-f947f469538b" />

After:
<img width="724" height="183" alt="image" src="https://github.com/user-attachments/assets/d17b9b0d-33e7-4065-8ccf-bfa912a04a7c" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
