### PR TITLE
[UIK-5374][flex-box] remove tag prop from BoxProps

### DIFF
--- a/semcore/base-components/src/components/flex-box/Box/index.tsx
+++ b/semcore/base-components/src/components/flex-box/Box/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import useBox, { type BoxProps } from './useBox';
 
-function Box(props: any, ref: any) {
+function Box(props: BoxProps, ref: React.Ref<HTMLElement>) {
   const [Tag, boxProps] = useBox(props, ref);
   if (Array.isArray(Tag)) {
     const [FirstTag, htmlTag] = Tag;

--- a/semcore/base-components/src/components/flex-box/Box/useBox.tsx
+++ b/semcore/base-components/src/components/flex-box/Box/useBox.tsx
@@ -14,11 +14,6 @@ type BorderRadius = `${keyof Theme['semanticTokens']['radii']}-rounded`;
 
 export type BoxProps = IStyledProps & {
   /**
-   * Custom tag to render
-   * @default div
-   */
-  tag?: Intergalactic.Tag;
-  /**
    * HTML class name attribute
    */
   className?: string;
@@ -258,7 +253,7 @@ function calculateIndentStyles(props: BoxProps, scaleIndent: number, colorResolv
   });
 }
 
-export default function useBox<T extends BoxProps>(
+export default function useBox<T extends BoxProps & { tag?: Intergalactic.Tag }>(
   props: T,
   ref: React.Ref<HTMLElement>,
 ): [React.ElementType | string, any] {


### PR DESCRIPTION
## Changelog

### @semcore/flex-box

#### Fixed

- Removed `tag` prop for `BoxProps`.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Removed `tag` prop from `BoxProps`.

## How has this been tested?

Manually

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
