### PR TITLE
[chore] added scrollbar-gutter: stable for storybook preview container

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -3,5 +3,6 @@
     html {
         font-family: Inter, sans-serif;
         -webkit-font-smoothing: antialiased;
+        scrollbar-gutter: stable;
     }
 </style>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
I need this fix for the theme-comparer - to display test components without unnecessary horizontal scroll 
<img width="1910" height="979" alt="Screenshot 2026-06-24 at 11 28 46" src="https://github.com/user-attachments/assets/f1a688b1-a50a-4c2b-b523-79500f8ca92c" />

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
