### PR TITLE
[UIK-5565][dropdown-menu] fixed preventFocusByClick - skip draggable elements

### DIFF
--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -332,7 +332,9 @@ function List({ styles, Children }) {
   const SScrollContainer = ScrollAreaComponent.Container;
 
   const preventFocusByClick = React.useCallback((e) => {
-    e.preventDefault();
+    if (!e.target.draggable) {
+      e.preventDefault();
+    }
   }, []);
 
   return sstyled(styles)(


### PR DESCRIPTION
## Changelog

### @semcore/dropdown-menu

#### Fixed

- `preventFocusByClick` handler - skip draggable elements.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
