### PR TITLE
[UIK-3410][bulk-textarea] first row issues

### DIFF
--- a/semcore/bulk-textarea/__tests__/bulk-textarea.browser-test.tsx
+++ b/semcore/bulk-textarea/__tests__/bulk-textarea.browser-test.tsx
@@ -680,9 +680,7 @@ test.describe(`${TAG.FUNCTIONAL}`, () => {
         expect(lineCount).toBe(2);
         await expect(locators.counter(page)).toHaveText('1/10of 10 lines');
 
-        const firstLineText = await locators.row(page, 0).textContent();
-
-        expect(firstLineText).not.toMatch(/^http:\/\//);
+        await expect(locators.row(page, 0)).not.toHaveText(/^http:\/\//);
 
         await locators.button(page, 'Clear all').click();
         await page.waitForTimeout(100);

--- a/semcore/bulk-textarea/src/BulkTextarea.tsx
+++ b/semcore/bulk-textarea/src/BulkTextarea.tsx
@@ -234,6 +234,14 @@ class BulkTextareaRoot<T extends string | string[]> extends Component<
       this.handlers.showErrors(false);
       this.handlers.errors([]);
       this.handlers.state('normal');
+
+      if (document.activeElement === this.clearAllButtonRef.current) {
+        const textarea = this.inputFieldRef.current?.querySelector('[role="textbox"]');
+
+        if (textarea instanceof HTMLDivElement) {
+          textarea.focus();
+        }
+      }
     }
   };
 
@@ -241,15 +249,9 @@ class BulkTextareaRoot<T extends string | string[]> extends Component<
     this.handlers.showErrors(false);
     this.handlers.errors([]);
     this.setState({ errorIndex: -1 });
-    // @ts-ignore
-    this.handlers.value('', e);
+    // @ts-ignore (we should set right type of value depending on the type of value passed)
+    this.handlers.value(typeof this.asProps.value === 'string' ? '' : [], e);
     this.handlers.state('normal');
-
-    const textarea = this.inputFieldRef.current?.querySelector('[role="textbox"]');
-
-    if (textarea instanceof HTMLDivElement) {
-      textarea.focus();
-    }
   };
 
   handleChangeErrorIndex = (amount: number) => () => {

--- a/semcore/bulk-textarea/src/components/InputField/InputField.tsx
+++ b/semcore/bulk-textarea/src/components/InputField/InputField.tsx
@@ -638,7 +638,9 @@ class InputField<T extends string | string[]> extends Component<
     onBlur(valueToChange as T, event);
 
     setTimeout(() => {
-      this.setState({ keyboardLineIndex: -1 });
+      if (document.activeElement !== this.textarea) {
+        this.setState({ keyboardLineIndex: -1 });
+      }
     }, 200);
   }
 

--- a/semcore/bulk-textarea/src/components/InputField/InputField.tsx
+++ b/semcore/bulk-textarea/src/components/InputField/InputField.tsx
@@ -218,7 +218,11 @@ class InputField<T extends string | string[]> extends Component<
 
         if (paragraph instanceof HTMLParagraphElement) {
           if (newValue === '') {
-            paragraph.innerHTML = this.emptyLineValue;
+            if (lines.length === 1) {
+              this.textarea.textContent = '';
+            } else {
+              paragraph.innerHTML = this.emptyLineValue;
+            }
           } else {
             paragraph.replaceChild(newValueTextNode, paragraph.childNodes.item(0));
           }

--- a/semcore/dropdown-menu/src/DropdownMenu.jsx
+++ b/semcore/dropdown-menu/src/DropdownMenu.jsx
@@ -332,7 +332,9 @@ function List({ styles, Children }) {
   const SScrollContainer = ScrollAreaComponent.Container;
 
   const preventFocusByClick = React.useCallback((e) => {
-    e.preventDefault();
+    if (!e.target.draggable) {
+      e.preventDefault();
+    }
   }, []);
 
   return sstyled(styles)(


### PR DESCRIPTION
## Changelog

### @semcore/bulk-textarea

#### Fixed

- `RowProcessing` not works in 1st line after clicking on Clear all by mouse and entering value to replace manually.
- The placeholder doesn't appear in case entered text was removed by the lineProcessing.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
