### PR TITLE
[UIK-5574][drag-and-drop] rewrite component types to NS

### DIFF
--- a/semcore/drag-and-drop/src/DragAndDrop.tsx
+++ b/semcore/drag-and-drop/src/DragAndDrop.tsx
@@ -568,8 +568,6 @@ function Draggable(
     'Draggable'
   > & {
     // Passed from DropZone.
-    noDrag?: boolean;
-    // Passed from DropZone.
     isDropZone?: boolean;
   },
 ) {
@@ -617,7 +615,7 @@ function Draggable(
       placement={placement}
       role='group'
       aria-describedby={`describe-draggable-${uid}`}
-      use:keyboardFocused={isCustomFocus || false}
+      use:keyboardFocused={isCustomFocus || undefined}
       tabIndex={0}
     >
       <Children />

--- a/semcore/drag-and-drop/src/DragAndDrop.tsx
+++ b/semcore/drag-and-drop/src/DragAndDrop.tsx
@@ -1,4 +1,5 @@
 import { Box, ScreenReaderOnly } from '@semcore/base-components';
+import type { Intergalactic } from '@semcore/core';
 import { createComponent, sstyled, Component, Root } from '@semcore/core';
 import canUseDOM from '@semcore/core/lib/utils/canUseDOM';
 import type { WithI18nEnhanceProps } from '@semcore/core/lib/utils/enhances/i18nEnhance';
@@ -7,56 +8,31 @@ import uniqueIDEnhance from '@semcore/core/lib/utils/uniqueID';
 import useEnhancedEffect from '@semcore/core/lib/utils/use/useEnhancedEffect';
 import React from 'react';
 
-import type { DragAndDropComponent, DragAndDropProps, DropZoneProps, DragAndDropDefaultProps } from './DragAndDrop.type';
+import type { NSDragAndDrop } from './DragAndDrop.type';
 import style from './style/drag-and-drop.shadow.css';
 import type { LocalizedMessages } from './translations/__intergalactic-dynamic-locales';
 import { localizedMessages } from './translations/__intergalactic-dynamic-locales';
-
-type AttachDetails = {
-  index: number;
-  children: React.ReactNode;
-  node: HTMLElement;
-  id: string;
-  draggingAllowed: boolean;
-  isDropZone?: boolean;
-  zoneName?: string;
-};
 
 const noop: (...args: any[]) => any = () => {
   /* do nothing */
 };
 const DragAndDropContext = React.createContext<{
-  attach: (details: AttachDetails) => void;
+  attach: (details: NSDragAndDrop.AttachDetails) => void;
   detach: (index: number) => void;
 }>({
       attach: noop,
       detach: noop,
     });
 
-type State = {
-  items: Array<Omit<AttachDetails, 'index'> | undefined>;
-  dragging: null | {
-    index: number;
-    initialItemsRects: Array<{ x: number; y: number; width: number; height: number } | undefined>;
-    placeholder: HTMLElement | null;
-  };
-  dragOver: number | null;
-  hideHoverEffect: boolean;
-  a11yHint: string | null;
-  keyboardDraggingIndex: number | null;
-  animatedScaling: number | null;
-  reversedScaling: boolean;
-};
-
 type A11yHintKeys = keyof LocalizedMessages['en'];
 
 class DragAndDropRoot extends Component<
-  DragAndDropProps,
+  Intergalactic.InternalTypings.InferComponentProps<NSDragAndDrop.Component>,
   typeof DragAndDropRoot.enhance,
   {},
   WithI18nEnhanceProps,
-  State,
-  DragAndDropDefaultProps
+  NSDragAndDrop.State,
+  NSDragAndDrop.DefaultProps
 > {
   static displayName = 'DragAndDrop';
   static enhance = [i18nEnhance(localizedMessages), uniqueIDEnhance()] as const;
@@ -67,7 +43,7 @@ class DragAndDropRoot extends Component<
 
   static style = style;
 
-  state: State = {
+  state: NSDragAndDrop.State = {
     items: [],
     dragging: null,
     dragOver: null,
@@ -126,7 +102,7 @@ class DragAndDropRoot extends Component<
     const yOffset = this.asProps.scrollableContainerRef?.current?.scrollTop ?? 0;
     const xOffset = this.asProps.scrollableContainerRef?.current?.scrollLeft ?? 0;
 
-    this.setState((prevState: State) => ({
+    this.setState((prevState: NSDragAndDrop.State) => ({
       dragging: {
         index,
         initialItemsRects: prevState.items.map((item) => {
@@ -259,7 +235,11 @@ class DragAndDropRoot extends Component<
       }
 
       const fromNode = items[dragging.index];
-      if (fromNode) {
+      if (
+        fromNode &&
+        fromNode.id !== undefined &&
+        currentItem.id !== undefined
+      ) {
         onDnD({
           fromId: fromNode.id,
           fromIndex: dragging.index,
@@ -501,8 +481,8 @@ class DragAndDropRoot extends Component<
     }
   };
 
-  attach = ({ index, children, node, id, draggingAllowed, zoneName, isDropZone }: AttachDetails) => {
-    this.setState((prevState: State) => {
+  attach = ({ index, children, node, id, draggingAllowed, zoneName, isDropZone }: NSDragAndDrop.AttachDetails) => {
+    this.setState((prevState: NSDragAndDrop.State) => {
       if (prevState.items[index]?.children === children && prevState.items[index]?.node === node) return prevState;
       const { items } = prevState;
       items[index] = { children, node, id, draggingAllowed, zoneName, isDropZone };
@@ -511,7 +491,7 @@ class DragAndDropRoot extends Component<
   };
 
   detach = (index: number) => {
-    this.setState((prevState: State) => {
+    this.setState((prevState: NSDragAndDrop.State) => {
       if (!prevState.items[index]) return prevState;
       const { items } = prevState;
       items[index] = undefined;
@@ -554,7 +534,7 @@ class DragAndDropRoot extends Component<
     document.removeEventListener('keydown', this.handlePageKeyDown, { capture: true });
   }
 
-  componentDidUpdate(prevProps: DragAndDropProps) {
+  componentDidUpdate(prevProps: typeof this.asProps) {
     if (prevProps.customFocus !== this.asProps.customFocus) {
       const itemIndex = this.getCustomFocusItemIndex(this.asProps.customFocus);
       if (this.state.items[itemIndex!]) this.handleItemFocus();
@@ -585,7 +565,18 @@ class DragAndDropRoot extends Component<
   }
 }
 
-function Draggable(props: any) {
+function Draggable(
+  props: Intergalactic.InternalTypings.InferChildComponentProps<
+    NSDragAndDrop.Draggable.Component,
+    typeof DragAndDropRoot,
+    'Draggable'
+  > & {
+    // Passed from DropZone.
+    noDrag?: boolean;
+    // Passed from DropZone.
+    isDropZone?: boolean;
+  },
+) {
   const SDraggable = Root;
   const ref = React.useRef();
   const { attach, detach } = React.useContext(DragAndDropContext);
@@ -601,9 +592,10 @@ function Draggable(props: any) {
     isDropZone = false,
     uid,
     isCustomFocus = false,
-    keyboardFocused,
   } = props;
+
   const resolvedChildren = React.useMemo(
+    // @ts-expect-error
     () => (typeof children === 'function' ? children(props) : children),
     [children, props],
   );
@@ -629,7 +621,7 @@ function Draggable(props: any) {
       placement={placement}
       role='group'
       aria-describedby={`describe-draggable-${uid}`}
-      use:keyboardFocused={isCustomFocus ? false : keyboardFocused}
+      use:keyboardFocused={isCustomFocus || false}
       tabIndex={0}
     >
       <Children />
@@ -698,7 +690,9 @@ const findNextRectangleIndex = <
   return rectangles.indexOf(candidate!);
 };
 
-function DropZone(props: DropZoneProps) {
+function DropZone(
+  props: Intergalactic.InternalTypings.InferComponentProps<NSDragAndDrop.DropZone.Component>,
+) {
   const SDropZone = Root;
   const { styles } = props;
 
@@ -713,7 +707,7 @@ function DropZone(props: DropZoneProps) {
  * {@link https://developer.semrush.com/intergalactic/components/drag-and-drop/drag-and-drop-api/|API} | {@link https://developer.semrush.com/intergalactic/components/drag-and-drop/drag-and-drop-code/|Examples}
  */
 const DragAndDrop = createComponent<
-  DragAndDropComponent,
+  NSDragAndDrop.Component,
   typeof DragAndDropRoot
 >(DragAndDropRoot, {
   Draggable,

--- a/semcore/drag-and-drop/src/DragAndDrop.tsx
+++ b/semcore/drag-and-drop/src/DragAndDrop.tsx
@@ -235,11 +235,7 @@ class DragAndDropRoot extends Component<
       }
 
       const fromNode = items[dragging.index];
-      if (
-        fromNode &&
-        fromNode.id !== undefined &&
-        currentItem.id !== undefined
-      ) {
+      if (fromNode) {
         onDnD({
           fromId: fromNode.id,
           fromIndex: dragging.index,

--- a/semcore/drag-and-drop/src/DragAndDrop.type.ts
+++ b/semcore/drag-and-drop/src/DragAndDrop.type.ts
@@ -112,17 +112,17 @@ declare namespace NSDragAndDrop {
   };
 }
 
-/** @deprecated It will be removed in v18. */
+/** @deprecated It will be removed in v19. */
 export type DragAndDropProps = NSDragAndDrop.Props;
-/** @deprecated It will be removed in v18. */
+/** @deprecated It will be removed in v19. */
 export type DragAndDropDefaultProps = NSDragAndDrop.DefaultProps;
-/** @deprecated It will be removed in v18. */
+/** @deprecated It will be removed in v19. */
 export type DraggableProps = NSDragAndDrop.Draggable.Props;
-/** @deprecated It will be removed in v18. */
+/** @deprecated It will be removed in v19. */
 export type DragAndDropContext = NSDragAndDrop.Ctx;
-/** @deprecated It will be removed in v18. */
+/** @deprecated It will be removed in v19. */
 export type DropZoneProps = NSDragAndDrop.DropZone.Props;
-/** @deprecated It will be removed in v18. */
+/** @deprecated It will be removed in v19. */
 export type DragAndDropComponent = NSDragAndDrop.Component;
 
 export type { NSDragAndDrop };

--- a/semcore/drag-and-drop/src/DragAndDrop.type.ts
+++ b/semcore/drag-and-drop/src/DragAndDrop.type.ts
@@ -85,6 +85,10 @@ declare namespace NSDragAndDrop {
          * Flag for disable keyboardFocused style form DnD.Draggable element
          */
         isCustomFocus?: boolean;
+        /**
+          * Disable drag ability
+        */
+        noDrag?: boolean;
       };
 
     type Component = Intergalactic.Component<'div', Props>;

--- a/semcore/drag-and-drop/src/DragAndDrop.type.ts
+++ b/semcore/drag-and-drop/src/DragAndDrop.type.ts
@@ -9,7 +9,7 @@ declare namespace NSDragAndDrop {
       /**
        * Controlled drag and drop handler
        */
-      onDnD: (dndData: { fromIndex: number; fromId: string; toIndex: number; toId: string }) => void;
+      onDnD: (dndData: { fromIndex: number; fromId: NSDragAndDrop.AttachDetails['id']; toIndex: number; toId: NSDragAndDrop.AttachDetails['id'] }) => void;
       /**
        * Index of id that indicates item that is currently under the user focus in case of real browser focus cannot be used.
        * When provided, drag and drop listens to whole page keyboard events. Doesn't provide `onCustomFocusChange` callback.

--- a/semcore/drag-and-drop/src/DragAndDrop.type.ts
+++ b/semcore/drag-and-drop/src/DragAndDrop.type.ts
@@ -3,79 +3,122 @@ import type { PropGetterFn, Intergalactic } from '@semcore/core';
 
 import type { LocalizedMessages } from './translations/__intergalactic-dynamic-locales';
 
-/**
- * DragAndDrop and Draggable containers must have an accessible names (aria-group-name).
- */
-type DNDAriaProps = Intergalactic.RequireAtLeastOne<{
-  'aria-label'?: string;
-  'aria-labelledby'?: string;
-  'title'?: string;
-}>;
-
-export type DragAndDropProps = BoxProps & {
+declare namespace NSDragAndDrop {
+  type Props = BoxProps &
+    NSDragAndDrop.AriaProps & {
+      /**
+       * Controlled drag and drop handler
+       */
+      onDnD: (dndData: { fromIndex: number; fromId: string; toIndex: number; toId: string }) => void;
+      /**
+       * Index of id that indicates item that is currently under the user focus in case of real browser focus cannot be used.
+       * When provided, drag and drop listens to whole page keyboard events. Doesn't provide `onCustomFocusChange` callback.
+       */
+      customFocus?: number | string;
+      /** Specifies the locale for i18n support */
+      locale?: string;
+      /**
+       * Ref to a scrollable container, if exists
+       */
+      scrollableContainerRef?: React.MutableRefObject<HTMLElement | null>;
+    };
+  type DefaultProps = {
+    i18n: LocalizedMessages;
+    locale: 'en';
+  };
   /**
-   * Controlled drag and drop handler
+   * DragAndDrop and Draggable containers must have an accessible names (aria-group-name).
    */
-  onDnD: (dndData: { fromIndex: number; fromId: string; toIndex: number; toId: string }) => void;
-  /**
-   * Index of id that indicates item that is currently under the user focus in case of real browser focus cannot be used.
-   * When provided, drag and drop listens to whole page keyboard events. Doesn't provide `onCustomFocusChange` callback.
-   */
-  customFocus?: number | string;
-  /** Specifies the locale for i18n support */
-  locale?: string;
-  /**
-   * Ref to a scrollable container, if exists
-   */
-  scrollableContainerRef?: React.MutableRefObject<HTMLElement | null>;
-};
-
-export type DragAndDropDefaultProps = {
-  i18n: LocalizedMessages;
-  locale: 'en';
-};
-
-export type DraggableProps = BoxProps & {
-  /** Placement of visual drag-and-drop marker
-   * @default right
-   * */
-  placement?: 'top' | 'right' | 'bottom' | 'left' | false;
-  /** Disabled DropZone abilities of component
-   * @default false
-   * */
-  noDrop?: boolean;
-  /**
-   * Used as `fromId` or `toId` in `onDnD` handler.
-   */
-  id?: string;
-  /**
-   * Used for add zoneName in a11y hints
-   */
-  zoneName?: string;
-  /**
-   * Flag for disable keyboardFocused style form DnD.Draggable element
-   */
-  isCustomFocus?: boolean;
-};
-
-export type DragAndDropContext = {
-  getDraggableProps: PropGetterFn;
-  getDroppableProps: PropGetterFn;
-};
-
-export type DropZoneProps = BoxProps &
-  DNDAriaProps & {
-    /**
-     * Used for add zoneName in a11y hints
-     */
+  type AriaProps = Intergalactic.RequireAtLeastOne<{
+    'aria-label'?: string;
+    'aria-labelledby'?: string;
+    'title'?: string;
+  }>;
+  type State = {
+    items: Array<Omit<NSDragAndDrop.AttachDetails, 'index'> | undefined>;
+    dragging: null | {
+      index: number;
+      initialItemsRects: Array<{ x: number; y: number; width: number; height: number } | undefined>;
+      placeholder: HTMLElement | null;
+    };
+    dragOver: number | null;
+    hideHoverEffect: boolean;
+    a11yHint: string | null;
+    keyboardDraggingIndex: number | null;
+    animatedScaling: number | null;
+    reversedScaling: boolean;
+  };
+  type Ctx = {
+    getDraggableProps: PropGetterFn;
+    getDroppableProps: PropGetterFn;
+  };
+  type AttachDetails = {
+    index: number;
+    children: React.ReactNode;
+    node: HTMLElement;
+    id?: string;
+    draggingAllowed: boolean;
+    isDropZone?: boolean;
     zoneName?: string;
   };
 
-export type DragAndDropComponent = Intergalactic.Component<
-  'div',
-  DragAndDropProps & DNDAriaProps,
-  DragAndDropContext
-> & {
-  Draggable: Intergalactic.Component<'div', DraggableProps & DNDAriaProps>;
-  DropZone: Intergalactic.Component<typeof Box, DropZoneProps>;
-};
+  namespace Draggable {
+    type Props = BoxProps &
+      NSDragAndDrop.AriaProps & {
+        /** Placement of visual drag-and-drop marker
+         * @default right
+         * */
+        placement?: 'top' | 'right' | 'bottom' | 'left' | false;
+        /** Disabled DropZone abilities of component
+         * @default false
+         * */
+        noDrop?: boolean;
+        /**
+         * Used as `fromId` or `toId` in `onDnD` handler.
+         */
+        id?: string;
+        /**
+         * Used for add zoneName in a11y hints
+         */
+        zoneName?: string;
+        /**
+         * Flag for disable keyboardFocused style form DnD.Draggable element
+         */
+        isCustomFocus?: boolean;
+      };
+
+    type Component = Intergalactic.Component<'div', Props>;
+  }
+
+  namespace DropZone {
+    type Props = BoxProps &
+      NSDragAndDrop.AriaProps & {
+        /**
+         * Used for add zoneName in a11y hints
+         */
+        zoneName?: string;
+      };
+
+    type Component = Intergalactic.Component<typeof Box, Props>;
+  }
+
+  type Component = Intergalactic.Component<'div', Props, Ctx> & {
+    Draggable: Draggable.Component;
+    DropZone: DropZone.Component;
+  };
+}
+
+/** @deprecated It will be removed in v18. */
+export type DragAndDropProps = NSDragAndDrop.Props;
+/** @deprecated It will be removed in v18. */
+export type DragAndDropDefaultProps = NSDragAndDrop.DefaultProps;
+/** @deprecated It will be removed in v18. */
+export type DraggableProps = NSDragAndDrop.Draggable.Props;
+/** @deprecated It will be removed in v18. */
+export type DragAndDropContext = NSDragAndDrop.Ctx;
+/** @deprecated It will be removed in v18. */
+export type DropZoneProps = NSDragAndDrop.DropZone.Props;
+/** @deprecated It will be removed in v18. */
+export type DragAndDropComponent = NSDragAndDrop.Component;
+
+export type { NSDragAndDrop };

--- a/semcore/drag-and-drop/src/index.ts
+++ b/semcore/drag-and-drop/src/index.ts
@@ -1,5 +1,5 @@
-import type { DragAndDropProps, DropZoneProps } from './DragAndDrop.type';
+import type { DragAndDropProps, DropZoneProps, NSDragAndDrop } from './DragAndDrop.type';
 
 export { default } from './DragAndDrop';
 
-export type { DragAndDropProps, DropZoneProps };
+export type { DragAndDropProps, DropZoneProps, NSDragAndDrop };

--- a/website/docs/components/drag-and-drop/drag-and-drop-api.md
+++ b/website/docs/components/drag-and-drop/drag-and-drop-api.md
@@ -13,7 +13,7 @@ import DnD from '@semcore/ui/drag-and-drop';
 <DnD />;
 ```
 
-<TypesView type="DragAndDropProps" :types={...types} />
+<TypesView type="NSDragAndDrop.Props" :types={...types} />
 
 ## DnD.Draggable
 
@@ -26,7 +26,7 @@ import DnD from '@semcore/ui/drag-and-drop';
 </DnD>
 ```
 
-<TypesView type="DraggableProps" :types={...types} />
+<TypesView type="NSDragAndDrop.Draggable.Props" :types={...types} />
 
 ## DnD.DropZone
 
@@ -39,6 +39,6 @@ import DnD from '@semcore/ui/drag-and-drop';
 </DnD>
 ```
 
-<TypesView type="DropZoneProps" :types={...types} />
+<TypesView type="NSDragAndDrop.DropZone.Props" :types={...types} />
 
 <script setup>import { data as types } from '@types.data.ts';</script>


### PR DESCRIPTION
## Changelog

### @semcore/drag-and-drop

#### Changed

- Refactor component types. Deprecated atomic types. Atomic types are part of `NSDragAndDrop` namespace.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Refactor component types. Deprecated atomic types in favor namespaces. Nothing changed in how component works.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
