### PR TITLE
[UIK-5577][feature-popover] rewrite component to NS

### DIFF
--- a/playground/entries/FeaturePopover.tsx
+++ b/playground/entries/FeaturePopover.tsx
@@ -1,5 +1,5 @@
 import Button from '@semcore/ui/button';
-import type { FeaturePopoverProps as FeaturePopoverComponentProps } from '@semcore/ui/feature-popover';
+import type { NSFeaturePopover } from '@semcore/ui/feature-popover';
 import FeaturePopover from '@semcore/ui/feature-popover';
 import { Text } from '@semcore/ui/typography';
 import React from 'react';
@@ -8,7 +8,7 @@ import type { JSXProps } from '../types/JSXProps';
 import type { PlaygroundEntry } from '../types/Playground';
 import createGithubLink from '../utils/createGHLink';
 
-type FeaturePopoverProps = FeaturePopoverComponentProps & {
+type FeaturePopoverProps = NSFeaturePopover.Props & {
   closeIcon: boolean;
 };
 export type FeaturePopoverJSXProps = JSXProps<FeaturePopoverProps>;

--- a/semcore/feature-popover/src/FeaturePopover.tsx
+++ b/semcore/feature-popover/src/FeaturePopover.tsx
@@ -1,22 +1,13 @@
-import type { PopperProps } from '@semcore/base-components';
 import { Box, Popper, Animation } from '@semcore/base-components';
 import Button from '@semcore/button';
-import type { IRootComponentProps } from '@semcore/core';
+import type { Intergalactic, IRootComponentProps } from '@semcore/core';
 import { createComponent, Root, Component, sstyled } from '@semcore/core';
 import { callAllEventHandlers } from '@semcore/core/lib/utils/assignProps';
-import type { WithI18nEnhanceProps } from '@semcore/core/lib/utils/enhances/i18nEnhance';
 import i18nEnhance from '@semcore/core/lib/utils/enhances/i18nEnhance';
 import CloseIcon from '@semcore/icon/Close/m';
 import React from 'react';
 
-import type {
-  FeaturePopoverProps,
-  FeaturePopoverComponent,
-  FeaturePopoverSpotProps,
-  FeaturePopoverPopperProps,
-  FeaturePopoverPopperInnerProps,
-  FeaturePopoverDefaultProps,
-} from './FeaturePopover.type';
+import type { NSFeaturePopover } from './FeaturePopover.type';
 import style from './style/feature-popover.shadow.css';
 import { localizedMessages } from './translations/__intergalactic-dynamic-locales';
 
@@ -44,25 +35,18 @@ const stylePopper = sstyled.css`
   }
 `;
 
-const enhance = [
-  i18nEnhance(localizedMessages),
-] as const;
-
-type FeaturePopoverInternalProps = {
-  interaction?: PopperProps['interaction'];
-};
-
 class FeaturePopover extends Component<
-  FeaturePopoverProps,
-  typeof enhance,
-  { visible: null },
-  WithI18nEnhanceProps & FeaturePopoverInternalProps,
+  Intergalactic.InternalTypings.InferComponentProps<NSFeaturePopover.Component>,
+  typeof FeaturePopover.enhance,
+  NSFeaturePopover.Handlers,
+  NSFeaturePopover.InternalProps,
   {},
-  FeaturePopoverDefaultProps
+  NSFeaturePopover.DefaultProps
 > {
+  static enhance = [i18nEnhance(localizedMessages)] as const;
   static displayName = 'FeaturePopover';
   static style = style;
-  static defaultProps: FeaturePopoverDefaultProps = {
+  static defaultProps: NSFeaturePopover.DefaultProps = {
     offset: [0, 12],
     placement: 'bottom-start',
     defaultVisible: false,
@@ -72,8 +56,6 @@ class FeaturePopover extends Component<
     locale: 'en',
     theme: 'accent',
   };
-
-  static enhance = enhance;
 
   defaultModifiers = [
     {
@@ -134,7 +116,9 @@ function Trigger({ Children, styles }: IRootComponentProps) {
   );
 }
 
-class FeaturePopoverPopper extends Component<FeaturePopoverPopperProps, [], {}, FeaturePopoverPopperInnerProps> {
+class FeaturePopoverPopper extends Component<
+  Intergalactic.InternalTypings.InferChildComponentProps<NSFeaturePopover.Popper.Component, typeof FeaturePopover, 'Popper'>
+> {
   static defaultProps = {
     closeIcon: false,
     duration: 200,
@@ -213,7 +197,7 @@ class FeaturePopoverPopper extends Component<FeaturePopoverPopperProps, [], {}, 
   }
 }
 
-function Spot(props: IRootComponentProps & FeaturePopoverSpotProps) {
+function Spot(props: Intergalactic.InternalTypings.InferChildComponentProps<NSFeaturePopover.Spot.Component, typeof FeaturePopover, 'Spot'>) {
   const SSpot = Root;
 
   const { styles, visible } = props;
@@ -229,7 +213,7 @@ function Spot(props: IRootComponentProps & FeaturePopoverSpotProps) {
  * {@link https://developer.semrush.com/intergalactic/components/feature-popover/feature-popover-api/|API} | {@link https://developer.semrush.com/intergalactic/components/feature-popover/feature-popover-code/|Examples}
  */
 export default createComponent<
-  FeaturePopoverComponent,
+  NSFeaturePopover.Component,
   typeof FeaturePopover
 >(
   FeaturePopover,

--- a/semcore/feature-popover/src/FeaturePopover.type.ts
+++ b/semcore/feature-popover/src/FeaturePopover.type.ts
@@ -24,62 +24,22 @@ import type { UniqueIDProps } from '@semcore/core/lib/utils/uniqueID';
 import type { LocalizedMessages } from './translations/__intergalactic-dynamic-locales';
 
 declare namespace NSFeaturePopover {
-  type Props = OutsideClickProps &
-    PortalProps &
-    UniqueIDProps &
-    AnimationProps & {
-      /**
-       * Popper can have different positioning options
-       * @default absolute
-       */
-      strategy?: PositioningStrategy;
-      /**
-       * Modifiers for popper.js
-       */
-      modifiers?: Array<Partial<Modifier<any, any>>>;
-      /** Timer to show and hide the popper */
-      timeout?: number | [number, number];
-      /** PopperJS modifier settings for popper indent */
-      offset?: Partial<OptionsOffset> | number | [number, number];
-      /** PopperJS modifier settings for finding borders */
-      preventOverflow?: Partial<OptionsPreventOverflow>;
-      /** PopperJS modifier settings responsible for the arrow */
-      arrow?: Partial<OptionsArrow>;
-      /** PopperJS modifier settings responsible for turning the popper when there is not enough space */
-      flip?: Partial<OptionsFlip>;
-      /** PopperJS modifier settings for applying styles */
-      computeStyles?: Partial<OptionsComputeStyles>;
-      /** PopperJS modifier settings responsible for subscribing to global events */
-      eventListeners?: Partial<OptionsEventListeners>;
-      /** @ignore */
-      onFirstUpdate?: Options['onFirstUpdate'];
-      /**
-       * Flag for disable Popover (if true, it will close Popper and it will not respond to handlers)
-       * @default false
-       */
-      disabled?: boolean;
-      /**
-       * If enabled, you will need to use setTrigger function from children rendering function to set popper trigger.
-       */
-      explicitTriggerSet?: boolean;
-
-      popperMargin?: number;
-
-      /** Popper visibility value */
-      visible?: boolean;
-      /** Function called when visibility changes */
-      onVisibleChange?: (visible: boolean, e?: Event) => boolean | void;
-      /**
-       * The position of the popper relative to the trigger that called it.
-       * @default auto
-       */
-      placement?: Placement;
-      /**
-       * The theme of FeaturePopover
-       * @default accent
-       */
-      theme?: 'accent' | 'neutral';
-    };
+  type Props = FPPopperProps & {
+    /** Popper visibility value */
+    visible?: boolean;
+    /** Function called when visibility changes */
+    onVisibleChange?: (visible: boolean, e?: Event) => boolean | void;
+    /**
+      * The position of the popper relative to the trigger that called it.
+      * @default auto
+      */
+    placement?: Placement;
+    /**
+      * The theme of FeaturePopover
+      * @default accent
+      */
+    theme?: 'accent' | 'neutral';
+  };
   type DefaultProps = {
     offset: NSFeaturePopover.Props['offset'];
     placement: 'bottom-start';
@@ -154,6 +114,50 @@ declare namespace NSFeaturePopover {
     Spot: Spot.Component;
   };
 }
+
+// Re-think it since looks like those props aren't needed for the Root component.
+/** @deprecated It will be removed in v18. */
+export type FPPopperProps = OutsideClickProps &
+  PortalProps &
+  UniqueIDProps &
+  AnimationProps & {
+    /**
+     * Popper can have different positioning options
+     * @default absolute
+     */
+    strategy?: PositioningStrategy;
+    /**
+     * Modifiers for popper.js
+     */
+    modifiers?: Array<Partial<Modifier<any, any>>>;
+    /** Timer to show and hide the popper */
+    timeout?: number | [number, number];
+    /** PopperJS modifier settings for popper indent */
+    offset?: Partial<OptionsOffset> | number | [number, number];
+    /** PopperJS modifier settings for finding borders */
+    preventOverflow?: Partial<OptionsPreventOverflow>;
+    /** PopperJS modifier settings responsible for the arrow */
+    arrow?: Partial<OptionsArrow>;
+    /** PopperJS modifier settings responsible for turning the popper when there is not enough space */
+    flip?: Partial<OptionsFlip>;
+    /** PopperJS modifier settings for applying styles */
+    computeStyles?: Partial<OptionsComputeStyles>;
+    /** PopperJS modifier settings responsible for subscribing to global events */
+    eventListeners?: Partial<OptionsEventListeners>;
+    /** @ignore */
+    onFirstUpdate?: Options['onFirstUpdate'];
+    /**
+     * Flag for disable Popover (if true, it will close Popper and it will not respond to handlers)
+     * @default false
+     */
+    disabled?: boolean;
+    /**
+     * If enabled, you will need to use setTrigger function from children rendering function to set popper trigger.
+     */
+    explicitTriggerSet?: boolean;
+
+    popperMargin?: number;
+  };
 
 /** @deprecated It will be removed in v18. */
 export type FeaturePopoverPopperProps = NSFeaturePopover.Popper.Props;

--- a/semcore/feature-popover/src/FeaturePopover.type.ts
+++ b/semcore/feature-popover/src/FeaturePopover.type.ts
@@ -10,132 +10,165 @@ import type {
   BoxProps,
   OutsideClickProps,
   PortalProps,
-  Box, PopperContext, PopperPopperProps, Placement, Popper } from '@semcore/base-components';
+  Box,
+  PopperProps,
+  PopperContext,
+  PopperPopperProps,
+  Placement,
+  Popper,
+} from '@semcore/base-components';
 import type { Intergalactic, PropGetterFn } from '@semcore/core';
+import type { WithI18nEnhanceProps } from '@semcore/core/lib/utils/enhances/i18nEnhance';
 import type { UniqueIDProps } from '@semcore/core/lib/utils/uniqueID';
 import type React from 'react';
 
 import type { LocalizedMessages } from './translations/__intergalactic-dynamic-locales';
 
-/**
- * Popper must have an accessible names (aria-group-name).
- */
-type AriaProps = Intergalactic.RequireAtLeastOne<{
-  'aria-label'?: string;
-  'aria-labelledby'?: string;
-  'title'?: string;
-}>;
+declare namespace NSFeaturePopover {
+  type Props = OutsideClickProps &
+    PortalProps &
+    UniqueIDProps &
+    AnimationProps & {
+      /**
+       * Popper can have different positioning options
+       * @default absolute
+       */
+      strategy?: PositioningStrategy;
+      /**
+       * Modifiers for popper.js
+       */
+      modifiers?: Array<Partial<Modifier<any, any>>>;
+      /** Timer to show and hide the popper */
+      timeout?: number | [number, number];
+      /** PopperJS modifier settings for popper indent */
+      offset?: Partial<OptionsOffset> | number | [number, number];
+      /** PopperJS modifier settings for finding borders */
+      preventOverflow?: Partial<OptionsPreventOverflow>;
+      /** PopperJS modifier settings responsible for the arrow */
+      arrow?: Partial<OptionsArrow>;
+      /** PopperJS modifier settings responsible for turning the popper when there is not enough space */
+      flip?: Partial<OptionsFlip>;
+      /** PopperJS modifier settings for applying styles */
+      computeStyles?: Partial<OptionsComputeStyles>;
+      /** PopperJS modifier settings responsible for subscribing to global events */
+      eventListeners?: Partial<OptionsEventListeners>;
+      /** @ignore */
+      onFirstUpdate?: Options['onFirstUpdate'];
+      /**
+       * Flag for disable Popover (if true, it will close Popper and it will not respond to handlers)
+       * @default false
+       */
+      disabled?: boolean;
+      /**
+       * If enabled, you will need to use setTrigger function from children rendering function to set popper trigger.
+       */
+      explicitTriggerSet?: boolean;
 
-export type FeaturePopoverPopperProps = PopperPopperProps & {
-  /**
-   * The property responsible for the visibility of the closing icon
-   * @default false
-   */
-  closeIcon?: boolean;
-  /** Animation display duration in `ms`
-   * @default 200
-   */
-  duration?: number;
-  /** Specifies the locale for i18n support */
-  locale?: string;
-};
+      popperMargin?: number;
 
-export type FeaturePopoverPopperInnerProps = {
-  theme: FeaturePopoverProps['theme'];
-
-  visible: boolean;
-
-  $onCloseClick: (e: React.SyntheticEvent<HTMLButtonElement>) => void;
-  animationsDisabled: boolean;
-  getI18nText: (message: string, opts?: Record<string, unknown>) => string;
-  autofocus: boolean;
-};
-
-export type FeaturePopoverContext = PopperContext & {
-  getSpotProps: PropGetterFn;
-};
-
-export type FPPopperProps = OutsideClickProps &
-  PortalProps &
-  UniqueIDProps &
-  AnimationProps & {
-    /**
-     * Popper can have different positioning options
-     * @default absolute
-     */
-    strategy?: PositioningStrategy;
-    /**
-     * Modifiers for popper.js
-     */
-    modifiers?: Array<Partial<Modifier<any, any>>>;
-    /** Timer to show and hide the popper */
-    timeout?: number | [number, number];
-    /** PopperJS modifier settings for popper indent */
-    offset?: Partial<OptionsOffset> | number | [number, number];
-    /** PopperJS modifier settings for finding borders */
-    preventOverflow?: Partial<OptionsPreventOverflow>;
-    /** PopperJS modifier settings responsible for the arrow */
-    arrow?: Partial<OptionsArrow>;
-    /** PopperJS modifier settings responsible for turning the popper when there is not enough space */
-    flip?: Partial<OptionsFlip>;
-    /** PopperJS modifier settings for applying styles */
-    computeStyles?: Partial<OptionsComputeStyles>;
-    /** PopperJS modifier settings responsible for subscribing to global events */
-    eventListeners?: Partial<OptionsEventListeners>;
-    /** @ignore */
-    onFirstUpdate?: Options['onFirstUpdate'];
-    /**
-     * Flag for disable Popover (if true, it will close Popper and it will not respond to handlers)
-     * @default false
-     */
-    disabled?: boolean;
-    /**
-     * If enabled, you will need to use setTrigger function from children rendering function to set popper trigger.
-     */
-    explicitTriggerSet?: boolean;
-
-    popperMargin?: number;
+      /** Popper visibility value */
+      visible?: boolean;
+      /** Function called when visibility changes */
+      onVisibleChange?: (visible: boolean, e?: Event) => boolean | void;
+      /**
+       * The position of the popper relative to the trigger that called it.
+       * @default auto
+       */
+      placement?: Placement;
+      /**
+       * The theme of FeaturePopover
+       * @default accent
+       */
+      theme?: 'accent' | 'neutral';
+    };
+  type DefaultProps = {
+    offset: NSFeaturePopover.Props['offset'];
+    placement: 'bottom-start';
+    defaultVisible: false;
+    onOutsideClick: () => void;
+    interaction: 'none';
+    i18n: LocalizedMessages;
+    locale: 'en';
+    theme: 'accent';
+  };
+  type InternalProps = WithI18nEnhanceProps & {
+    interaction?: PopperProps['interaction'];
+  };
+  type Handlers = {
+    visible: null;
+  };
+  type Ctx = PopperContext & {
+    getSpotProps: PropGetterFn;
   };
 
-export type FeaturePopoverProps = FPPopperProps & {
-  /** Popper visibility value */
-  visible?: boolean;
-  /** Function called when visibility changes */
-  onVisibleChange?: (visible: boolean, e?: Event) => boolean | void;
-  /**
-   * The position of the popper relative to the trigger that called it.
-   * @default auto
-   */
-  placement?: Placement;
-  /**
-   * The theme of FeaturePopover
-   * @default accent
-   */
-  theme?: 'accent' | 'neutral';
-};
+  namespace Trigger {
+    type Props = BoxProps & {
+      theme?: NSFeaturePopover.Props['theme'];
+    };
 
-export type FeaturePopoverDefaultProps = {
-  offset: FPPopperProps['offset'];
-  placement: 'bottom-start';
-  defaultVisible: false;
-  onOutsideClick: () => void;
-  interaction: 'none';
-  i18n: LocalizedMessages;
-  locale: 'en';
-  theme: 'accent';
-};
+    type Component = Intergalactic.Component<typeof Popper.Trigger, Props>;
+  }
 
-export type FeaturePopoverTriggerProps = BoxProps & {
-  theme?: FeaturePopoverProps['theme'];
-};
+  namespace Popper {
+    type Props = PopperPopperProps &
+      /**
+       * Popper must have an accessible names (aria-group-name).
+       */
+      Intergalactic.RequireAtLeastOne<{
+        'aria-label'?: string;
+        'aria-labelledby'?: string;
+        'title'?: string;
+      }> & {
+        /**
+         * The property responsible for the visibility of the closing icon
+         * @default false
+         */
+        closeIcon?: boolean;
+        /** Animation display duration in `ms`
+         * @default 200
+         */
+        duration?: number;
+        /** Specifies the locale for i18n support */
+        locale?: string;
+        /**
+         * Disable animation
+         * @deprecated
+         */
+        animationsDisabled?: boolean;
+      };
 
-export type FeaturePopoverSpotProps = {
-  visible?: boolean;
-  theme?: FeaturePopoverProps['theme'];
-};
+    type Component = Intergalactic.Component<'div', Props>;
+  }
 
-export type FeaturePopoverComponent = Intergalactic.Component<'div', FeaturePopoverProps, FeaturePopoverContext> & {
-  Trigger: Intergalactic.Component<typeof Popper.Trigger, FeaturePopoverTriggerProps>;
-  Popper: Intergalactic.Component<'div', FeaturePopoverPopperProps & AriaProps>;
-  Spot: Intergalactic.Component<typeof Box, FeaturePopoverSpotProps>;
-};
+  namespace Spot {
+    type Props = {
+      visible?: boolean;
+      theme?: NSFeaturePopover.Props['theme'];
+    };
+
+    type Component = Intergalactic.Component<typeof Box, Props>;
+  }
+
+  type Component = Intergalactic.Component<'div', Props, Ctx> & {
+    Trigger: Trigger.Component;
+    Popper: Popper.Component;
+    Spot: Spot.Component;
+  };
+}
+
+/** @deprecated It will be removed in v18. */
+export type FeaturePopoverPopperProps = NSFeaturePopover.Popper.Props;
+/** @deprecated It will be removed in v18. */
+export type FeaturePopoverContext = NSFeaturePopover.Ctx;
+/** @deprecated It will be removed in v18. */
+export type FeaturePopoverProps = NSFeaturePopover.Props;
+/** @deprecated It will be removed in v18. */
+export type FeaturePopoverDefaultProps = NSFeaturePopover.DefaultProps;
+/** @deprecated It will be removed in v18. */
+export type FeaturePopoverTriggerProps = NSFeaturePopover.Trigger.Props;
+/** @deprecated It will be removed in v18. */
+export type FeaturePopoverSpotProps = NSFeaturePopover.Spot.Props;
+/** @deprecated It will be removed in v18. */
+export type FeaturePopoverComponent = NSFeaturePopover.Component;
+
+export type { NSFeaturePopover };

--- a/semcore/feature-popover/src/FeaturePopover.type.ts
+++ b/semcore/feature-popover/src/FeaturePopover.type.ts
@@ -20,7 +20,6 @@ import type {
 import type { Intergalactic, PropGetterFn } from '@semcore/core';
 import type { WithI18nEnhanceProps } from '@semcore/core/lib/utils/enhances/i18nEnhance';
 import type { UniqueIDProps } from '@semcore/core/lib/utils/uniqueID';
-import type React from 'react';
 
 import type { LocalizedMessages } from './translations/__intergalactic-dynamic-locales';
 

--- a/semcore/feature-popover/src/index.ts
+++ b/semcore/feature-popover/src/index.ts
@@ -1,8 +1,9 @@
-import type { FeaturePopoverProps, FeaturePopoverPopperProps } from './FeaturePopover.type';
+import type { FeaturePopoverProps, FeaturePopoverPopperProps, NSFeaturePopover } from './FeaturePopover.type';
 
 export { default } from './FeaturePopover';
 
 export type {
   FeaturePopoverProps,
   FeaturePopoverPopperProps,
+  NSFeaturePopover,
 };

--- a/stories/components/feature-popover/docs/examples/Basic.tsx
+++ b/stories/components/feature-popover/docs/examples/Basic.tsx
@@ -3,7 +3,7 @@ import { Flex, Box, ScreenReaderOnly } from '@semcore/ui/base-components';
 import Button from '@semcore/ui/button';
 import DropdownMenu from '@semcore/ui/dropdown-menu';
 import FeaturePopover from '@semcore/ui/feature-popover';
-import type { FeaturePopoverProps } from '@semcore/ui/feature-popover';
+import type { NSFeaturePopover } from '@semcore/ui/feature-popover';
 import { Text } from '@semcore/ui/typography';
 import React from 'react';
 
@@ -107,7 +107,7 @@ Demo.defaultProps = defaultProps;
 
 export type FeaturePopoverExampleProps = {
   closeIcon: boolean;
-  theme: FeaturePopoverProps['theme'];
+  theme: NSFeaturePopover.Props['theme'];
 };
 
 export default Demo;

--- a/stories/components/feature-popover/tests/examples/base-usage-with-all-props.tsx
+++ b/stories/components/feature-popover/tests/examples/base-usage-with-all-props.tsx
@@ -4,11 +4,11 @@ import type { PopperProps, PopperTriggerProps, PopperPopperProps } from '@semcor
 import Button from '@semcore/ui/button';
 import DropdownMenu from '@semcore/ui/dropdown-menu';
 import FeaturePopover from '@semcore/ui/feature-popover';
-import type { FeaturePopoverPopperProps, FeaturePopoverProps } from '@semcore/ui/feature-popover';
+import type { NSFeaturePopover } from '@semcore/ui/feature-popover';
 import { Text } from '@semcore/ui/typography';
 import React from 'react';
 
-type ExampleProps = FeaturePopoverProps & FeaturePopoverPopperProps & PopperProps & PopperTriggerProps & PopperPopperProps;
+type ExampleProps = NSFeaturePopover.Props & NSFeaturePopover.Popper.Props & PopperProps & PopperTriggerProps & PopperPopperProps;
 const Demo = (props: ExampleProps) => {
   const [visible, setVisible] = React.useState(true);
   const handleVisibleChange = (visible: boolean) => () => setVisible(visible);

--- a/stories/components/feature-popover/tests/examples/base-usage-with-all-props.tsx
+++ b/stories/components/feature-popover/tests/examples/base-usage-with-all-props.tsx
@@ -81,17 +81,17 @@ const Demo = (props: ExampleProps) => {
 };
 
 export const defaultProps: ExampleProps = {
-  autoFocus: true,
-  placement: undefined,
-  timeout: undefined,
-  disablePortal: true,
-  explicitTriggerSet: false,
-  popperMargin: undefined,
-  closeIcon: true,
-  duration: undefined,
-  theme: 'accent',
-  disableEnforceFocus: true,
-
+  'autoFocus': true,
+  'placement': undefined,
+  'timeout': undefined,
+  'disablePortal': true,
+  'explicitTriggerSet': false,
+  'popperMargin': undefined,
+  'closeIcon': true,
+  'duration': undefined,
+  'theme': 'accent',
+  'disableEnforceFocus': true,
+  'aria-label': 'label',
 };
 
 Demo.defaultProps = defaultProps;

--- a/stories/components/feature-popover/tests/examples/base-usage-with-all-props.tsx
+++ b/stories/components/feature-popover/tests/examples/base-usage-with-all-props.tsx
@@ -9,7 +9,8 @@ import { Text } from '@semcore/ui/typography';
 import React from 'react';
 
 type ExampleProps = NSFeaturePopover.Props & NSFeaturePopover.Popper.Props & PopperProps & PopperTriggerProps & PopperPopperProps;
-const Demo: React.FC<ExampleProps> = (props) => {
+
+const Demo: ((props: ExampleProps) => React.ReactNode) & { defaultProps: ExampleProps } = (props) => {
   const [visible, setVisible] = React.useState(true);
   const handleVisibleChange = (visible: boolean) => () => setVisible(visible);
 

--- a/stories/components/feature-popover/tests/examples/base-usage-with-all-props.tsx
+++ b/stories/components/feature-popover/tests/examples/base-usage-with-all-props.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 
 type ExampleProps = NSFeaturePopover.Props & NSFeaturePopover.Popper.Props & PopperProps & PopperTriggerProps & PopperPopperProps;
 
-const Demo: ((props: ExampleProps) => React.ReactNode) & { defaultProps: ExampleProps } = (props) => {
+const Demo: ((props: ExampleProps) => React.ReactElement) & { defaultProps: ExampleProps } = (props) => {
   const [visible, setVisible] = React.useState(true);
   const handleVisibleChange = (visible: boolean) => () => setVisible(visible);
 

--- a/stories/components/feature-popover/tests/examples/base-usage-with-all-props.tsx
+++ b/stories/components/feature-popover/tests/examples/base-usage-with-all-props.tsx
@@ -9,7 +9,7 @@ import { Text } from '@semcore/ui/typography';
 import React from 'react';
 
 type ExampleProps = NSFeaturePopover.Props & NSFeaturePopover.Popper.Props & PopperProps & PopperTriggerProps & PopperPopperProps;
-const Demo = (props: ExampleProps) => {
+const Demo: React.FC<ExampleProps> = (props) => {
   const [visible, setVisible] = React.useState(true);
   const handleVisibleChange = (visible: boolean) => () => setVisible(visible);
 

--- a/stories/components/feature-popover/tests/examples/base-usage-with-medium-illustration.tsx
+++ b/stories/components/feature-popover/tests/examples/base-usage-with-medium-illustration.tsx
@@ -9,7 +9,8 @@ import { Text } from '@semcore/ui/typography';
 import React from 'react';
 
 type ExampleProps = NSFeaturePopover.Popper.Props & PopperProps & PopperTriggerProps & PopperPopperProps;
-const Demo: React.FC<ExampleProps> = (props: ExampleProps) => {
+
+const Demo: ((props: ExampleProps) => React.ReactNode) & { defaultProps: ExampleProps } = (props) => {
   const [visible, setVisible] = React.useState(true);
   const handleVisibleChange = (visible: boolean) => () => setVisible(visible);
 

--- a/stories/components/feature-popover/tests/examples/base-usage-with-medium-illustration.tsx
+++ b/stories/components/feature-popover/tests/examples/base-usage-with-medium-illustration.tsx
@@ -9,7 +9,7 @@ import { Text } from '@semcore/ui/typography';
 import React from 'react';
 
 type ExampleProps = NSFeaturePopover.Popper.Props & PopperProps & PopperTriggerProps & PopperPopperProps;
-const Demo = (props: ExampleProps) => {
+const Demo: React.FC<ExampleProps> = (props: ExampleProps) => {
   const [visible, setVisible] = React.useState(true);
   const handleVisibleChange = (visible: boolean) => () => setVisible(visible);
 

--- a/stories/components/feature-popover/tests/examples/base-usage-with-medium-illustration.tsx
+++ b/stories/components/feature-popover/tests/examples/base-usage-with-medium-illustration.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 
 type ExampleProps = NSFeaturePopover.Popper.Props & PopperProps & PopperTriggerProps & PopperPopperProps;
 
-const Demo: ((props: ExampleProps) => React.ReactNode) & { defaultProps: ExampleProps } = (props) => {
+const Demo: ((props: ExampleProps) => React.ReactElement) & { defaultProps: ExampleProps } = (props) => {
   const [visible, setVisible] = React.useState(true);
   const handleVisibleChange = (visible: boolean) => () => setVisible(visible);
 

--- a/stories/components/feature-popover/tests/examples/base-usage-with-medium-illustration.tsx
+++ b/stories/components/feature-popover/tests/examples/base-usage-with-medium-illustration.tsx
@@ -4,11 +4,11 @@ import type { PopperProps, PopperTriggerProps, PopperPopperProps } from '@semcor
 import Button from '@semcore/ui/button';
 import DropdownMenu from '@semcore/ui/dropdown-menu';
 import FeaturePopover from '@semcore/ui/feature-popover';
-import type { FeaturePopoverPopperProps } from '@semcore/ui/feature-popover';
+import type { NSFeaturePopover } from '@semcore/ui/feature-popover';
 import { Text } from '@semcore/ui/typography';
 import React from 'react';
 
-type ExampleProps = FeaturePopoverPopperProps & PopperProps & PopperTriggerProps & PopperPopperProps;
+type ExampleProps = NSFeaturePopover.Popper.Props & PopperProps & PopperTriggerProps & PopperPopperProps;
 const Demo = (props: ExampleProps) => {
   const [visible, setVisible] = React.useState(true);
   const handleVisibleChange = (visible: boolean) => () => setVisible(visible);
@@ -73,13 +73,14 @@ const Demo = (props: ExampleProps) => {
 };
 
 export const defaultProps: ExampleProps = {
-  placement: undefined,
-  visible: true,
-  timeout: undefined,
-  explicitTriggerSet: false,
-  popperMargin: undefined,
-  closeIcon: true,
-  duration: undefined,
+  'placement': undefined,
+  'visible': true,
+  'timeout': undefined,
+  'explicitTriggerSet': false,
+  'popperMargin': undefined,
+  'closeIcon': true,
+  'duration': undefined,
+  'aria-label': 'label',
 };
 
 Demo.defaultProps = defaultProps;

--- a/website/docs/components/feature-popover/feature-popover-api.md
+++ b/website/docs/components/feature-popover/feature-popover-api.md
@@ -13,7 +13,7 @@ import FeaturePopover from '@semcore/ui/feature-popover';
 <FeaturePopover />;
 ```
 
-<TypesView type="FeaturePopoverProps" :types={...types} />
+<TypesView type="NSFeaturePopover.Props" :types={...types} />
 
 ## FeaturePopover.Trigger
 
@@ -33,7 +33,7 @@ import FeaturePopover from '@semcore/ui/feature-popover';
 <FeaturePopover.Popper />;
 ```
 
-<TypesView type="FeaturePopoverPopperProps" :types={...types} />
+<TypesView type="NSFeaturePopover.Popper.Props" :types={...types} />
 
 ## FeaturePopover.Spot
 


### PR DESCRIPTION
## Changelog

### @semcore/feature-popover

#### Changed

- Refactor component types. Deprecated atomic types. Atomic types are part of `NSFeaturePopover` namespace.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Refactor component types. Deprecated atomic types in favor namespaces. Nothing changed in how component works.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
