### PR TITLE
[select] fix indeterminate state not showing with undefined size

### DIFF
--- a/semcore/select/__tests__/select.browser-test.tsx
+++ b/semcore/select/__tests__/select.browser-test.tsx
@@ -93,6 +93,33 @@ test.describe(`${TAG.VISUAL} `, () => {
     });
   });
 
+  test('Verify indeterminate checkbox has default size when Select size is omitted', {
+    tag: [TAG.PRIORITY_HIGH, '@select', '@checkbox'],
+  }, async ({ page }) => {
+    await loadPage(page, 'stories/components/select/tests/examples/options_checkbox_group_and_hint.tsx', 'en', {
+      omitSize: true,
+      showLabel: false,
+      option2ShowCheckbox: false,
+      option3ShowCheckbox: true,
+      option3CheckboxIndeterminate: true,
+      showGroup: false,
+    });
+
+    await locators.selectTrigger(page).click();
+    await locators.options(page).first().waitFor({ state: 'visible' });
+
+    const checkbox = page.locator('[data-ui-name="Select.Option.Checkbox"]');
+    await expect(checkbox).toHaveCount(1);
+    await expect(checkbox).toHaveCSS('width', '16px');
+    await expect(checkbox).toHaveCSS('height', '16px');
+
+    const indicatorSize = await checkbox.evaluate((element) => {
+      const style = window.getComputedStyle(element, '::after');
+      return { width: style.width, height: style.height };
+    });
+    expect(indicatorSize).toEqual({ width: '8px', height: '2px' });
+  });
+
   const subcomponentsConfigVariables = [
     // Test trigger size and state variations
     { description: 'trigger M normal, list M, no search', triggerSize: 'm', triggerState: 'normal', triggerDisabled: false, triggerLoading: false, listSize: 'm', showInputSearch: false },

--- a/semcore/select/src/Select.jsx
+++ b/semcore/select/src/Select.jsx
@@ -229,10 +229,9 @@ class RootSelect extends AbstractDropdown {
   }
 
   getOptionCheckboxProps() {
-    const { size, resolveColor } = this.asProps;
+    const { resolveColor } = this.asProps;
 
     return {
-      size,
       resolveColor,
     };
   }

--- a/semcore/select/src/style/select.shadow.css
+++ b/semcore/select/src/style/select.shadow.css
@@ -81,11 +81,14 @@ SOptionCheckbox[indeterminate]:after {
   margin: auto;
   /* disable-tokens-validator */
   border-radius: 1px;
-  width: 8px;
-  height: 2px;
 }
 
 SOptionCheckbox[indeterminate][size='l']:after {
   width: 12px;
+  height: 2px;
+}
+
+SOptionCheckbox[indeterminate][size='m']:after {
+  width: 8px;
   height: 2px;
 }

--- a/semcore/select/src/style/select.shadow.css
+++ b/semcore/select/src/style/select.shadow.css
@@ -81,14 +81,11 @@ SOptionCheckbox[indeterminate]:after {
   margin: auto;
   /* disable-tokens-validator */
   border-radius: 1px;
+  width: 8px;
+  height: 2px;
 }
 
 SOptionCheckbox[indeterminate][size='l']:after {
   width: 12px;
-  height: 2px;
-}
-
-SOptionCheckbox[indeterminate][size='m']:after {
-  width: 8px;
   height: 2px;
 }

--- a/stories/components/select/tests/examples/options_checkbox_group_and_hint.tsx
+++ b/stories/components/select/tests/examples/options_checkbox_group_and_hint.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 export type SelectAdvancedConfigProps = SelectProps & {
   // Main Select props
   size?: 'm' | 'l';
+  omitSize?: boolean;
   labelText?: string;
   showLabel?: boolean;
   triggerPlaceholder?: string;
@@ -62,6 +63,7 @@ const Demo = (props: SelectAdvancedConfigProps) => {
     showLabel = true,
     triggerPlaceholder = 'Select an option',
     size = 'm',
+    omitSize = false,
     disabled = undefined,
     state = undefined,
     visible = undefined,
@@ -120,7 +122,7 @@ const Demo = (props: SelectAdvancedConfigProps) => {
         </Text>
       )}
       <Select
-        size={size}
+        {...(!omitSize ? { size } : {})}
         disabled={disabled}
         state={state}
         visible={visible}
@@ -209,6 +211,7 @@ export const defaultProps: SelectAdvancedConfigProps = {
   showLabel: true,
   triggerPlaceholder: 'Select an option',
   size: 'm',
+  omitSize: false,
   disabled: undefined,
   state: undefined,
 


### PR DESCRIPTION
## Changelog

### @semcore/select

#### Fixed

- indeterminate state had incorrect appearance when Select size was undefined

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

Before:
<img width="329" height="379" alt="imagen" src="https://github.com/user-attachments/assets/ea90bd01-ff5e-43f2-9add-1e8b2b96370d" />

After:
<img width="372" height="380" alt="imagen" src="https://github.com/user-attachments/assets/b170a82d-3cbf-4ac4-8e3d-c67cb05ab6f1" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
