### PR TITLE
[icon] apply color only when it's defined

### DIFF
--- a/semcore/icon/src/style/icon.shadow.css
+++ b/semcore/icon/src/style/icon.shadow.css
@@ -6,5 +6,8 @@ SIcon {
   fill: currentColor;
   flex-shrink: 0;
   outline: none;
-  color: var(--color);
+
+  &[color] {
+    color: var(--color);
+  }
 }


### PR DESCRIPTION
## Changelog

### @semcore/icon

#### Fixed

- Prevent applying `color` when the corresponding CSS variable is undefined.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
