### PR TITLE
[UIK-5712][notice-bubble] rewrite component to NS

### DIFF
--- a/semcore/notice-bubble/src/NoticeBubble.tsx
+++ b/semcore/notice-bubble/src/NoticeBubble.tsx
@@ -1,11 +1,10 @@
-import { Animation, Box, Flex, Portal, ScreenReaderOnly } from '@semcore/base-components';
+import { Animation, Box, Flex, Portal } from '@semcore/base-components';
 import Button from '@semcore/button';
-import { createComponent, Component, sstyled, Root, lastInteraction } from '@semcore/core';
+import { createComponent, Component, sstyled, Root } from '@semcore/core';
 import type { Intergalactic } from '@semcore/core';
 import type { WithI18nEnhanceProps } from '@semcore/core/lib/utils/enhances/i18nEnhance';
 import i18nEnhance from '@semcore/core/lib/utils/enhances/i18nEnhance';
 import fire from '@semcore/core/lib/utils/fire';
-import { getFocusableIn } from '@semcore/core/lib/utils/focus-lock/getFocusableIn';
 import isNode from '@semcore/core/lib/utils/isNode';
 import { useForkRef } from '@semcore/core/lib/utils/ref';
 import { contextThemeEnhance } from '@semcore/core/lib/utils/ThemeProvider';
@@ -18,30 +17,19 @@ import {
 import CloseIcon from '@semcore/icon/Close/m';
 import React from 'react';
 
-import type {
-  NoticeBubbleContainerDefaultProps,
-  NoticeBubbleContainerProps,
-  NoticeBubbleViewItemProps,
-} from './NoticeBubble.type';
-import type { NoticeItem } from './NoticeBubbleManager';
+import type { NSNoticeBubble } from './NoticeBubble.type';
 import manager from './NoticeBubbleManager';
 import style from './style/notice-bubble.shadow.css';
 import { localizedMessages } from './translations/__intergalactic-dynamic-locales';
 import { Timer } from './utils';
 
-type State = {
-  notices: NoticeItem[];
-  infos: NoticeItem[];
-  warnings: NoticeItem[];
-};
-
 class NoticeBubbleContainerRoot extends Component<
-  NoticeBubbleContainerProps,
+  Intergalactic.InternalTypings.InferComponentProps<NSNoticeBubble.Container.Component>,
   typeof NoticeBubbleContainerRoot.enhance,
   {},
   WithI18nEnhanceProps,
-  State,
-  NoticeBubbleContainerDefaultProps
+  NSNoticeBubble.Container.State,
+  NSNoticeBubble.Container.DefaultProps
 > {
   static displayName = 'NoticeBubbleContainer';
   static style = style;
@@ -65,7 +53,7 @@ class NoticeBubbleContainerRoot extends Component<
 
   _unsubscribe: (() => void) | null = null;
 
-  state: State = {
+  state: NSNoticeBubble.Container.State = {
     notices: [],
     infos: [],
     warnings: [],
@@ -81,7 +69,7 @@ class NoticeBubbleContainerRoot extends Component<
     }
   };
 
-  handleChange = (notices: NoticeItem[]) => {
+  handleChange = (notices: NSNoticeBubble.Item[]) => {
     this.setState({ notices });
     this.forceUpdate(); // need this, because somehow this component doesn't rerender event if the notices are different
   };
@@ -168,7 +156,7 @@ const FocusLock = React.forwardRef((props: any, outerRef: React.ForwardedRef<HTM
   return <Flex ref={ref} {...other} />;
 });
 
-const PortalForNoticeItem = (props: Intergalactic.InternalTypings.EfficientOmit<NoticeBubbleViewItemProps, 'tag'> & { containerNode: HTMLElement; tag: typeof ViewInfo }) => {
+const PortalForNoticeItem = (props: Intergalactic.InternalTypings.EfficientOmit<NSNoticeBubble.ViewItemProps, 'tag'> & { containerNode: HTMLElement; tag: typeof ViewInfo }) => {
   const [showContent, setShowContent] = React.useState(false);
 
   // Show content for info notice in previously mounted node with aria-live polite
@@ -202,7 +190,7 @@ const PortalForNoticeItem = (props: Intergalactic.InternalTypings.EfficientOmit<
   );
 };
 
-class ViewInfo extends Component<NoticeBubbleViewItemProps> {
+class ViewInfo extends Component<NSNoticeBubble.ViewItemProps> {
   timer: Timer | null = null;
   ref = React.createRef<HTMLDivElement>();
   closeButtonRef = React.createRef<HTMLButtonElement>();
@@ -379,7 +367,7 @@ class ViewWarning extends ViewInfo {
  * {@link https://developer.semrush.com/intergalactic/components/notice-bubble/notice-bubble-api/|API} | {@link https://developer.semrush.com/intergalactic/components/notice-bubble/notice-bubble-code/|Examples}
  */
 const NoticeBubbleContainer = createComponent<
-  Intergalactic.Component<'div', NoticeBubbleContainerProps>,
+  NSNoticeBubble.Container.Component,
   typeof NoticeBubbleContainerRoot
 >(NoticeBubbleContainerRoot);
 

--- a/semcore/notice-bubble/src/NoticeBubble.type.ts
+++ b/semcore/notice-bubble/src/NoticeBubble.type.ts
@@ -3,115 +3,144 @@ import type { Intergalactic } from '@semcore/core';
 import type { useI18n } from '@semcore/core/lib/utils/enhances/WithI18n';
 import type { RefObject } from 'react';
 
-import type { NoticeItem } from './NoticeBubbleManager';
 import type { LocalizedMessages } from './translations/__intergalactic-dynamic-locales';
 
-/**
- * @deprecated. Pass noticeBubbleContainer property from window.sm2.getNoticeBubbleContainer()
- */
-export type NoticeBubbleContainerPortalProps = NSPortal.Props;
-
-export type NoticeBubbleContainerProps = NSBox.Props &
-  NoticeBubbleContainerPortalProps & {
-    /** Ref to mount bubbles in. You should use element form window.sm2.getNoticeBubbleContainer() */
-    containerNode?: HTMLElement | null;
-    /** Manager copy */
-    manager?: NoticeBubbleManagerClass;
-    /** Specifies the locale for i18n support */
-    locale?: string;
+declare namespace NSNoticeBubble {
+  type Props = NSBox.Props & {
+    /** Notice type */
+    type?: 'info' | 'warning';
+    /**
+     * Notice display duration. Set to 0 to disable auto-close.
+     */
+    duration?: number;
+    /**
+     * Enables animation on first rendering.
+     * @default false
+     */
+    initialAnimation?: boolean;
+    /**
+     * Use it for complex notices with important controls.
+     * If enabled, browser focus will be locked in the notice
+     * until it's closed. After close focus should return to the element
+     * where it was placed before notice appear.
+     *
+     * @deprecated
+     */
+    focusLock?: boolean;
+    /**
+     * Notice visibility.
+     */
+    visible?: boolean;
+    /**
+     * Control under the notice children.
+     * */
+    action?: React.ReactNode;
+    /**
+     * Callback triggered by "Close" icon click.
+     * */
+    onClose?: (e?: React.SyntheticEvent) => void;
+    /**
+     * Notice content.
+     * */
+    children?: React.ReactNode;
+    manager?: NSNoticeBubble.Manager;
+    icon?: React.ReactElement;
+  };
+  type Item = (NSNoticeBubble.Info.Props | NSNoticeBubble.Warning.Props) & {
+    uid: number;
+    visible: boolean;
+    forwardRef: RefObject<HTMLElement>;
+    onClose: () => void;
+  };
+  type ViewItemProps = NSNoticeBubble.Props & {
+    containerNode?: HTMLElement;
+    animationDuration: number;
+    getI18nText: ReturnType<typeof useI18n>;
+    styles: React.DetailedHTMLProps<React.StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | undefined;
+  };
+  type Meta = {
+    uid: number;
+    update: (props: Info.Props | Warning.Props) => Promise<NSNoticeBubble.Meta>;
+    remove: () => boolean;
+    ref: RefObject<HTMLElement>;
+  };
+  type Manager = {
+    /**
+     * Creates and shows a notice.
+     * */
+    add: (props: NSNoticeBubble.Info.Props | NSNoticeBubble.Warning.Props) => NSNoticeBubble.Meta;
+    /**
+     * Removes notice by uid.
+     * */
+    remove: (uid: number) => boolean;
+    /**
+     * Replace notice by uid.
+     */
+    replace: (uid: number, props: NSNoticeBubble.Info.Props | NSNoticeBubble.Warning.Props) => void;
+    /**
+     * Replace last notice (if it is existing)
+     */
+    replaceLast: (props: NSNoticeBubble.Info.Props | NSNoticeBubble.Warning.Props) => void;
+    /** Add change listener */
+    addListener: (fn: (items: NSNoticeBubble.Item[]) => void) => () => void;
   };
 
-export type NoticeBubbleContainerDefaultProps = {
-  manager: NoticeBubbleManagerClass;
-  i18n: LocalizedMessages;
-  locale: 'en';
-};
+  namespace Container {
+    type Props = NSBox.Props &
+      NSPortal.Props & {
+        /** Ref to mount bubbles in. You should use element form window.sm2.getNoticeBubbleContainer() */
+        containerNode?: HTMLElement | null;
+        /** Manager copy */
+        manager?: NSNoticeBubble.Manager;
+        /** Specifies the locale for i18n support */
+        locale?: string;
+      };
+    type DefaultProps = {
+      manager: NSNoticeBubble.Manager;
+      i18n: LocalizedMessages;
+      locale: 'en';
+    };
+    type State = {
+      notices: NSNoticeBubble.Item[];
+      infos: NSNoticeBubble.Item[];
+      warnings: NSNoticeBubble.Item[];
+    };
 
-export type NoticeBubbleViewItemProps = NoticeBubbleProps & {
-  containerNode?: HTMLElement;
-  animationDuration: number;
-  getI18nText: ReturnType<typeof useI18n>;
-  styles: React.DetailedHTMLProps<React.StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | undefined;
-};
+    type Component = Intergalactic.Component<'div', Props>;
+  }
 
-export type NoticeBubbleProps = NSBox.Props & {
-  /** Notice type */
-  type?: 'info' | 'warning';
-  /**
-   * Notice display duration. Set to 0 to disable auto-close.
-   */
-  duration?: number;
-  /**
-   * Enables animation on first rendering.
-   * @default false
-   */
-  initialAnimation?: boolean;
-  /**
-   * Use it for complex notices with important controls.
-   * If enabled, browser focus will be locked in the notice
-   * until it's closed. After close focus should return to the element
-   * where it was placed before notice appear.
-   *
-   * @deprecated
-   */
-  focusLock?: boolean;
-  /**
-   * Notice visibility.
-   */
-  visible?: boolean;
-  /**
-   * Control under the notice children.
-   * */
-  action?: React.ReactNode;
-  /**
-   * Callback triggered by "Close" icon click.
-   * */
-  onClose?: (e?: React.SyntheticEvent) => void;
-  /**
-   * Notice content.
-   * */
-  children?: React.ReactNode;
-  manager?: NoticeBubbleManagerClass;
-  icon?: React.ReactElement;
-};
+  namespace Info {
+    type Props = NSNoticeBubble.Props & {
+      readonly type?: 'info';
+    };
+  }
 
-export type NoticeBubbleInfoProps = NoticeBubbleProps & {
-  readonly type?: 'info';
-};
+  namespace Warning {
+    type Props = NSNoticeBubble.Props & {
+      readonly type?: 'warning';
+    };
+  }
+}
 
-export type NoticeBubbleWarningProps = NoticeBubbleProps & {
-  readonly type?: 'warning';
-};
+/**
+ * @deprecated. Pass noticeBubbleContainer property from window.sm2.getNoticeBubbleContainer().
+ */
+export type NoticeBubbleContainerPortalProps = NSPortal.Props;
+/** @deprecated It will be removed in v19. */
+export type NoticeBubbleContainerProps = NSNoticeBubble.Container.Props;
+/** @deprecated It will be removed in v19. */
+export type NoticeBubbleContainerDefaultProps = NSNoticeBubble.Container.DefaultProps;
+/** @deprecated It will be removed in v19. */
+export type NoticeBubbleViewItemProps = NSNoticeBubble.ViewItemProps;
+/** @deprecated It will be removed in v19. */
+export type NoticeBubbleProps = NSNoticeBubble.Props;
+/** @deprecated It will be removed in v19. */
+export type NoticeBubbleInfoProps = NSNoticeBubble.Info.Props;
+/** @deprecated It will be removed in v19. */
+export type NoticeBubbleWarningProps = NSNoticeBubble.Warning.Props;
+/** @deprecated It will be removed in v19. */
+export type AddedNoticeMeta = NSNoticeBubble.Meta;
+/** @deprecated It will be removed in v19. */
+export type NoticeBubbleManagerClass = NSNoticeBubble.Manager;
 
-export type AddedNoticeMeta = {
-  uid: number;
-  update: (props: NoticeBubbleInfoProps | NoticeBubbleWarningProps) => Promise<AddedNoticeMeta>;
-  remove: () => boolean;
-  ref: RefObject<HTMLElement>;
-};
-
-export type NoticeBubbleManagerClass = {
-  /**
-   * Creates and shows a notice.
-   * */
-  add: (props: NoticeBubbleInfoProps | NoticeBubbleWarningProps) => AddedNoticeMeta;
-  /**
-   * Removes notice by uid.
-   * */
-  remove: (uid: number) => boolean;
-  /**
-   * Replace notice by uid.
-   */
-  replace: (uid: number, props: NoticeBubbleInfoProps | NoticeBubbleWarningProps) => void;
-  /**
-   * Replace last notice (if it is existing)
-   */
-  replaceLast: (props: NoticeBubbleInfoProps | NoticeBubbleWarningProps) => void;
-  /** Add change listener */
-  addListener: (fn: (items: NoticeItem[]) => void) => (() => void);
-};
-
-export declare const NoticeBubbleContainer: Intergalactic.Component<
-  'div',
-  NoticeBubbleContainerProps
->;
+export type { NSNoticeBubble };

--- a/semcore/notice-bubble/src/NoticeBubbleManager.ts
+++ b/semcore/notice-bubble/src/NoticeBubbleManager.ts
@@ -1,30 +1,17 @@
 import { callAllEventHandlers } from '@semcore/core/lib/utils/assignProps';
 import EventEmitter from '@semcore/core/lib/utils/eventEmitter';
-import type { RefObject } from 'react';
 import React from 'react';
 
-import type {
-  NoticeBubbleManagerClass,
-  NoticeBubbleInfoProps,
-  NoticeBubbleWarningProps,
-  AddedNoticeMeta,
-} from './NoticeBubble.type';
+import type { NSNoticeBubble } from './NoticeBubble.type';
 
 const EVENT_NAME = 'CHANGE';
 
-export type NoticeItem = (NoticeBubbleInfoProps | NoticeBubbleWarningProps) & {
-  uid: number;
-  visible: boolean;
-  forwardRef: RefObject<HTMLElement>;
-  onClose: () => void;
-};
-
-class NoticeBubbleManager implements NoticeBubbleManagerClass {
-  private items: NoticeItem[] = [];
+class NoticeBubbleManager implements NSNoticeBubble.Manager {
+  private items: NSNoticeBubble.Item[] = [];
   private emitter = new EventEmitter();
   private counter = 0;
 
-  public addListener(fn: (items: NoticeItem[]) => void): () => void {
+  public addListener(fn: (items: NSNoticeBubble.Item[]) => void): () => void {
     return this.emitter.subscribe(EVENT_NAME, fn);
   }
 
@@ -32,7 +19,7 @@ class NoticeBubbleManager implements NoticeBubbleManagerClass {
     this.emitter.emit(EVENT_NAME, this.items);
   }
 
-  public add(props: NoticeBubbleInfoProps | NoticeBubbleWarningProps): AddedNoticeMeta {
+  public add(props: NSNoticeBubble.Info.Props | NSNoticeBubble.Warning.Props): NSNoticeBubble.Meta {
     const uid = this.counter++;
     const ref = React.createRef<HTMLElement>();
 
@@ -56,7 +43,7 @@ class NoticeBubbleManager implements NoticeBubbleManagerClass {
     };
   }
 
-  public replace(uid: number, props: NoticeBubbleInfoProps | NoticeBubbleWarningProps): Promise<AddedNoticeMeta> {
+  public replace(uid: number, props: NSNoticeBubble.Info.Props | NSNoticeBubble.Warning.Props): Promise<NSNoticeBubble.Meta> {
     this.remove(uid);
 
     return new Promise((resolve) => {
@@ -66,7 +53,7 @@ class NoticeBubbleManager implements NoticeBubbleManagerClass {
     });
   }
 
-  public replaceLast(props: NoticeBubbleInfoProps | NoticeBubbleWarningProps): Promise<AddedNoticeMeta> {
+  public replaceLast(props: NSNoticeBubble.Info.Props | NSNoticeBubble.Warning.Props): Promise<NSNoticeBubble.Meta> {
     const item = this.items[this.items.length - 1];
 
     if (item?.visible) {

--- a/semcore/notice-bubble/src/index.ts
+++ b/semcore/notice-bubble/src/index.ts
@@ -4,6 +4,7 @@ import type {
   NoticeBubbleInfoProps,
   NoticeBubbleWarningProps,
   AddedNoticeMeta,
+  NSNoticeBubble,
 } from './NoticeBubble.type';
 import { default as noticeBubbleDefaultManager } from './NoticeBubbleManager';
 
@@ -18,4 +19,5 @@ export type {
   NoticeBubbleInfoProps,
   NoticeBubbleWarningProps,
   AddedNoticeMeta,
+  NSNoticeBubble,
 };

--- a/stories/components/notice-bubble/docs/examples/dynamic_notice.tsx
+++ b/stories/components/notice-bubble/docs/examples/dynamic_notice.tsx
@@ -3,7 +3,7 @@ import WarningM from '@semcore/icon/Warning/m';
 import { Flex } from '@semcore/ui/base-components';
 import Button from '@semcore/ui/button';
 import { lastInteraction } from '@semcore/ui/core';
-import type { AddedNoticeMeta } from '@semcore/ui/notice-bubble';
+import type { NSNoticeBubble } from '@semcore/ui/notice-bubble';
 import { NoticeBubbleContainer, NoticeBubbleManager } from '@semcore/ui/notice-bubble';
 import Spin from '@semcore/ui/spin';
 import React from 'react';
@@ -11,7 +11,7 @@ type DynamicNoticeBubbleProps = { initialAnimation: boolean; duration: number; t
 
 const manager = new NoticeBubbleManager();
 
-let notice: AddedNoticeMeta | null = null;
+let notice: NSNoticeBubble.Meta | null = null;
 
 const Demo = (props: DynamicNoticeBubbleProps) => {
   const openButtonRef = React.useRef<HTMLButtonElement>(null);

--- a/website/docs/components/notice-bubble/notice-bubble-api.md
+++ b/website/docs/components/notice-bubble/notice-bubble-api.md
@@ -11,7 +11,7 @@ import { noticeBubbleDefaultManager } from '@semcore/ui/notice-bubble';
 
 Manager is a storage of all notice instances. It can add, delete and update notices by calling the appropriate methods.
 
-<TypesView type="NoticeBubbleManagerClass" :types={...types} />
+<TypesView type="NSNoticeBubble.Manager" :types={...types} />
 
 ## NoticeBubbleContainer
 
@@ -21,6 +21,6 @@ import { NoticeBubbleContainer } from '@semcore/ui/notice-bubble';
 
 Container is a `div` created in the `body` using `React.Portal`. It's inserted once in any part of the application and subscribes to Manager updates (`NoticeBubbleManager`). Later, notices will be rendered to it.
 
-<TypesView type="NoticeBubbleContainerProps" :types={...types} />
+<TypesView type="NSNoticeBubble.Container.Props" :types={...types} />
 
 <script setup>import { data as types } from '@types.data.ts';</script>


### PR DESCRIPTION
## Changelog

### @semcore/notice-bubble

#### Changed

- Refactor component types. Deprecated atomic types. Atomic types are part of `NSNoticeBubble` namespace.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Refactor component types. Deprecated atomic types in favor namespaces. Nothing changed in how component works.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
