### PR TITLE
[UIK-5778][scroll-area] added early exit from calculateSizeContainer for components without wMax and hMax

### DIFF
--- a/semcore/base-components/src/components/scroll-area/ScrollArea.tsx
+++ b/semcore/base-components/src/components/scroll-area/ScrollArea.tsx
@@ -100,6 +100,7 @@ class ScrollAreaRoot extends Component<
     const { wMax, hMax, observeParentSize } = this.asProps;
     const size = { width: '', height: '' };
     if (!this.$container || !this.$wrapper) return size;
+    if (!wMax && !hMax) return size;
     const { scrollWidth, scrollHeight } = this.$container;
     const style = window.getComputedStyle(this.$wrapper);
     const parent = this.$wrapper.parentElement;

--- a/semcore/data-table/src/components/Body/Body.tsx
+++ b/semcore/data-table/src/components/Body/Body.tsx
@@ -237,6 +237,7 @@ class BodyRoot<Data extends DataTableData, UniqKeyType> extends Component<DataTa
       rows,
       renderCellOverlay,
       selectedRows,
+      hasGroups,
     } = this.asProps;
 
     let rowsToRender = rows;
@@ -394,6 +395,7 @@ class BodyRoot<Data extends DataTableData, UniqKeyType> extends Component<DataTa
           <SSpinContainer
             innerOutline
             // @ts-ignore
+            hasGroups={hasGroups}
             headerHeight={`${this.getSpinnerTopOffset()}px`}
             tabIndex={-1}
             ref={spinnerRef}

--- a/semcore/data-table/src/components/Body/style.shadow.css
+++ b/semcore/data-table/src/components/Body/style.shadow.css
@@ -284,9 +284,13 @@ SSpinContainer {
 
   &[headerHeight] {
     position: sticky;
-    top: 0;
+    top: var(--headerHeight);
     height: min(100vh, calc(var(--global-table-height) - var(--headerHeight)));
     min-height: min(100vh, calc(var(--global-table-height) - var(--headerHeight)));
+  }
+
+  &[hasGroups] {
+    grid-area: 3 / 1 / 20 / 5;
   }
 }
 


### PR DESCRIPTION
## Changelog

### @semcore/scroll-area

#### Fixed

- Unnecessary calculation of container size if wMin and wMax are not specified.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
