### PR TITLE
[UIK-5800][textarea] added aria-invalid atribute for invalid state

### DIFF
--- a/semcore/bulk-textarea/__tests__/bulk-textarea.browser-test.tsx
+++ b/semcore/bulk-textarea/__tests__/bulk-textarea.browser-test.tsx
@@ -1080,7 +1080,9 @@ test.describe(`${TAG.FUNCTIONAL}`, () => {
       tag: [TAG.PRIORITY_HIGH,
         TAG.MOUSE,
         '@bulk-textarea'],
-    }, async ({ page }) => {
+    }, async ({ page, browserName }) => {
+      test.skip(browserName === 'firefox', 'Hover events are unstable in Playwright Firefox');
+
       await loadPage(page, 'stories/components/bulk-textarea/tests/examples/basic-props.tsx', 'en', { maxLines: 15 });
 
       await test.step('Row Error on Hover', async () => {

--- a/semcore/textarea/__tests__/index.test.tsx
+++ b/semcore/textarea/__tests__/index.test.tsx
@@ -24,4 +24,9 @@ describe('Textarea', () => {
     await userEvent.type(getByTestId('textarea'), 'text');
     expect(spyChange).lastCalledWith('text', expect.any(Object));
   });
+
+  test('Verify aria-invalid attribute for invalid state should be true', async () => {
+    const { getByTestId } = render(<Textarea data-testid='textarea' state='invalid' />);
+    expect(getByTestId('textarea')).toHaveAttribute('aria-invalid', 'true');
+  });
 });

--- a/semcore/textarea/__tests__/textarea.browser-test.tsx
+++ b/semcore/textarea/__tests__/textarea.browser-test.tsx
@@ -100,32 +100,27 @@ test.describe(`${TAG.FUNCTIONAL} `, () => {
       '@typography'],
   }, async ({ page }) => {
     await loadPage(page, 'stories/components/textarea/docs/examples/textarea_with_auto_height.tsx', 'en');
+    const getNumberOfLines = () => locators.textarea(page).evaluate((el) => {
+      const computed = window.getComputedStyle(el);
+      const lineHeight = parseFloat(computed.lineHeight);
 
-    await test.step('Verify textarea focused when perssing TAB', async () => {
+      return Math.round(el.scrollHeight / lineHeight);
+    });
+
+    await test.step('Verify textarea focused when pressing TAB', async () => {
       await page.keyboard.press('Tab');
       await expect(locators.textarea(page)).toBeFocused();
     });
 
-    await test.step('Verify ampunf of lines update when enetring text', async () => {
+    await test.step('Verify amount of lines updates when entering text', async () => {
       const text =
         'Zoom in on product categories to understand how each site segment drives \nconversions.\nSecond row\n4 row\n5 row\n6 row\n7 row\n8 row\n9 row\n10 row\n11 row';
       await page.keyboard.type(text, { delay: 10 });
 
-      const { scrollHeight, lineHeight } = await locators.textarea(page).evaluate((el) => {
-        const computed = window.getComputedStyle(el);
-        const lh = parseFloat(computed.lineHeight);
-        return {
-          scrollHeight: el.scrollHeight,
-          lineHeight: lh,
-        };
-      });
-
-      const numberOfLines = Math.round(scrollHeight / lineHeight);
-
-      expect(numberOfLines).toBe(11);
+      await expect.poll(getNumberOfLines).toBe(11);
     });
 
-    await test.step('Verify ampunf of lines update when removing all text', async () => {
+    await test.step('Verify amount of lines updates when removing all text', async () => {
       if (platform() === 'darwin') {
         await page.keyboard.press('Meta+A');
       } else {
@@ -133,17 +128,7 @@ test.describe(`${TAG.FUNCTIONAL} `, () => {
       }
       await page.keyboard.press('Backspace');
 
-      const { scrollHeight, lineHeight } = await locators.textarea(page).evaluate((el) => {
-        const computed = window.getComputedStyle(el);
-        const lh = parseFloat(computed.lineHeight);
-        return {
-          scrollHeight: el.scrollHeight,
-          lineHeight: lh,
-        };
-      });
-
-      const numberOfLines = Math.round(scrollHeight / lineHeight);
-      expect(numberOfLines).toBe(2);
+      await expect.poll(getNumberOfLines).toBe(2);
     });
   });
 });

--- a/semcore/textarea/src/Textarea.tsx
+++ b/semcore/textarea/src/Textarea.tsx
@@ -140,9 +140,17 @@ class Textarea extends Component<
 
   render() {
     const STextarea = Root;
-    const { styles } = this.asProps;
+    const { styles, state } = this.asProps;
 
-    return sstyled(styles)(<STextarea render={Box} tag='textarea' ref={this.setRef} use:autoFocus={false} />);
+    return sstyled(styles)(
+      <STextarea
+        render={Box}
+        tag='textarea'
+        ref={this.setRef}
+        use:autoFocus={false}
+        aria-invalid={state === 'invalid'}
+      />,
+    );
   }
 }
 

--- a/website/docs/components/textarea/textarea-a11y.md
+++ b/website/docs/components/textarea/textarea-a11y.md
@@ -10,6 +10,16 @@ tabs: Design('textarea'), A11y('textarea-a11y'), API('textarea-api'), Examples('
 
 For detailed information about keyboard support for the Input, refer to the [Keyboard control guide](/core-principles/a11y/a11y-keyboard#input-and-textarea).
 
+### Roles and attributes
+
+The following list describes roles and attributes that the component already has.
+
+Table: Roles and attributes
+
+| Component | Role / Attribute | Usage |
+| --- | --- | --- |
+| `Textarea` | `aria-invalid="false/true"` | Is set to `true` when `state="invalid"` is provided; otherwise `false`. |
+
 ## Considerations for developers
 
 - Keep it simple - not all browsers correctly expose multiple labels that are linked to the same form element.


### PR DESCRIPTION
## Changelog

### @semcore/textarea

#### Fixed

- The aria-disabled attribute for the disabled state was missing.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] I have added new tests on added of fixed functionality.
