### PR TITLE
[UIK-5915][data-table] fixed scrollOffest calculation after table resize

### DIFF
--- a/semcore/data-table/__tests__/data-table-scroll.browser-test.tsx
+++ b/semcore/data-table/__tests__/data-table-scroll.browser-test.tsx
@@ -218,3 +218,48 @@ test.describe(`${TAG.VISUAL}`, () => {
 
   // add cases when hedader has interactive element
 });
+
+/* =====================================================
+@functional
+Scroll bar geometry - no snapshots here.
+We verify offsets of the scroll bars against the fixed columns.
+===================================================== */
+test.describe(`${TAG.FUNCTIONAL}`, () => {
+  test('Verify offset of horizontal scroll bar is recalculated after table resize', {
+    tag: [TAG.PRIORITY_HIGH, '@data-table'],
+  }, async ({ page }) => {
+    await loadPage(page, 'stories/components/data-table/tests/examples/scroll-tests/real-table.tsx', 'en');
+
+    // The fixed column is sized as `minmax(139px, auto)`, so it takes the leftover space in a wide
+    // container and shrinks back to its minimum in a narrow one.
+    const fixedColumn = locators.getHeadColumn(page, 1);
+    const horizontalScrollBars = page.locator('[data-ui-name="ScrollArea.Bar"][aria-orientation="horizontal"]');
+
+    await page.setViewportSize({ width: 1500, height: 900 });
+    await expect(fixedColumn).toBeVisible();
+    const wideColumnWidth = (await fixedColumn.boundingBox())!.width;
+
+    await page.setViewportSize({ width: 800, height: 900 });
+
+    await test.step('Verify the fixed column shrinks together with the table', async () => {
+      await expect.poll(async () => (await fixedColumn.boundingBox())!.width, { timeout: 3000 }).toBeLessThan(wideColumnWidth);
+    });
+
+    await test.step('Verify horizontal scroll bars start at the end of the fixed column', async () => {
+      await expect(horizontalScrollBars.first()).toBeVisible();
+
+      const scrollBarsCount = await horizontalScrollBars.count();
+
+      for (let i = 0; i < scrollBarsCount; i++) {
+        const scrollBar = horizontalScrollBars.nth(i);
+
+        await expect.poll(async () => {
+          const scrollBarBox = (await scrollBar.boundingBox())!;
+          const columnBox = (await fixedColumn.boundingBox())!;
+
+          return Math.abs(scrollBarBox.x - (columnBox.x + columnBox.width));
+        }, { timeout: 3000 }).toBeLessThanOrEqual(1);
+      }
+    });
+  });
+});

--- a/semcore/data-table/src/components/DataTable/DataTable.tsx
+++ b/semcore/data-table/src/components/DataTable/DataTable.tsx
@@ -926,7 +926,9 @@ class DataTableRoot<
       this.calculateVerticalShadow();
       this.calculateStickyHeaderAnimation();
       this.calculateContainerHeight();
-      this.getScrollOffsetValue();
+      this.setState({
+        scrollOffset: this.getScrollOffsetValue(),
+      });
     }, 0);
 
     this.asProps.onResize?.(entries, observer);

--- a/semcore/data-table/src/components/DataTable/DataTable.tsx
+++ b/semcore/data-table/src/components/DataTable/DataTable.tsx
@@ -926,6 +926,7 @@ class DataTableRoot<
       this.calculateVerticalShadow();
       this.calculateStickyHeaderAnimation();
       this.calculateContainerHeight();
+      this.getScrollOffsetValue();
     }, 0);
 
     this.asProps.onResize?.(entries, observer);
@@ -1060,7 +1061,7 @@ class DataTableRoot<
       return [0, 0];
     }
 
-    return this.columns.reduce(
+    const offsets = this.columns.reduce(
       (acc, column) => {
         if (column.fixed === 'left') {
           acc[0] += this.headerNodesMap.get(column.name)?.current?.getBoundingClientRect().width ?? 0;
@@ -1072,6 +1073,8 @@ class DataTableRoot<
       },
       [0, 0] as [leftOffset: number, rightOffset: number],
     );
+
+    return offsets;
   };
 
   private getFixedStyle = (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
