### PR TITLE
[UIK-5920][data-table] fixed unnecessary scrolls to table in loading state

### DIFF
--- a/semcore/data-table/__tests__/data-table-states.browser-test.tsx
+++ b/semcore/data-table/__tests__/data-table-states.browser-test.tsx
@@ -768,6 +768,40 @@ test.describe(`${TAG.FUNCTIONAL}`, () => {
         await expect(locators.getCell(page, 2, 1)).not.toBeFocused();
       });
     });
+
+    test('Verify mouse interaction in loading state does not steal focus and does not scroll to the table', {
+      tag: [TAG.PRIORITY_HIGH,
+        TAG.MOUSE,
+        '@data-table'],
+    }, async ({ page }) => {
+      await loadPage(page, 'stories/components/data-table/tests/examples/table-states-tests/loading-with-sort-and-scroll.tsx', 'en');
+
+      const spin = page.locator('svg[data-ui-name="Spin"]');
+      const spinContainer = page.getByRole('row', { name: 'Loading…' });
+
+      await locators.dataTable(page).waitFor({ state: 'visible' });
+      await locators.button(page, 'Start loading').click();
+      await spin.waitFor({ state: 'visible' });
+
+      await test.step('Verify click in the loading table does not move focus to the spinner', async () => {
+        const sortButton = locators.sortButton(page, 4);
+
+        await sortButton.click();
+
+        await expect(spinContainer).not.toBeFocused();
+        await expect(sortButton).toBeFocused();
+      });
+
+      await test.step('Verify page is not scrolled back to the table when loading is finished', async () => {
+        await spinContainer.click();
+        await page.evaluate(() => window.scrollTo(0, 0));
+        expect(await page.evaluate(() => window.scrollY)).toBe(0);
+
+        await spin.waitFor({ state: 'hidden', timeout: 10000 });
+
+        expect(await page.evaluate(() => window.scrollY)).toBe(0);
+      });
+    });
   });
 
   test.describe('Selectable rows ', () => {

--- a/semcore/data-table/src/components/Body/Body.tsx
+++ b/semcore/data-table/src/components/Body/Body.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@semcore/base-components';
-import { Component, createComponent, Root, sstyled } from '@semcore/core';
+import { Component, createComponent, lastInteraction, Root, sstyled } from '@semcore/core';
 import canUseDOM from '@semcore/core/lib/utils/canUseDOM';
 import { hasParent } from '@semcore/core/lib/utils/hasParent';
 import Spin from '@semcore/spin';
@@ -213,7 +213,9 @@ class BodyRoot<Data extends DataTableData, UniqKeyType> extends Component<DataTa
   };
 
   handleFocusSpinContainer = () => {
-    this.spinContainerIsFocused = true;
+    if (lastInteraction.isKeyboard()) {
+      this.spinContainerIsFocused = true;
+    }
   };
 
   handleBlurSpinContainer = () => {

--- a/semcore/data-table/src/components/DataTable/DataTable.tsx
+++ b/semcore/data-table/src/components/DataTable/DataTable.tsx
@@ -829,7 +829,7 @@ class DataTableRoot<
   };
 
   handleFocus = (e: React.FocusEvent<HTMLElement, HTMLElement>) => {
-    if (this.asProps.loading) {
+    if (this.asProps.loading && lastInteraction.isKeyboard()) {
       this.spinnerRef.current?.focus();
       e.currentTarget.setAttribute('tabIndex', '-1');
 

--- a/stories/components/data-table/tests/data-table-states.stories.tsx
+++ b/stories/components/data-table/tests/data-table-states.stories.tsx
@@ -5,6 +5,7 @@ import EmptyStateSortableExample from './examples/table-states-tests/empty-sorta
 import LoadingPaginationExample from './examples/table-states-tests/loading-in-pagination';
 import LoadingScrollExample from './examples/table-states-tests/loading-in-scroll';
 import LoadingWithScrollAndButtonExample from './examples/table-states-tests/loading-with-button-and-scroll';
+import LoadingWithSortAndScrollExample from './examples/table-states-tests/loading-with-sort-and-scroll';
 import NothingFoundWithFixedColumnWidthExample from './examples/table-states-tests/nothing-found-with-fixed-column-width';
 import WidgetEmptyInCellExample from './examples/table-states-tests/widget-empty-in-cell';
 
@@ -18,6 +19,10 @@ type Story = StoryObj<typeof DataTable>;
 
 export const WidgetEmptyInCell: Story = {
   render: WidgetEmptyInCellExample,
+};
+
+export const LoadingWithSortAndScroll: Story = {
+  render: LoadingWithSortAndScrollExample,
 };
 
 export const NothingFoundWithFixedColumnWidth: StoryObj<{ loading: boolean }> = {

--- a/stories/components/data-table/tests/examples/table-states-tests/loading-with-sort-and-scroll.tsx
+++ b/stories/components/data-table/tests/examples/table-states-tests/loading-with-sort-and-scroll.tsx
@@ -1,0 +1,119 @@
+import Button from '@semcore/ui/button';
+import type { DataTableSort } from '@semcore/ui/data-table';
+import { DataTable } from '@semcore/ui/data-table';
+import { Text } from '@semcore/ui/typography';
+import React from 'react';
+type SortableColumn = Exclude<keyof (typeof data)[0], 'keyword'>;
+
+const Demo = () => {
+  const [sort, setSort] = React.useState<DataTableSort<keyof (typeof data)[0]>>(
+    ['vol', 'desc'],
+  );
+  const [loading, setLoading] = React.useState(false);
+  const timeoutRef = React.useRef();
+
+  const sortedData = React.useMemo(
+    () =>
+      [...data].sort((aRow, bRow) => {
+        const [prop, sortDirection] = sort;
+        const a = aRow[prop as SortableColumn];
+        const b = bRow[prop as SortableColumn];
+        if (a === b) return 0;
+        if (sortDirection === 'asc') return a > b ? 1 : -1;
+        else return a > b ? -1 : 1;
+      }),
+    [sort],
+  );
+  const numberFormat = React.useMemo(() => new Intl.NumberFormat('en-US'), []);
+  const currencyFormat = React.useMemo(
+    () =>
+      new Intl.NumberFormat('en-US', { currency: 'USD', style: 'currency' }),
+    [],
+  );
+  const handleSortChange: (
+    sort: DataTableSort<string>,
+    e?: React.SyntheticEvent,
+  ) => void = (newSort) => {
+    setSort(newSort as DataTableSort<SortableColumn>);
+  };
+
+  const handleLoadingStart = () => {
+    clearTimeout(timeoutRef.current);
+    setLoading(true);
+
+    timeoutRef.current = setTimeout(() => {
+      setLoading(false);
+    }, 5000);
+  };
+
+  React.useEffect(() => {
+    return () => clearTimeout(timeoutRef.current);
+  }, []);
+
+  return (
+    <div>
+      <Button style={{ marginBottom: 500 }} onClick={handleLoadingStart}>Start loading (5s)</Button>
+      <DataTable
+        data={sortedData}
+        sort={sort}
+        onSortChange={handleSortChange}
+        loading={loading}
+        aria-label='Sorting'
+        columns={[
+          {
+            name: 'keyword',
+            children: 'Keyword',
+            justifyContent: 'left',
+            sortable: true,
+          },
+          {
+            name: 'kd',
+            children: (
+              <Text ellipsis={true}>KD % and some another text long</Text>
+            ),
+            justifyContent: 'right',
+            gtcWidth: 'minmax(0, 68px)',
+            sortable: true,
+          },
+          {
+            name: 'cpc',
+            children: 'CPC',
+            gtcWidth: 'minmax(0, 60px)',
+            sortable: 'asc',
+          },
+          {
+            name: 'vol',
+            children: 'Vol.',
+            gtcWidth: 'minmax(0, 120px)',
+            justifyContent: 'left',
+            sortable: 'desc',
+          },
+        ]}
+        renderCell={(props) => {
+          if (props.columnName === 'keyword') {
+            return props.defaultRender();
+          }
+
+          const rawValue = props.row[props.columnName as SortableColumn];
+
+          return typeof rawValue === 'number' && rawValue !== -1
+            ? props.columnName === 'cpc'
+              ? currencyFormat.format(rawValue)
+              : numberFormat.format(rawValue)
+            : 'n/a';
+        }}
+      />
+    </div>
+  );
+};
+
+export default Demo;
+
+const data = Array.from({ length: 100 }, (_, index) => ({
+  keyword: `ebay buy ${index}`,
+  kd: 77.8,
+  cpc: 1.25,
+  vol: 32500000,
+}));
+
+export const App = () => <Demo />;

--- a/stories/components/data-table/tests/examples/table-states-tests/loading-with-sort-and-scroll.tsx
+++ b/stories/components/data-table/tests/examples/table-states-tests/loading-with-sort-and-scroll.tsx
@@ -10,7 +10,7 @@ const Demo = () => {
     ['vol', 'desc'],
   );
   const [loading, setLoading] = React.useState(false);
-  const timeoutRef = React.useRef();
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout>>();
 
   const sortedData = React.useMemo(
     () =>


### PR DESCRIPTION
## Changelog

### @semcore/data-table

#### Fixed

- Unnecessary scrolling during loading when interacting with the mouse.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- For example: -->
<!--- I have added unit tests -->
<!--- I have added Voice Over tests -->
<!--- Code cannot be tested automatically so I have tested it only manually -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Nice improve.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added new tests on added of fixed functionality.
